### PR TITLE
[codex] add project memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anton
 
-A mini AI coding agent harness — built as a learning project to understand how production AI agent systems (Claude Code, Codex, Devin, Hermes, OpenClaw) work under the hood.
+A mini AI coding agent harness - built as a learning project to understand how production AI agent systems (Claude Code, Codex, Devin, Hermes, OpenClaw) work under the hood.
 
 ## Stack
 
@@ -33,9 +33,9 @@ pnpm dev                            # http://localhost:3000
 
 ## Roadmap
 
-- **Phase 0** — scaffold (done)
-- **Phase 1** — streaming chat MVP (no tools)
-- **Phase 2** — agent loop + tools (`read_file`, `write_file`, `bash`, `grep`, `glob`) + permission gate
-- **Phase 3** — persistent sessions
-- **Phase 4** — markdown, diff viewer, token counter, QoL
-- **Phase 5** — memory / skills / sub-agents / MCP
+- **Phase 0** - scaffold (done)
+- **Phase 1** - streaming chat MVP (no tools) (done)
+- **Phase 2** - agent loop + tools (`read_file`, `write_file`, `bash`, `grep`, `glob`) + permission gate (done)
+- **Phase 3** - persistent sessions (done)
+- **Phase 4** - markdown, diff viewer, token counter, QoL (done)
+- **Phase 5** - memory / skills / sub-agents / MCP (in progress: project-wide memory slice)

--- a/app/s/[sessionId]/page.tsx
+++ b/app/s/[sessionId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { Chat } from "@/components/chat/chat";
 import { getSession, loadMessages } from "@/src/db/queries";
 import type { AntonUIMessage } from "@/src/agent/loop";
-import type { ModelId } from "@/src/lib/providers";
+import type { ModelId } from "@/src/lib/models";
 
 export const dynamic = "force-dynamic";
 

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -7,7 +7,7 @@ import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
 
-import { DEFAULT_MODEL, type ModelId } from "@/src/lib/providers";
+import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
 import type { AntonUIMessage } from "@/src/agent/loop";
 import { MessageList } from "./message-list";
 import { Composer } from "./composer";
@@ -34,7 +34,7 @@ export function Chat({
 
   const [sessionId] = useState<string>(() => sessionIdProp ?? generateId());
   const [model, setModel] = useState<ModelId>(
-    (initialModel ?? DEFAULT_MODEL) as ModelId,
+    (initialModel ?? DEFAULT_MODEL_ID) as ModelId,
   );
 
   const transport = useMemo(

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -54,6 +54,7 @@ export function Composer({ onSend, onStop, disabled, streaming }: ComposerProps)
           ref={textareaRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onInput={(e) => setInput(e.currentTarget.value)}
           onKeyDown={onKeyDown}
           placeholder="Message Anton... (Enter to send, Shift+Enter for newline)"
           rows={1}

--- a/components/chat/model-picker.tsx
+++ b/components/chat/model-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MODEL_CATALOG, type ModelId } from "@/src/lib/providers";
+import { MODEL_CATALOG, type ModelId } from "@/src/lib/models";
 import { cn } from "@/lib/utils";
 
 interface ModelPickerProps {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -7,6 +7,7 @@ import {
   type InferUITools,
 } from "ai";
 import { openrouter, DEFAULT_MODEL } from "@/src/lib/providers";
+import { listMemories } from "@/src/db/queries";
 import { antonTools } from "./tools";
 import { workspaceRelative, ensureWorkspaceRoot } from "./sandbox";
 
@@ -23,20 +24,37 @@ function systemPrompt(): string {
     "Absolute paths and `..` traversal are rejected by the sandbox before execution.",
     "",
     "Tools available:",
-    "- `read_file(path, startLine?, endLine?)` — read a text file. Prefer narrow ranges for large files.",
-    "- `write_file(path, content)` — overwrite a file. Destructive; the user must approve each call.",
-    "- `bash(command, timeoutMs?)` — run a shell command in the workspace. Destructive; requires approval. `sudo` is forbidden.",
-    "- `grep(pattern, path?, glob?, caseInsensitive?)` — ripgrep-style search. Use this before reading large files.",
-    "- `glob(pattern, path?)` — list files matching a glob like `**/*.ts`.",
+    "- `read_file(path, startLine?, endLine?)` - read a text file. Prefer narrow ranges for large files.",
+    "- `write_file(path, content)` - overwrite a file. Destructive; the user must approve each call.",
+    "- `bash(command, timeoutMs?)` - run a shell command in the workspace. Destructive; requires approval. `sudo` is forbidden.",
+    "- `grep(pattern, path?, glob?, caseInsensitive?)` - ripgrep-style search. Use this before reading large files.",
+    "- `glob(pattern, path?)` - list files matching a glob like `**/*.ts`.",
+    "- `list_memory(limit?)` - list project-wide memories that apply across sessions.",
+    "- `remember(content)` - save a concise project-wide memory. Destructive; the user must approve each call.",
+    "- `forget_memory(id)` - delete one project-wide memory. Destructive; the user must approve each call.",
+    "",
+    ...projectMemoryPromptLines(),
     "",
     "Conventions:",
     "- Answer concisely. Prefer short, correct answers over long hedged ones.",
     "- Plan first for multi-step tasks: explore (`glob`, `grep`, `read_file`) before editing (`write_file`).",
+    "- Use memory only for durable project preferences or facts that should carry across sessions.",
     "- When you finish, summarize what you changed and why in one short paragraph.",
-    "- Do not guess file contents — read them first.",
+    "- Do not guess file contents - read them first.",
     "- Never ask the user for approval in prose; the harness shows an approval UI for risky tools.",
     "- If a tool returns `{ ok: false, error }`, report the error and try a different approach; do not retry the exact same call.",
   ].join("\n");
+}
+
+function projectMemoryPromptLines(): string[] {
+  const memories = listMemories(10);
+  if (memories.length === 0) {
+    return ["Project memory:", "- No saved memories yet."];
+  }
+  return [
+    "Project memory:",
+    ...memories.map((memory) => `- [${memory.id}] ${memory.content}`),
+  ];
 }
 
 export type AntonUIMessage = UIMessage<

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -14,6 +14,9 @@ export const RISK_LEVELS: Record<string, RiskLevel> = {
   glob: "safe",
   write_file: "risky",
   bash: "risky",
+  list_memory: "safe",
+  remember: "risky",
+  forget_memory: "risky",
 };
 
 // Commands we refuse to execute in `bash` even after approval — the user

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -3,6 +3,11 @@ import { writeFileTool } from "./write-file";
 import { bashTool } from "./bash";
 import { grepTool } from "./grep";
 import { globTool } from "./glob";
+import {
+  forgetMemoryTool,
+  listMemoryTool,
+  rememberTool,
+} from "./memory";
 
 export const antonTools = {
   read_file: readFileTool,
@@ -10,6 +15,9 @@ export const antonTools = {
   bash: bashTool,
   grep: grepTool,
   glob: globTool,
+  list_memory: listMemoryTool,
+  remember: rememberTool,
+  forget_memory: forgetMemoryTool,
 } as const;
 
 export type AntonTools = typeof antonTools;

--- a/src/agent/tools/memory.ts
+++ b/src/agent/tools/memory.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { tool } from "ai";
+import {
+  createMemory,
+  deleteMemory,
+  listMemories,
+} from "@/src/db/queries";
+import type { Memory } from "@/src/db/schema";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const MAX_MEMORY_CHARS = 1000;
+
+export const listMemoryTool = tool({
+  description:
+    "List project-wide memories that Anton should use across sessions. Returns the most recently updated memories first.",
+  inputSchema: z.object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_LIMIT)
+      .optional()
+      .describe(`Maximum memories to return. Defaults to ${DEFAULT_LIMIT}.`),
+  }),
+  execute: async ({ limit }) => {
+    try {
+      return {
+        ok: true as const,
+        memories: listMemories(limit ?? DEFAULT_LIMIT).map(serializeMemory),
+      };
+    } catch (err) {
+      return { ok: false as const, error: errorMessage(err) };
+    }
+  },
+});
+
+export const rememberTool = tool({
+  description:
+    "Save one concise project-wide memory for future Anton sessions. Requires user approval.",
+  inputSchema: z.object({
+    content: z
+      .string()
+      .trim()
+      .min(1)
+      .max(MAX_MEMORY_CHARS)
+      .describe("A concise memory to preserve across sessions."),
+  }),
+  needsApproval: true,
+  execute: async ({ content }) => {
+    try {
+      return {
+        ok: true as const,
+        memory: serializeMemory(createMemory(content)),
+      };
+    } catch (err) {
+      return { ok: false as const, error: errorMessage(err) };
+    }
+  },
+});
+
+export const forgetMemoryTool = tool({
+  description:
+    "Delete one project-wide memory by ID. Use list_memory first if you need the ID. Requires user approval.",
+  inputSchema: z.object({
+    id: z.string().min(1).describe("The memory ID to delete."),
+  }),
+  needsApproval: true,
+  execute: async ({ id }) => {
+    try {
+      const deleted = deleteMemory(id);
+      if (!deleted) {
+        return { ok: false as const, error: `memory not found: ${id}` };
+      }
+      return { ok: true as const, id };
+    } catch (err) {
+      return { ok: false as const, error: errorMessage(err) };
+    }
+  },
+});
+
+function serializeMemory(memory: Memory): {
+  id: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+} {
+  return {
+    id: memory.id,
+    content: memory.content,
+    createdAt: memory.createdAt.getTime(),
+    updatedAt: memory.updatedAt.getTime(),
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/db/migrations/0002_fat_patriot.sql
+++ b/src/db/migrations/0002_fat_patriot.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `memories` (
+	`id` text PRIMARY KEY NOT NULL,
+	`content` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL
+);

--- a/src/db/migrations/meta/0002_snapshot.json
+++ b/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,173 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0cb78a3e-ce04-4ed8-bd1d-6d068f9cee8d",
+  "prevId": "ad61807c-f779-480e-96b4-9099e11bf287",
+  "tables": {
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776786820810,
       "tag": "0001_motionless_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777093067247,
+      "tag": "0002_fat_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,8 +1,15 @@
 import { asc, desc, eq, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
+import { randomUUID } from "node:crypto";
 
 import { db } from "./client";
-import { messages, sessions, type Session } from "./schema";
+import {
+  memories,
+  messages,
+  sessions,
+  type Memory,
+  type Session,
+} from "./schema";
 
 export type StoredMessage<UI extends UIMessage = UIMessage> = {
   id: string;
@@ -71,6 +78,39 @@ export function renameSession(id: string, title: string): Session | undefined {
 
 export function deleteSession(id: string): void {
   db.delete(sessions).where(eq(sessions.id, id)).run();
+}
+
+export function listMemories(limit = 20): Memory[] {
+  const safeLimit = Number.isFinite(limit)
+    ? Math.max(1, Math.min(100, Math.trunc(limit)))
+    : 20;
+  return db
+    .select()
+    .from(memories)
+    .orderBy(desc(memories.updatedAt))
+    .limit(safeLimit)
+    .all();
+}
+
+export function createMemory(content: string): Memory {
+  const now = new Date();
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error("memory content must not be empty");
+  }
+  const row: Memory = {
+    id: randomUUID(),
+    content: trimmed,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(memories).values(row).run();
+  return row;
+}
+
+export function deleteMemory(id: string): boolean {
+  const result = db.delete(memories).where(eq(memories.id, id)).run();
+  return result.changes > 0;
 }
 
 export function loadMessages<UI extends UIMessage>(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,7 +26,20 @@ export const messages = sqliteTable("messages", {
     .default(sql`(unixepoch('now') * 1000)`),
 });
 
+export const memories = sqliteTable("memories", {
+  id: text("id").primaryKey(),
+  content: text("content").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(unixepoch('now') * 1000)`),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .notNull()
+    .default(sql`(unixepoch('now') * 1000)`),
+});
+
 export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
+export type Memory = typeof memories.$inferSelect;
+export type NewMemory = typeof memories.$inferInsert;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4.5";
+
+export const MODEL_CATALOG = [
+  { id: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { id: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { id: "openai/gpt-5", label: "GPT-5" },
+  { id: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+] as const;
+
+export type ModelId = (typeof MODEL_CATALOG)[number]["id"];

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,4 +1,5 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { DEFAULT_MODEL_ID } from "./models";
 
 const apiKey = process.env.OPENROUTER_API_KEY;
 
@@ -13,13 +14,4 @@ export const openrouter = createOpenRouter({
 });
 
 export const DEFAULT_MODEL =
-  process.env.DEFAULT_MODEL ?? "anthropic/claude-sonnet-4.5";
-
-export const MODEL_CATALOG = [
-  { id: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
-  { id: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
-  { id: "openai/gpt-5", label: "GPT-5" },
-  { id: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-] as const;
-
-export type ModelId = (typeof MODEL_CATALOG)[number]["id"];
+  process.env.DEFAULT_MODEL ?? DEFAULT_MODEL_ID;


### PR DESCRIPTION
## Summary

- Add project-wide memories backed by SQLite and Drizzle migrations.
- Register `list_memory`, `remember`, and `forget_memory` agent tools with approval required for mutations.
- Inject recent memories into Anton's system prompt across sessions.
- Split model catalog constants into a client-safe module and keep OpenRouter provider setup server-side.
- Fix composer input handling discovered during browser verification.

## Verification

- `pnpm db:generate`
- `pnpm db:migrate`
- `pnpm typecheck`
- `pnpm lint`
- DB smoke test for memory create/list/delete
- Browser verification with `@browser-use`: approved `remember`, verified memory in a fresh session, approved `forget_memory`, and confirmed `list_memory` returned no saved memories afterward.