### PR TITLE
feat(phase-3): persistent sessions with sidebar and SQLite-backed history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Never log the API key. Never commit `.env.local`, `anton.db`, or anything under 
 
 ## Roadmap phase
 
-Phase 1 (streaming chat MVP) is shipped. Phase 2 (agent loop + tools + permission gate) is next — see `README.md` for the full roadmap. Do not implement later phases ahead of time.
+Phases 1–3 (streaming chat MVP, agent loop + tools + permission gate, persistent sessions) are shipped. Phase 4 (markdown, diff viewer, token counter, QoL) is next — see `README.md` for the full roadmap. Do not implement later phases ahead of time.
 
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,17 +1,60 @@
 import { convertToModelMessages } from "ai";
+import { z } from "zod";
+
 import { runAgent, type AntonUIMessage } from "@/src/agent/loop";
+import {
+  createSession,
+  deriveTitleFromMessages,
+  getSession,
+  replaceMessages,
+  touchSession,
+} from "@/src/db/queries";
+import { DEFAULT_MODEL } from "@/src/lib/providers";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
 
+const bodySchema = z.object({
+  sessionId: z.string().min(1),
+  model: z.string().min(1).optional(),
+  messages: z.array(z.unknown()).min(1),
+});
+
 export async function POST(req: Request) {
-  const { messages, model }: { messages: AntonUIMessage[]; model?: string } =
-    await req.json();
+  const json = await req.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const { sessionId } = parsed.data;
+  const uiMessages = parsed.data.messages as AntonUIMessage[];
+  const model = parsed.data.model ?? DEFAULT_MODEL;
+
+  const existing = getSession(sessionId);
+  if (!existing) {
+    createSession({
+      id: sessionId,
+      title: deriveTitleFromMessages(uiMessages),
+      model,
+    });
+  } else if (existing.model !== model) {
+    touchSession(sessionId, model);
+  }
 
   const result = runAgent({
-    messages: await convertToModelMessages(messages),
+    messages: await convertToModelMessages(uiMessages),
     model,
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse<AntonUIMessage>({
+    originalMessages: uiMessages,
+    onFinish: ({ messages, isAborted }) => {
+      if (isAborted) return;
+      replaceMessages<AntonUIMessage>(sessionId, messages);
+    },
+  });
 }

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+import {
+  deleteSession,
+  getSession,
+  loadMessages,
+  renameSession,
+} from "@/src/db/queries";
+import type { AntonUIMessage } from "@/src/agent/loop";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const session = getSession(id);
+  if (!session) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  const messages = loadMessages<AntonUIMessage>(id);
+  return Response.json({
+    session: {
+      id: session.id,
+      title: session.title,
+      model: session.model,
+      createdAt: session.createdAt.getTime(),
+      updatedAt: session.updatedAt.getTime(),
+    },
+    messages,
+  });
+}
+
+const patchSchema = z.object({
+  title: z.string().min(1).max(200),
+});
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  if (!getSession(id)) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  const updated = renameSession(id, parsed.data.title);
+  if (!updated) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  return Response.json({
+    session: {
+      id: updated.id,
+      title: updated.title,
+      model: updated.model,
+      createdAt: updated.createdAt.getTime(),
+      updatedAt: updated.updatedAt.getTime(),
+    },
+  });
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  if (!getSession(id)) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  deleteSession(id);
+  return new Response(null, { status: 204 });
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,16 @@
+import { listSessions } from "@/src/db/queries";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const rows = listSessions();
+  return Response.json({
+    sessions: rows.map((s) => ({
+      id: s.id,
+      title: s.title,
+      model: s.model,
+      createdAt: s.createdAt.getTime(),
+      updatedAt: s.updatedAt.getTime(),
+    })),
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import { SessionSidebar } from "@/components/chat/session-sidebar";
+import { SessionStoreProvider } from "@/components/chat/session-store";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -27,7 +30,14 @@ export default function RootLayout({
       lang="en"
       className={`dark ${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col font-sans">{children}</body>
+      <body className="min-h-full flex flex-col font-sans">
+        <SessionStoreProvider>
+          <div className="flex-1 flex min-h-0">
+            <SessionSidebar />
+            <main className="flex-1 flex flex-col min-w-0">{children}</main>
+          </div>
+        </SessionStoreProvider>
+      </body>
     </html>
   );
 }

--- a/app/s/[sessionId]/page.tsx
+++ b/app/s/[sessionId]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from "next/navigation";
+
+import { Chat } from "@/components/chat/chat";
+import { getSession, loadMessages } from "@/src/db/queries";
+import type { AntonUIMessage } from "@/src/agent/loop";
+import type { ModelId } from "@/src/lib/providers";
+
+export const dynamic = "force-dynamic";
+
+export default async function SessionPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { sessionId } = await params;
+  const session = getSession(sessionId);
+  if (!session) notFound();
+
+  const messages = loadMessages<AntonUIMessage>(sessionId);
+
+  return (
+    <Chat
+      sessionId={session.id}
+      initialMessages={messages}
+      initialModel={session.model as ModelId}
+      initialTitle={session.title}
+    />
+  );
+}

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -1,40 +1,80 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
+
 import { DEFAULT_MODEL, type ModelId } from "@/src/lib/providers";
 import type { AntonUIMessage } from "@/src/agent/loop";
 import { MessageList } from "./message-list";
 import { Composer } from "./composer";
 import { ModelPicker } from "./model-picker";
+import { useSessionStore } from "./session-store";
 
-export function Chat() {
-  const [model, setModel] = useState<ModelId>(DEFAULT_MODEL as ModelId);
+interface ChatProps {
+  sessionId?: string;
+  initialMessages?: AntonUIMessage[];
+  initialModel?: ModelId;
+  initialTitle?: string;
+}
 
-  const { messages, sendMessage, status, stop, error, addToolApprovalResponse } =
-    useChat<AntonUIMessage>({
-      transport: new DefaultChatTransport({
+export function Chat({
+  sessionId: sessionIdProp,
+  initialMessages,
+  initialModel,
+  initialTitle,
+}: ChatProps) {
+  const { refresh } = useSessionStore();
+  const persistedRef = useRef(sessionIdProp !== undefined);
+
+  const [sessionId] = useState<string>(() => sessionIdProp ?? generateId());
+  const [model, setModel] = useState<ModelId>(
+    (initialModel ?? DEFAULT_MODEL) as ModelId,
+  );
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport<AntonUIMessage>({
         api: "/api/chat",
-        body: () => ({ model }),
+        body: () => ({ sessionId, model }),
       }),
-      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
-    });
+    [sessionId, model],
+  );
+
+  const {
+    messages,
+    sendMessage,
+    status,
+    stop,
+    error,
+    addToolApprovalResponse,
+  } = useChat<AntonUIMessage>({
+    transport,
+    messages: initialMessages,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+    onFinish: () => {
+      if (!persistedRef.current) {
+        persistedRef.current = true;
+        if (typeof window !== "undefined") {
+          window.history.replaceState(null, "", `/s/${sessionId}`);
+        }
+      }
+      void refresh();
+    },
+  });
 
   const streaming = status === "streaming" || status === "submitted";
+  const headerTitle = initialTitle ?? (sessionIdProp ? "Session" : "New chat");
 
   return (
-    <div className="flex-1 flex flex-col max-w-3xl w-full mx-auto">
+    <div className="flex-1 flex flex-col min-w-0">
       <header className="flex items-center justify-between px-4 py-3 border-b border-border">
-        <div className="flex items-center gap-2">
-          <h1 className="text-sm font-semibold tracking-tight">Anton</h1>
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            Phase 2
-          </span>
-        </div>
+        <h1 className="text-sm font-semibold tracking-tight truncate">
+          {headerTitle}
+        </h1>
         <ModelPicker value={model} onChange={setModel} disabled={streaming} />
       </header>
 
@@ -58,4 +98,11 @@ export function Chat() {
       />
     </div>
   );
+}
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }

--- a/components/chat/session-sidebar.tsx
+++ b/components/chat/session-sidebar.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import {
+  Check,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  useSessionStore,
+  type SessionSummary,
+} from "./session-store";
+
+export function SessionSidebar() {
+  const { sessions, loading, error } = useSessionStore();
+  const params = useParams<{ sessionId?: string }>();
+  const activeId = params?.sessionId;
+
+  return (
+    <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-background/80">
+      <div className="flex items-center justify-between gap-2 px-3 py-3 border-b border-border">
+        <span className="text-sm font-semibold tracking-tight">Anton</span>
+        <Button asChild size="sm" variant="outline" className="gap-1 text-xs">
+          <Link href="/">
+            <Plus />
+            New chat
+          </Link>
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto py-2">
+        {loading && sessions.length === 0 ? (
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            Loading…
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            No sessions yet. Send a message to start one.
+          </div>
+        ) : (
+          <ul className="space-y-0.5 px-2">
+            {sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                isActive={s.id === activeId}
+              />
+            ))}
+          </ul>
+        )}
+        {error && (
+          <div className="mx-3 mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
+            {error}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function SessionRow({
+  session,
+  isActive,
+}: {
+  session: SessionSummary;
+  isActive: boolean;
+}) {
+  const { rename, remove } = useSessionStore();
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(session.title);
+
+  const commit = async () => {
+    const trimmed = draft.trim();
+    setEditing(false);
+    if (trimmed && trimmed !== session.title) {
+      await rename(session.id, trimmed);
+    } else {
+      setDraft(session.title);
+    }
+  };
+
+  const cancel = () => {
+    setDraft(session.title);
+    setEditing(false);
+  };
+
+  const onDelete = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!confirm("Delete this session? This cannot be undone.")) return;
+    await remove(session.id);
+    if (isActive) router.push("/");
+  };
+
+  if (editing) {
+    return (
+      <li
+        className={cn(
+          "flex items-center gap-1 rounded-md px-2 py-1.5",
+          "bg-accent/60",
+        )}
+      >
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void commit();
+            if (e.key === "Escape") cancel();
+          }}
+          className="flex-1 min-w-0 bg-transparent text-xs focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={commit}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Save"
+        >
+          <Check className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={cancel}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Cancel"
+        >
+          <X className="size-3.5" />
+        </button>
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <Link
+        href={`/s/${session.id}`}
+        className={cn(
+          "group flex items-center gap-1 rounded-md px-2 py-1.5 text-xs",
+          "text-foreground hover:bg-accent",
+          isActive && "bg-accent",
+        )}
+      >
+        <span className="flex-1 min-w-0 truncate">{session.title}</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setDraft(session.title);
+            setEditing(true);
+          }}
+          className="shrink-0 rounded p-1 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent-foreground/10"
+          aria-label="Rename"
+        >
+          <Pencil className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="shrink-0 rounded p-1 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-destructive/20 hover:text-destructive"
+          aria-label="Delete"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      </Link>
+    </li>
+  );
+}

--- a/components/chat/session-store.tsx
+++ b/components/chat/session-store.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type SessionSummary = {
+  id: string;
+  title: string;
+  model: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+interface SessionStoreValue {
+  sessions: SessionSummary[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  rename: (id: string, title: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+const SessionStoreContext = createContext<SessionStoreValue | null>(null);
+
+export function SessionStoreProvider({ children }: { children: ReactNode }) {
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { sessions: SessionSummary[] };
+      setSessions(data.sessions);
+      setError(null);
+      setLoading(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load sessions");
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Fetching on mount — setState happens after `await fetch(...)` resolves,
+    // not during the effect body. The rule can't see through `async`.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+  }, [refresh]);
+
+  const rename = useCallback(
+    async (id: string, title: string) => {
+      const trimmed = title.trim();
+      if (!trimmed) return;
+      setSessions((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, title: trimmed } : s)),
+      );
+      try {
+        const res = await fetch(`/api/sessions/${id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ title: trimmed }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Rename failed");
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      const snapshot = sessions;
+      setSessions((prev) => prev.filter((s) => s.id !== id));
+      try {
+        const res = await fetch(`/api/sessions/${id}`, { method: "DELETE" });
+        if (!res.ok && res.status !== 204) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Delete failed");
+        setSessions(snapshot);
+      }
+    },
+    [sessions],
+  );
+
+  const value = useMemo<SessionStoreValue>(
+    () => ({ sessions, loading, error, refresh, rename, remove }),
+    [sessions, loading, error, refresh, rename, remove],
+  );
+
+  return (
+    <SessionStoreContext.Provider value={value}>
+      {children}
+    </SessionStoreContext.Provider>
+  );
+}
+
+export function useSessionStore(): SessionStoreValue {
+  const ctx = useContext(SessionStoreContext);
+  if (!ctx) {
+    throw new Error(
+      "useSessionStore must be used within a SessionStoreProvider",
+    );
+  }
+  return ctx;
+}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,0 +1,125 @@
+import { asc, desc, eq } from "drizzle-orm";
+import type { UIMessage } from "ai";
+
+import { db } from "./client";
+import { messages, sessions, type Session } from "./schema";
+
+export type StoredMessage<UI extends UIMessage = UIMessage> = {
+  id: string;
+  sessionId: string;
+  role: UI["role"];
+  parts: UI["parts"];
+  createdAt: Date;
+};
+
+export function listSessions(): Session[] {
+  return db.select().from(sessions).orderBy(desc(sessions.updatedAt)).all();
+}
+
+export function getSession(id: string): Session | undefined {
+  return db.select().from(sessions).where(eq(sessions.id, id)).get();
+}
+
+export function sessionExists(id: string): boolean {
+  return getSession(id) !== undefined;
+}
+
+export function createSession(input: {
+  id: string;
+  title: string;
+  model: string;
+}): Session {
+  const now = new Date();
+  const row: Session = {
+    ...input,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(sessions).values(row).run();
+  return row;
+}
+
+export function touchSession(id: string, model?: string): void {
+  const update: { updatedAt: Date; model?: string } = { updatedAt: new Date() };
+  if (model) update.model = model;
+  db.update(sessions).set(update).where(eq(sessions.id, id)).run();
+}
+
+export function renameSession(id: string, title: string): Session | undefined {
+  const trimmed = title.trim();
+  if (!trimmed) return getSession(id);
+  db
+    .update(sessions)
+    .set({ title: trimmed, updatedAt: new Date() })
+    .where(eq(sessions.id, id))
+    .run();
+  return getSession(id);
+}
+
+export function deleteSession(id: string): void {
+  db.delete(sessions).where(eq(sessions.id, id)).run();
+}
+
+export function loadMessages<UI extends UIMessage>(
+  sessionId: string,
+): UI[] {
+  const rows = db
+    .select()
+    .from(messages)
+    .where(eq(messages.sessionId, sessionId))
+    .orderBy(asc(messages.createdAt))
+    .all();
+
+  return rows.map((row) => {
+    const parts = row.parts as UI["parts"];
+    return {
+      id: row.id,
+      role: row.role as UI["role"],
+      parts,
+    } as UI;
+  });
+}
+
+export function replaceMessages<UI extends UIMessage>(
+  sessionId: string,
+  incoming: UI[],
+): void {
+  db.transaction((tx) => {
+    tx.delete(messages).where(eq(messages.sessionId, sessionId)).run();
+    if (incoming.length === 0) return;
+    tx
+      .insert(messages)
+      .values(
+        incoming.map((m, idx) => ({
+          id: m.id,
+          sessionId,
+          role: m.role,
+          parts: m.parts as unknown,
+          // Preserve ordering even when created_at ticks collide.
+          createdAt: new Date(Date.now() + idx),
+        })),
+      )
+      .run();
+    tx
+      .update(sessions)
+      .set({ updatedAt: new Date() })
+      .where(eq(sessions.id, sessionId))
+      .run();
+  });
+}
+
+export function deriveTitleFromMessages(
+  incoming: Pick<UIMessage, "role" | "parts">[],
+): string {
+  const firstUser = incoming.find((m) => m.role === "user");
+  if (!firstUser) return "New chat";
+  for (const part of firstUser.parts) {
+    if (part.type === "text" && typeof part.text === "string") {
+      const cleaned = part.text.replace(/\s+/g, " ").trim();
+      if (cleaned.length === 0) continue;
+      return cleaned.length > 60 ? `${cleaned.slice(0, 57).trimEnd()}…` : cleaned;
+    }
+  }
+  return "New chat";
+}
+


### PR DESCRIPTION
## Summary

Phase 3 turns Anton from a single in-memory chat into a multi-session workspace backed by SQLite.

**Backend**
- `src/db/queries.ts` — typed helpers over the existing `sessions` / `messages` tables (list/get/create/rename/delete, `loadMessages`, `replaceMessages`, `deriveTitleFromMessages`). No new migration — the Phase 1 schema already covers this.
- `GET /api/sessions` — list sessions ordered by `updatedAt desc`.
- `GET|PATCH|DELETE /api/sessions/[id]` — fetch a session with its messages, rename, or delete (cascades to messages).
- `POST /api/chat` now accepts `{ sessionId, model, messages }`. It auto-creates the session row on first use (title = first 60 chars of the first user text part), then persists the full updated UI message list via `toUIMessageStreamResponse({ originalMessages, onFinish })`. Aborts are not persisted.

**Frontend**
- `SessionStoreProvider` (root layout) — client context holding the session list with optimistic rename/delete and a `refresh()` used by the chat after each `onFinish`.
- `SessionSidebar` — left rail with a "New chat" link to `/`, active-session highlight, inline rename, and a delete-with-confirm (auto-navigates home if the active session is deleted).
- `/s/[sessionId]/page.tsx` — server component that loads the session + messages from SQLite and hydrates `<Chat>` with `initialMessages` / `initialModel` / `initialTitle`. Unknown IDs hit `notFound()`.
- `<Chat>` takes optional `sessionId` + `initialMessages`. When started from `/`, it generates a UUID up front and, on first `onFinish`, does `history.replaceState('/s/<id>')` so a refresh resumes the conversation without a remount. Model picker still works mid-session and is persisted to `sessions.model` on the next request.

**Conventions respected**
- Strict TS, no `any` (one narrow `as unknown` on stored parts which are Drizzle `json`).
- Server-only DB access stays in `src/db/*` and server route handlers.
- Approval flow from Phase 2 is untouched — `useChat`'s `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` still drives the loop and persistence only fires on clean stream finishes.

## Review & Testing Checklist for Human

- [x] `pnpm dev`, send a message from `/` → URL flips to `/s/<uuid>` after the first response, sidebar shows the new session with the derived title, hard refresh still loads the history.
- [x] Open two sessions in the sidebar, switch between them → each re-hydrates its own `initialMessages`; streaming in one doesn't bleed into the other.
- [x] Kick off a risky tool call (e.g. `write_file`), approve, stop mid-stream with the Stop button → aborted stream is **not** persisted (on next refresh the page reflects the last clean state).
- [x] Rename and delete in the sidebar — rename is optimistic and rolls back on HTTP failure; delete from the currently-open session redirects to `/`.
- [x] Change the model picker mid-session → next assistant turn uses the new model and `sessions.model` reflects it (verify via `pnpm db:studio`).

### Notes

- No new npm deps. Icons come from the already-pinned `lucide-react`.
- One `eslint-disable-next-line react-hooks/set-state-in-effect` in `session-store.tsx`: React 19's new rule can't see that `setState` only runs after `await fetch(...)` resolves. Left a short comment explaining.
- Mobile layout temporarily hides the sidebar (`hidden md:flex`) — a mobile session switcher can land in Phase 4.
- Updated `AGENTS.md` roadmap marker so future agents know Phase 3 is landed and Phase 4 (markdown / diff / token counter) is next.

Link to Devin session: https://app.devin.ai/sessions/ed92befc2f2944f5b3608ac9308e3c8a
Requested by: @Ramgopalbhat10