### PR TITLE
Polish compact workbench UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,16 @@ Path aliases: `@/*` → project root, so `@/components/...`, `@/lib/utils`, `@/s
 
 Run `pnpm typecheck` and `pnpm lint` before committing. If you change the schema, also run `pnpm db:generate` and commit the resulting migration.
 
+## GitHub workflow
+
+- Before starting a new implementation, create or identify a GitHub issue that describes the requested change, scope, acceptance criteria, and verification plan. Reference that issue in the branch name, commit message, or PR body when practical.
+- For new implementation work, create a new feature branch before editing code. Use a descriptive prefix such as `codex/<short-topic>` for Codex-driven work.
+- If the work clearly belongs to an existing feature branch, update that branch from `main` first, then continue on the existing branch instead of creating a duplicate branch.
+- Never commit directly to `main`. Open a pull request for review after the branch is pushed.
+- Keep commits focused. Do not include unrelated local changes, generated databases, `.env.local`, or workspace contents.
+- Before opening a PR, run `pnpm typecheck` and `pnpm lint`; include any failures or skipped checks in the PR body.
+- For UI changes, include a short visual verification note in the PR body with the important viewport(s) or interaction states checked.
+
 ## Environment
 
 `.env.local` (gitignored) needs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,11 @@ Follow the shared agent rules in `AGENTS.md`:
 
 ## Claude-specific notes
 
-- Use the `TodoWrite` tool to track any task that takes more than ~3 steps. Mark items `completed` as soon as they're done — do not batch.
+- Use the `TodoWrite` tool to track any task that takes more than ~3 steps. Mark items `completed` as soon as they are done; do not batch.
 - When a task spans many files, prefer a single `Agent` delegation with `subagent_type: "Explore"` over many serial reads.
 - Run `pnpm typecheck` and `pnpm lint` before reporting a coding task as done. A green build is the acceptance criterion.
-- Before writing Next.js code, consult `node_modules/next/dist/docs/` — this project pins Next 16, which has breaking changes from older training data.
+- Before writing Next.js code, consult `node_modules/next/dist/docs/`; this project pins Next 16, which has breaking changes from older training data.
+- Before implementation, create or identify the GitHub issue for the work and keep the branch/PR tied to that issue.
+- For new implementation work, create a fresh `claude/*` feature branch before editing. If the change belongs to an existing branch, update that branch from `main` first and continue there.
 - Never push to `main`. Work on `claude/*` feature branches and open PRs only when explicitly asked.
 - Never commit `.env.local`, `anton.db`, `anton.db-shm`, `anton.db-wal`, or anything under `workspace/`.

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,74 +5,74 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.148 0.004 228.8);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.148 0.004 228.8);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.148 0.004 228.8);
-  --primary: oklch(0.511 0.096 186.391);
-  --primary-foreground: oklch(0.984 0.014 180.72);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.963 0.002 197.1);
-  --muted-foreground: oklch(0.56 0.021 213.5);
-  --accent: oklch(0.963 0.002 197.1);
-  --accent-foreground: oklch(0.218 0.008 223.9);
+  --background: oklch(0.98 0.002 250);
+  --foreground: oklch(0.17 0.004 250);
+  --card: oklch(0.955 0.002 250);
+  --card-foreground: oklch(0.17 0.004 250);
+  --popover: oklch(0.955 0.002 250);
+  --popover-foreground: oklch(0.17 0.004 250);
+  --primary: oklch(0.63 0.17 47);
+  --primary-foreground: oklch(0.985 0.004 80);
+  --secondary: oklch(0.92 0.002 250);
+  --secondary-foreground: oklch(0.23 0.004 250);
+  --muted: oklch(0.92 0.002 250);
+  --muted-foreground: oklch(0.49 0.008 250);
+  --accent: oklch(0.91 0.002 250);
+  --accent-foreground: oklch(0.2 0.004 250);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.925 0.005 214.3);
-  --input: oklch(0.925 0.005 214.3);
-  --ring: oklch(0.723 0.014 214.4);
-  --radius: 0.625rem;
-  --chart-1: oklch(0.845 0.143 164.978);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.596 0.145 163.225);
-  --chart-4: oklch(0.508 0.118 165.612);
-  --chart-5: oklch(0.432 0.095 166.913);
-  --sidebar: oklch(0.987 0.002 197.1);
-  --sidebar-foreground: oklch(0.148 0.004 228.8);
-  --sidebar-primary: oklch(0.6 0.118 184.704);
-  --sidebar-primary-foreground: oklch(0.984 0.014 180.72);
-  --sidebar-accent: oklch(0.963 0.002 197.1);
-  --sidebar-accent-foreground: oklch(0.218 0.008 223.9);
-  --sidebar-border: oklch(0.925 0.005 214.3);
-  --sidebar-ring: oklch(0.723 0.014 214.4);
+  --border: oklch(0.82 0.004 250);
+  --input: oklch(0.86 0.004 250);
+  --ring: oklch(0.63 0.17 47);
+  --radius: 0.5rem;
+  --chart-1: oklch(0.73 0.12 185);
+  --chart-2: oklch(0.69 0.14 150);
+  --chart-3: oklch(0.67 0.17 47);
+  --chart-4: oklch(0.62 0.1 250);
+  --chart-5: oklch(0.58 0.09 310);
+  --sidebar: oklch(0.95 0.002 250);
+  --sidebar-foreground: oklch(0.17 0.004 250);
+  --sidebar-primary: oklch(0.63 0.17 47);
+  --sidebar-primary-foreground: oklch(0.985 0.004 80);
+  --sidebar-accent: oklch(0.9 0.002 250);
+  --sidebar-accent-foreground: oklch(0.19 0.004 250);
+  --sidebar-border: oklch(0.82 0.004 250);
+  --sidebar-ring: oklch(0.63 0.17 47);
 }
 
 .dark {
-  --background: oklch(0.148 0.004 228.8);
-  --foreground: oklch(0.987 0.002 197.1);
-  --card: oklch(0.218 0.008 223.9);
-  --card-foreground: oklch(0.987 0.002 197.1);
-  --popover: oklch(0.218 0.008 223.9);
-  --popover-foreground: oklch(0.987 0.002 197.1);
-  --primary: oklch(0.437 0.078 188.216);
-  --primary-foreground: oklch(0.984 0.014 180.72);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.275 0.011 216.9);
-  --muted-foreground: oklch(0.723 0.014 214.4);
-  --accent: oklch(0.275 0.011 216.9);
-  --accent-foreground: oklch(0.987 0.002 197.1);
+  --background: oklch(0.145 0.003 250);
+  --foreground: oklch(0.965 0.002 250);
+  --card: oklch(0.205 0.004 250);
+  --card-foreground: oklch(0.965 0.002 250);
+  --popover: oklch(0.205 0.004 250);
+  --popover-foreground: oklch(0.965 0.002 250);
+  --primary: oklch(0.69 0.18 48);
+  --primary-foreground: oklch(0.15 0.003 250);
+  --secondary: oklch(0.245 0.004 250);
+  --secondary-foreground: oklch(0.965 0.002 250);
+  --muted: oklch(0.245 0.004 250);
+  --muted-foreground: oklch(0.68 0.008 250);
+  --accent: oklch(0.275 0.004 250);
+  --accent-foreground: oklch(0.97 0.002 250);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.56 0.021 213.5);
-  --chart-1: oklch(0.845 0.143 164.978);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.596 0.145 163.225);
-  --chart-4: oklch(0.508 0.118 165.612);
-  --chart-5: oklch(0.432 0.095 166.913);
-  --sidebar: oklch(0.218 0.008 223.9);
-  --sidebar-foreground: oklch(0.987 0.002 197.1);
-  --sidebar-primary: oklch(0.704 0.14 182.503);
-  --sidebar-primary-foreground: oklch(0.277 0.046 192.524);
-  --sidebar-accent: oklch(0.275 0.011 216.9);
-  --sidebar-accent-foreground: oklch(0.987 0.002 197.1);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.56 0.021 213.5);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.69 0.18 48);
+  --chart-1: oklch(0.75 0.13 190);
+  --chart-2: oklch(0.72 0.15 150);
+  --chart-3: oklch(0.69 0.18 48);
+  --chart-4: oklch(0.64 0.11 250);
+  --chart-5: oklch(0.62 0.1 310);
+  --sidebar: oklch(0.185 0.003 250);
+  --sidebar-foreground: oklch(0.965 0.002 250);
+  --sidebar-primary: oklch(0.69 0.18 48);
+  --sidebar-primary-foreground: oklch(0.15 0.003 250);
+  --sidebar-accent: oklch(0.245 0.004 250);
+  --sidebar-accent-foreground: oklch(0.965 0.002 250);
+  --sidebar-border: oklch(1 0 0 / 7%);
+  --sidebar-ring: oklch(0.69 0.18 48);
 }
 
 @theme inline {
@@ -132,5 +132,26 @@
   }
   html {
     @apply font-sans;
+  }
+  ::selection {
+    background: color-mix(in oklch, var(--primary) 32%, transparent);
+  }
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: color-mix(in oklch, var(--foreground) 16%, transparent);
+    border: 3px solid transparent;
+    border-radius: 999px;
+    background-clip: padding-box;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklch, var(--foreground) 24%, transparent);
+    border: 3px solid transparent;
+    background-clip: padding-box;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import "./globals.css";
 
-import { SessionSidebar } from "@/components/chat/session-sidebar";
+import {
+  SessionSidebar,
+  SidebarProvider,
+} from "@/components/chat/session-sidebar";
 import { SessionStoreProvider } from "@/components/chat/session-store";
 import { cn } from "@/lib/utils";
 
@@ -33,12 +36,16 @@ export default function RootLayout({
       lang="en"
       className={cn("dark", "h-full", "antialiased", geistSans.variable, geistMono.variable, "font-sans", inter.variable)}
     >
-      <body className="min-h-full flex flex-col font-sans">
+      <body className="h-full w-full overflow-hidden flex flex-col font-sans">
         <SessionStoreProvider>
-          <div className="flex-1 flex min-h-0">
-            <SessionSidebar />
-            <main className="flex-1 flex flex-col min-w-0">{children}</main>
-          </div>
+          <SidebarProvider>
+            <div className="flex h-dvh min-h-0 w-full overflow-hidden">
+              <SessionSidebar />
+              <main className="flex-1 flex flex-col min-w-0 max-w-full overflow-hidden">
+                {children}
+              </main>
+            </div>
+          </SidebarProvider>
         </SessionStoreProvider>
       </body>
     </html>

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -6,17 +6,26 @@ import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
+import {
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+} from "lucide-react";
 
 import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
 import type { AntonUIMessage } from "@/src/agent/loop";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { MessageList } from "./message-list";
 import { Composer } from "./composer";
-import { ModelPicker } from "./model-picker";
+import { Worklog } from "./worklog";
 import { useSessionStore } from "./session-store";
+import { useSidebar } from "./session-sidebar";
 import {
   readActiveProjectId,
   type ProjectSummary,
 } from "./workspace-dialog";
+import { SettingsDialog } from "./settings-dialog";
 
 interface ChatProps {
   sessionId?: string;
@@ -36,13 +45,17 @@ export function Chat({
   initialProjectId = null,
 }: ChatProps) {
   const { sessions, refresh } = useSessionStore();
+  const sidebar = useSidebar();
   const persistedRef = useRef(sessionIdProp !== undefined);
 
   const [sessionId] = useState<string>(() => sessionIdProp ?? generateId());
   const [activeProjectId, setActiveProjectId] = useState<string | null>(
-    () => initialProjectId ?? readActiveProjectId(),
+    initialProjectId,
   );
   const [project, setProject] = useState<ProjectSummary | null>(null);
+  const [worklogOpen, setWorklogOpen] = useState(false);
+  const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [model, setModel] = useState<ModelId>(
     (initialModel ?? DEFAULT_MODEL_ID) as ModelId,
   );
@@ -88,6 +101,25 @@ export function Chat({
   const tokensTotal =
     sessions.find((s) => s.id === sessionId)?.tokensTotal ?? initialTokensTotal;
 
+  const toggleWorklog = () => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(min-width: 1280px)").matches
+    ) {
+      setWorklogOpen((open) => !open);
+    } else {
+      setMobileWorklogOpen((open) => !open);
+    }
+  };
+
+  useEffect(() => {
+    if (initialProjectId) return;
+    const storedProjectId = readActiveProjectId();
+    // Local storage is client-only; syncing after mount keeps hydration stable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (storedProjectId) setActiveProjectId(storedProjectId);
+  }, [initialProjectId]);
+
   useEffect(() => {
     const onActiveProjectChange = (event: Event) => {
       if (initialProjectId) return;
@@ -116,57 +148,138 @@ export function Chat({
   }, [effectiveProjectId]);
 
   return (
-    <div className="flex-1 flex flex-col min-w-0">
-      <header className="flex items-center justify-between px-4 py-3 border-b border-border gap-3">
-        <h1 className="text-sm font-semibold tracking-tight truncate min-w-0">
-          {headerTitle}
-        </h1>
-        <div className="flex items-center gap-3 shrink-0">
-          {project && project.id === effectiveProjectId && (
-            <span
-              className="hidden max-w-56 truncate rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground md:inline"
-              title={project.localPath}
+    <div className="flex min-w-0 max-w-full flex-1 flex-col overflow-hidden bg-background">
+      <header className="flex h-10 w-full max-w-full items-center justify-between gap-2 border-b border-border px-3">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {!sidebar.open && (
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              className="hidden md:inline-flex"
+              onClick={sidebar.toggle}
+              aria-label="Open sidebar"
+              aria-pressed={sidebar.open}
             >
-              {project.fullName}
-            </span>
+              <PanelLeftOpen />
+            </Button>
           )}
-          <TokenCounter tokens={tokensTotal} pending={streaming} />
-          <ModelPicker value={model} onChange={setModel} disabled={streaming} />
+          <h1 className="truncate text-xs font-semibold tracking-tight">
+            {headerTitle}
+          </h1>
+        </div>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            onClick={toggleWorklog}
+            aria-label="Toggle worklog"
+            aria-pressed={worklogOpen || mobileWorklogOpen}
+          >
+            {worklogOpen || mobileWorklogOpen ? (
+              <PanelRightClose />
+            ) : (
+              <PanelRightOpen />
+            )}
+          </Button>
         </div>
       </header>
 
-      <MessageList
-        messages={messages}
-        status={status}
-        onApproval={addToolApprovalResponse}
-      />
+      <div
+        className={cn(
+          "relative flex min-h-0 max-w-full flex-1 overflow-hidden",
+        )}
+      >
+        <section className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden">
+          <MessageList
+            messages={messages}
+            status={status}
+            onApproval={addToolApprovalResponse}
+          />
 
-      {messages.length === 0 && !effectiveProjectId && <WorkspaceRequired />}
+          {messages.length === 0 && !effectiveProjectId && (
+            <WorkspaceRequired onOpenSettings={() => setSettingsOpen(true)} />
+          )}
 
-      {error && (
-        <div className="px-4 py-2 text-xs text-destructive border-t border-border">
-          Error: {error.message}
-        </div>
-      )}
+          {error && (
+            <div className="border-t border-border px-4 py-2 text-xs text-destructive">
+              Error: {error.message}
+            </div>
+          )}
 
-      <Composer
-        onSend={(text) => {
-          if (!effectiveProjectId) return;
-          sendMessage({ text });
-        }}
-        onStop={stop}
-        disabled={streaming || !effectiveProjectId}
-        streaming={streaming}
+          <Composer
+            onSend={(text) => {
+              if (!effectiveProjectId) return;
+              sendMessage({ text });
+            }}
+            onStop={stop}
+            disabled={streaming || !effectiveProjectId}
+            streaming={streaming}
+            model={model}
+            onModelChange={setModel}
+            tokens={tokensTotal}
+            project={project}
+          />
+        </section>
+
+        <Worklog
+          messages={messages}
+          onApproval={addToolApprovalResponse}
+          className={cn(
+            "hidden shrink-0 overflow-hidden transition-[width] duration-200 ease-out xl:flex",
+            worklogOpen ? "xl:w-[420px]" : "xl:w-0 xl:border-l-0",
+          )}
+        />
+
+        {mobileWorklogOpen && (
+          <div
+            className="absolute inset-0 z-30 bg-background/70 backdrop-blur-sm xl:hidden"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) {
+                setMobileWorklogOpen(false);
+              }
+            }}
+          >
+            <Worklog
+              messages={messages}
+              onApproval={addToolApprovalResponse}
+              className="ml-auto h-full w-[min(420px,100%)] border-l"
+              onClose={() => setMobileWorklogOpen(false)}
+            />
+          </div>
+        )}
+      </div>
+      <SettingsDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        activeProjectId={activeProjectId}
+        onActiveProjectChange={setActiveProjectId}
+        initialSection="workspaces"
       />
     </div>
   );
 }
 
-function WorkspaceRequired() {
+function WorkspaceRequired({
+  onOpenSettings,
+}: {
+  onOpenSettings: () => void;
+}) {
   return (
-    <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
-      Select or clone a workspace from the sidebar before starting a new agent
-      chat.
+    <div className="grid w-full max-w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t border-border px-4 py-2 text-xs text-muted-foreground">
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="shrink-0 md:hidden"
+        onClick={onOpenSettings}
+      >
+        Settings
+      </Button>
+      <span className="min-w-0 flex-1 truncate">
+        Select or clone a workspace before starting a new agent chat.
+      </span>
     </div>
   );
 }
@@ -178,28 +291,3 @@ function generateId(): string {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
 
-function TokenCounter({
-  tokens,
-  pending,
-}: {
-  tokens: number;
-  pending: boolean;
-}) {
-  if (tokens <= 0 && !pending) return null;
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background/60 px-2 py-1 text-[11px] font-mono text-muted-foreground"
-      title="Total tokens used in this session"
-    >
-      <span className="size-1.5 rounded-full bg-muted-foreground/50" aria-hidden />
-      {formatTokens(tokens)}
-      <span className="text-muted-foreground/70">tok</span>
-    </span>
-  );
-}
-
-function formatTokens(n: number): string {
-  if (n < 1000) return String(n);
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
-  return `${(n / 1_000_000).toFixed(1)}M`;
-}

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -1,20 +1,46 @@
 "use client";
 
 import { useLayoutEffect, useRef, useState, type KeyboardEvent } from "react";
+import {
+  ArrowUp,
+  ChevronDown,
+  GitBranch,
+  Monitor,
+  Plus,
+  ShieldCheck,
+  Square,
+} from "lucide-react";
+
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import type { ModelId } from "@/src/lib/models";
+import type { ProjectSummary } from "./workspace-dialog";
+import { ModelPicker } from "./model-picker";
 
 interface ComposerProps {
   onSend: (text: string) => void;
   onStop: () => void;
   disabled: boolean;
   streaming: boolean;
+  model: ModelId;
+  onModelChange: (model: ModelId) => void;
+  tokens: number;
+  project: ProjectSummary | null;
 }
 
-const MIN_HEIGHT = 44; // ~2 rows
-const MAX_HEIGHT = 240;
+const MIN_HEIGHT = 24;
+const MAX_HEIGHT = 44;
 
-export function Composer({ onSend, onStop, disabled, streaming }: ComposerProps) {
+export function Composer({
+  onSend,
+  onStop,
+  disabled,
+  streaming,
+  model,
+  onModelChange,
+  tokens,
+  project,
+}: ComposerProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -47,30 +73,124 @@ export function Composer({ onSend, onStop, disabled, streaming }: ComposerProps)
         e.preventDefault();
         submit();
       }}
-      className="border-t border-border bg-background px-4 py-3"
+      className="w-full max-w-full shrink-0 overflow-hidden bg-background/95 px-3 pb-2 pt-1 sm:px-4"
     >
-      <div className="flex gap-2 items-end">
-        <Textarea
-          ref={textareaRef}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onInput={(e) => setInput(e.currentTarget.value)}
-          onKeyDown={onKeyDown}
-          placeholder="Message Anton... (Enter to send, Shift+Enter for newline)"
-          rows={1}
-          className="resize-none leading-6"
-          style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
-        />
-        {streaming ? (
-          <Button type="button" variant="destructive" onClick={onStop}>
-            Stop
-          </Button>
-        ) : (
-          <Button type="submit" disabled={disabled || !input.trim()}>
-            Send
-          </Button>
-        )}
+      <div className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-3xl">
+        <div className="rounded-lg bg-card p-2 ring-1 ring-border">
+          <Textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onInput={(e) => setInput(e.currentTarget.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Ask for follow-up changes"
+            rows={1}
+            className="field-sizing-fixed min-h-0 min-w-0 resize-none rounded-none border-0 bg-transparent p-0 font-mono text-xs leading-5 shadow-none placeholder:font-mono focus-visible:ring-0 dark:bg-transparent md:text-xs"
+            style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
+          />
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                disabled={disabled}
+                aria-label="Add context"
+              >
+                <Plus />
+              </Button>
+              <button
+                type="button"
+                className="inline-flex h-5 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-primary hover:bg-primary/10"
+              >
+                <ShieldCheck className="size-3" />
+                Full access
+                <ChevronDown className="size-3" />
+              </button>
+            </div>
+
+            <div className="flex min-w-0 items-center gap-1.5">
+              <TokenCounter tokens={tokens} pending={streaming} />
+              <ModelPicker
+                value={model}
+                onChange={onModelChange}
+                disabled={streaming}
+                triggerClassName="h-5 w-36 px-1.5 text-[11px]"
+              />
+              {streaming ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  onClick={onStop}
+                  aria-label="Stop generation"
+                >
+                  <Square className="fill-current" />
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  size="icon-xs"
+                  disabled={disabled || !input.trim()}
+                  aria-label="Send message"
+                >
+                  <ArrowUp />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 px-1.5 text-[11px] font-medium text-muted-foreground">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 hover:text-foreground"
+          >
+            <Monitor className="size-3.5" />
+            Work locally
+            <ChevronDown className="size-3" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex min-w-0 items-center gap-1.5 hover:text-foreground"
+            title={project ? `${project.fullName} : ${project.defaultBranch}` : undefined}
+          >
+            <GitBranch className="size-3.5 shrink-0" />
+            <span className="max-w-[20rem] truncate">
+              {project
+                ? `${project.fullName} : ${project.defaultBranch}`
+                : "No codebase selected"}
+            </span>
+            <ChevronDown className="size-3 shrink-0" />
+          </button>
+        </div>
       </div>
     </form>
   );
+}
+
+function TokenCounter({
+  tokens,
+  pending,
+}: {
+  tokens: number;
+  pending: boolean;
+}) {
+  if (tokens <= 0 && !pending) return null;
+  return (
+    <span
+      className="inline-flex h-5 items-center gap-1 rounded-md bg-secondary px-1.5 text-[11px] font-mono text-muted-foreground"
+      title="Total tokens used in this session"
+    >
+      <span className="size-1.5 rounded-full bg-muted-foreground/50" aria-hidden />
+      {formatTokens(tokens)}
+      <span className="text-muted-foreground/70">tok</span>
+    </span>
+  );
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
 }

--- a/components/chat/diff-view.tsx
+++ b/components/chat/diff-view.tsx
@@ -16,15 +16,15 @@ export function DiffView({ previous, next, newFile }: DiffViewProps) {
 
   if (rows.length === 0) {
     return (
-      <div className="rounded border border-border bg-background/60 px-3 py-2 text-[11px] text-muted-foreground">
+      <div className="rounded bg-background/60 px-3 py-2 text-[11px] text-muted-foreground ring-1 ring-border">
         No changes.
       </div>
     );
   }
 
   return (
-    <div className="rounded-md border border-border bg-background/60 font-mono text-[11px] leading-snug">
-      <div className="flex items-center gap-3 border-b border-border px-3 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+    <div className="rounded-md bg-background/60 font-mono text-[11px] leading-snug ring-1 ring-border">
+      <div className="flex items-center gap-3 border-b border-border px-3 py-1 text-[10px] uppercase text-muted-foreground">
         <span>diff</span>
         {newFile ? (
           <span className="text-emerald-600 dark:text-emerald-400">

--- a/components/chat/markdown.tsx
+++ b/components/chat/markdown.tsx
@@ -13,7 +13,7 @@ interface MarkdownProps {
 
 function MarkdownImpl({ children, className }: MarkdownProps) {
   return (
-    <div className={cn("anton-md space-y-2 leading-relaxed", className)}>
+    <div className={cn("anton-md space-y-1.5 leading-normal", className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={COMPONENTS}>
         {children}
       </ReactMarkdown>
@@ -37,26 +37,26 @@ const COMPONENTS: Components = {
     </a>
   ),
   ul: ({ children }) => (
-    <ul className="list-disc pl-5 space-y-0.5">{children}</ul>
+    <ul className="list-disc pl-4 space-y-0.5">{children}</ul>
   ),
   ol: ({ children }) => (
-    <ol className="list-decimal pl-5 space-y-0.5">{children}</ol>
+    <ol className="list-decimal pl-4 space-y-0.5">{children}</ol>
   ),
   li: ({ children }) => <li className="marker:text-muted-foreground">{children}</li>,
   h1: ({ children }) => (
-    <h1 className="text-base font-semibold tracking-tight mt-2">{children}</h1>
+    <h1 className="mt-1.5 text-sm font-semibold tracking-tight">{children}</h1>
   ),
   h2: ({ children }) => (
-    <h2 className="text-sm font-semibold tracking-tight mt-2">{children}</h2>
+    <h2 className="mt-1.5 text-xs font-semibold tracking-tight">{children}</h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-sm font-semibold tracking-tight mt-2">{children}</h3>
+    <h3 className="mt-1.5 text-xs font-semibold tracking-tight">{children}</h3>
   ),
   h4: ({ children }) => (
-    <h4 className="text-sm font-semibold tracking-tight mt-2">{children}</h4>
+    <h4 className="mt-1.5 text-xs font-semibold tracking-tight">{children}</h4>
   ),
   blockquote: ({ children }) => (
-    <blockquote className="border-l-2 border-border pl-3 text-muted-foreground">
+    <blockquote className="border-l-2 border-border pl-2.5 text-muted-foreground">
       {children}
     </blockquote>
   ),
@@ -93,10 +93,7 @@ function CodeBlock({
     return (
       <code
         {...rest}
-        className={cn(
-          "rounded bg-muted/70 px-1 py-0.5 font-mono text-[0.85em]",
-          className,
-        )}
+        className={cn("rounded bg-secondary px-1 py-0.5 font-mono text-[0.85em]", className)}
       >
         {children}
       </code>
@@ -122,8 +119,8 @@ function CodeFence({ language, text }: { language?: string; text: string }) {
   };
 
   return (
-    <div className="group relative rounded-md border border-border bg-background/60 font-mono text-[11px]">
-      <div className="flex items-center justify-between border-b border-border px-3 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+    <div className="group relative rounded-md bg-card/50 font-mono text-[11px] ring-1 ring-border">
+      <div className="flex items-center justify-between border-b border-border px-3 py-1 text-[10px] uppercase text-muted-foreground">
         <span>{language ?? "code"}</span>
         <button
           type="button"
@@ -142,7 +139,7 @@ function CodeFence({ language, text }: { language?: string; text: string }) {
           )}
         </button>
       </div>
-      <pre className="overflow-x-auto p-3 leading-snug">
+      <pre className="overflow-x-auto p-2.5 leading-snug">
         <code>{text}</code>
       </pre>
     </div>

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -6,11 +6,19 @@ import {
   isToolUIPart,
   type ChatAddToolApproveResponseFunction,
 } from "ai";
-import { Check, Copy } from "lucide-react";
+import {
+  Check,
+  Copy,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  TerminalSquare,
+} from "lucide-react";
+
 import type { AntonUIMessage } from "@/src/agent/loop";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
-import { ToolCard } from "./tool-card";
 
 interface MessageListProps {
   messages: AntonUIMessage[];
@@ -30,37 +38,38 @@ export function MessageList({ messages, status, onApproval }: MessageListProps) 
 
   if (messages.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-        Start a conversation with Anton.
+      <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+        Start a session by asking Anton to inspect or change the selected
+        workspace.
       </div>
     );
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
-      {messages.map((message) => (
-        <MessageBubble
-          key={message.id}
-          message={message}
-          onApproval={onApproval}
-        />
-      ))}
-      {status === "submitted" && (
-        <div className="flex justify-start">
-          <div className="bg-muted text-muted-foreground rounded-lg px-4 py-2 text-sm">
-            <span className="inline-flex gap-1">
-              <span className="animate-pulse">·</span>
-              <span className="animate-pulse [animation-delay:150ms]">·</span>
-              <span className="animate-pulse [animation-delay:300ms]">·</span>
-            </span>
+    <div
+      ref={scrollRef}
+      className="flex-1 overflow-y-auto px-3 py-3 sm:px-4 lg:px-6"
+    >
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+        {messages.map((message) => (
+          <MessageEvent
+            key={message.id}
+            message={message}
+            onApproval={onApproval}
+          />
+        ))}
+        {status === "submitted" && (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin text-sky-400" />
+            Anton is thinking
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
 
-function MessageBubble({
+function MessageEvent({
   message,
   onApproval,
 }: {
@@ -77,36 +86,35 @@ function MessageBubble({
   return (
     <div
       className={cn(
-        "group/msg flex flex-col gap-1",
+          "group/msg flex flex-col gap-1",
         isUser ? "items-end" : "items-start",
       )}
     >
       <div
         className={cn(
-          "max-w-[80%] rounded-lg text-sm break-words space-y-2",
+          "max-w-full text-xs break-words",
           isUser
-            ? "bg-primary text-primary-foreground px-4 py-2"
-            : "bg-muted text-foreground px-4 py-2",
+            ? "max-w-[88%] rounded-md bg-card px-2.5 py-1.5 text-foreground ring-1 ring-border"
+            : "w-full text-foreground",
         )}
       >
         {message.parts.map((part, i) => {
           if (part.type === "text") {
             if (isUser) {
               return (
-                <div key={i} className="whitespace-pre-wrap">
+                <div key={i} className="whitespace-pre-wrap leading-normal">
                   {part.text}
                 </div>
               );
             }
-            return <Markdown key={i}>{part.text}</Markdown>;
+            return <Markdown key={i} className="text-xs">{part.text}</Markdown>;
           }
           if (isToolUIPart(part)) {
-            const name = getToolName(part);
             return (
-              <ToolCard
+              <InlineToolEvent
                 key={i}
-                name={String(name)}
-                state={part.state}
+                name={String(getToolName(part))}
+                state={part.state as ToolState}
                 input={"input" in part ? part.input : undefined}
                 output={"output" in part ? part.output : undefined}
                 errorText={"errorText" in part ? part.errorText : undefined}
@@ -126,6 +134,82 @@ function MessageBubble({
         <CopyMessageButton text={plainText} />
       )}
     </div>
+  );
+}
+
+type ToolState =
+  | "input-streaming"
+  | "input-available"
+  | "approval-requested"
+  | "approval-responded"
+  | "output-available"
+  | "output-error"
+  | "output-denied";
+
+function InlineToolEvent({
+  name,
+  state,
+  input,
+  output,
+  errorText,
+  approvalId,
+  onApproval,
+}: {
+  name: string;
+  state: ToolState;
+  input: unknown;
+  output: unknown;
+  errorText: string | undefined;
+  approvalId: string | undefined;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  return (
+    <details className="group/tool my-1 text-xs text-muted-foreground">
+      <summary
+        className={cn(
+          "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 rounded px-1 py-0.5 font-mono text-[11px] text-foreground select-none",
+          "transition-colors hover:bg-card/40 [&::-webkit-details-marker]:hidden",
+        )}
+        aria-label={`${name} tool details`}
+      >
+        <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate">{name}</span>
+        <ChevronRight className="size-3 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:hidden" />
+        <ChevronDown className="hidden size-3 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:block group-open/tool:opacity-100" />
+      </summary>
+      <div className="ml-5 mt-1 rounded-md bg-card/50 px-2.5 py-2 ring-1 ring-border/70">
+        <p className="truncate font-mono text-[11px]">
+          {previewInput(input)}
+        </p>
+        {state === "approval-requested" && approvalId && (
+          <div className="mt-2 flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => onApproval({ id: approvalId, approved: true })}
+            >
+              Approve
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => onApproval({ id: approvalId, approved: false })}
+            >
+              Deny
+            </Button>
+          </div>
+        )}
+        {state === "output-error" && errorText && (
+          <p className="mt-1 line-clamp-2 text-destructive">{errorText}</p>
+        )}
+        {state === "output-available" && output !== undefined && (
+          <p className="mt-1 line-clamp-2 font-mono text-[10px] text-muted-foreground">
+            {safeStringify(output)}
+          </p>
+        )}
+      </div>
+    </details>
   );
 }
 
@@ -158,4 +242,24 @@ function CopyMessageButton({ text }: { text: string }) {
       )}
     </button>
   );
+}
+
+function previewInput(input: unknown): string {
+  if (typeof input === "object" && input !== null) {
+    const record = input as Record<string, unknown>;
+    for (const key of ["command", "path", "pattern", "slug", "task"]) {
+      if (typeof record[key] === "string") return record[key];
+    }
+  }
+  return safeStringify(input);
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/components/chat/model-picker.tsx
+++ b/components/chat/model-picker.tsx
@@ -1,31 +1,48 @@
 "use client";
 
 import { MODEL_CATALOG, type ModelId } from "@/src/lib/models";
-import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
 
 interface ModelPickerProps {
   value: ModelId;
   onChange: (value: ModelId) => void;
   disabled?: boolean;
+  triggerClassName?: string;
 }
 
-export function ModelPicker({ value, onChange, disabled }: ModelPickerProps) {
+export function ModelPicker({
+  value,
+  onChange,
+  disabled,
+  triggerClassName,
+}: ModelPickerProps) {
+  const selected = MODEL_CATALOG.find((model) => model.id === value);
+
   return (
-    <select
+    <Select
       value={value}
-      onChange={(e) => onChange(e.target.value as ModelId)}
+      onValueChange={(next) => onChange(next as ModelId)}
       disabled={disabled}
-      className={cn(
-        "h-8 rounded-md border border-input bg-background px-2 text-xs",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-      )}
     >
-      {MODEL_CATALOG.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.label}
-        </option>
-      ))}
-    </select>
+      <SelectTrigger className={triggerClassName ?? "w-44"}>
+        <SelectValue>{selected?.label ?? value}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectViewport>
+          {MODEL_CATALOG.map((model) => (
+            <SelectItem key={model.id} value={model.id}>
+              {model.label}
+            </SelectItem>
+          ))}
+        </SelectViewport>
+      </SelectContent>
+    </Select>
   );
 }

--- a/components/chat/project-context-dialog.tsx
+++ b/components/chat/project-context-dialog.tsx
@@ -71,7 +71,7 @@ export function ProjectContextDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/75 p-4 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-labelledby="project-context-title"
@@ -79,12 +79,12 @@ export function ProjectContextDialog({
         if (event.target === event.currentTarget) onOpenChange(false);
       }}
     >
-      <div className="flex h-[min(720px,calc(100vh-2rem))] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg">
-        <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+      <div className="flex h-[min(680px,calc(100vh-2rem))] w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-card shadow-none ring-1 ring-border">
+        <header className="flex h-10 items-center justify-between gap-2 border-b border-border px-3">
           <div className="min-w-0">
             <h2
               id="project-context-title"
-              className="text-sm font-semibold tracking-tight"
+              className="text-xs font-semibold tracking-tight"
             >
               Project Context
             </h2>
@@ -92,7 +92,7 @@ export function ProjectContextDialog({
           <Button
             type="button"
             variant="ghost"
-            size="icon"
+            size="icon-sm"
             onClick={() => onOpenChange(false)}
             aria-label="Close project context"
           >
@@ -100,7 +100,7 @@ export function ProjectContextDialog({
           </Button>
         </header>
 
-        <div className="flex border-b border-border px-3 py-2">
+        <div className="flex border-b border-border px-2 py-1.5">
           <TabButton
             active={tab === "memories"}
             onClick={() => setTab("memories")}
@@ -140,10 +140,10 @@ function TabButton({
       type="button"
       onClick={onClick}
       className={cn(
-        "inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+        "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors [&_svg]:size-3.5",
         active
-          ? "bg-accent text-foreground"
-          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
       )}
     >
       {children}
@@ -243,8 +243,8 @@ function MemoryPanel({ active }: { active: boolean }) {
 
   return (
     <>
-      <div className="flex h-full flex-col gap-3 overflow-y-auto p-4">
-        <div className="space-y-2">
+      <div className="flex h-full flex-col gap-2.5 overflow-y-auto p-3">
+        <div className="space-y-1.5">
           <label htmlFor="new-memory" className="text-xs font-medium">
             New memory
           </label>
@@ -254,7 +254,7 @@ function MemoryPanel({ active }: { active: boolean }) {
             onChange={(event) => setDraft(event.target.value)}
             maxLength={1000}
             placeholder="A durable project preference or fact."
-            className="min-h-20 resize-none text-xs"
+            className="min-h-16 resize-none text-xs"
           />
           <div className="flex items-center justify-between gap-3">
             <span className="text-[11px] text-muted-foreground">
@@ -279,13 +279,13 @@ function MemoryPanel({ active }: { active: boolean }) {
         ) : memories.length === 0 ? (
           <EmptyState message="No project memories saved." />
         ) : (
-          <ul className="space-y-2">
+          <ul className="space-y-1.5">
             {memories.map((memory) => {
               const editing = editingId === memory.id;
               return (
                 <li
                   key={memory.id}
-                  className="rounded-md border border-border bg-background/60 p-3"
+                  className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
                 >
                   {editing ? (
                     <div className="space-y-2">
@@ -295,7 +295,7 @@ function MemoryPanel({ active }: { active: boolean }) {
                           setEditingDraft(event.target.value)
                         }
                         maxLength={1000}
-                        className="min-h-20 resize-none text-xs"
+                        className="min-h-16 resize-none text-xs"
                         aria-label="Edit memory"
                       />
                       <div className="flex justify-end gap-2">
@@ -324,7 +324,7 @@ function MemoryPanel({ active }: { active: boolean }) {
                     </div>
                   ) : (
                     <div className="space-y-2">
-                      <p className="whitespace-pre-wrap text-sm leading-relaxed">
+                      <p className="whitespace-pre-wrap text-xs leading-normal">
                         {memory.content}
                       </p>
                       <div className="flex items-center justify-between gap-3">
@@ -334,7 +334,7 @@ function MemoryPanel({ active }: { active: boolean }) {
                         <div className="flex items-center gap-1">
                           <Button
                             type="button"
-                            size="icon"
+                            size="icon-sm"
                             variant="ghost"
                             onClick={() => {
                               setEditingId(memory.id);
@@ -346,7 +346,7 @@ function MemoryPanel({ active }: { active: boolean }) {
                           </Button>
                           <Button
                             type="button"
-                            size="icon"
+                            size="icon-sm"
                             variant="ghost"
                             onClick={() => setMemoryToDelete(memory)}
                             aria-label="Delete memory"
@@ -457,8 +457,8 @@ function SkillsPanel({ active }: { active: boolean }) {
   }, [selectedSlug]);
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-1 md:grid-cols-[220px_1fr]">
-      <aside className="min-h-0 overflow-y-auto border-b border-border p-3 md:border-b-0 md:border-r">
+    <div className="grid h-full min-h-0 grid-cols-1 md:grid-cols-[210px_1fr]">
+      <aside className="min-h-0 overflow-y-auto border-b border-border bg-background/20 p-2 md:border-b-0 md:border-r">
         {loading ? (
           <LoadingState label="Loading skills" />
         ) : skills.length === 0 ? (
@@ -471,10 +471,10 @@ function SkillsPanel({ active }: { active: boolean }) {
                   type="button"
                   onClick={() => setSelectedSlug(skill.slug)}
                   className={cn(
-                    "w-full rounded-md px-2 py-2 text-left text-xs transition-colors",
+                    "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
                     selectedSlug === skill.slug
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                      ? "bg-secondary text-foreground"
+                      : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
                   )}
                 >
                   <span className="block truncate font-medium">{skill.name}</span>
@@ -488,13 +488,13 @@ function SkillsPanel({ active }: { active: boolean }) {
         )}
       </aside>
 
-      <section className="min-h-0 overflow-y-auto p-4">
+      <section className="min-h-0 overflow-y-auto p-3">
         {error && <ErrorBanner message={error} />}
 
         {warnings.length > 0 && (
-          <div className="mb-3 space-y-1 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+          <div className="mb-2.5 space-y-1 rounded-md bg-amber-500/10 p-2.5 text-xs text-amber-700 ring-1 ring-amber-500/30 dark:text-amber-300">
             <div className="flex items-center gap-2 font-medium">
-              <AlertTriangle className="size-4" />
+              <AlertTriangle className="size-3.5" />
               Skill warnings
             </div>
             <ul className="list-disc space-y-1 pl-5">
@@ -512,7 +512,7 @@ function SkillsPanel({ active }: { active: boolean }) {
         ) : selectedSkill ? (
           <article className="space-y-3">
             <div>
-              <h3 className="text-sm font-semibold">{selectedSkill.name}</h3>
+              <h3 className="text-xs font-semibold">{selectedSkill.name}</h3>
               <p className="mt-1 text-xs text-muted-foreground">
                 {selectedSkill.description || "No description."}
               </p>
@@ -520,7 +520,7 @@ function SkillsPanel({ active }: { active: boolean }) {
                 {selectedSkill.path}
               </p>
             </div>
-            <pre className="max-h-[460px] overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed whitespace-pre-wrap">
+            <pre className="max-h-[420px] overflow-auto rounded-md bg-background/60 p-2.5 text-xs leading-normal whitespace-pre-wrap ring-1 ring-border">
               {selectedSkill.body || "(empty)"}
             </pre>
           </article>
@@ -533,7 +533,7 @@ function SkillsPanel({ active }: { active: boolean }) {
 function LoadingState({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <Loader2 className="size-4 animate-spin" />
+      <Loader2 className="size-3.5 animate-spin" />
       {label}
     </div>
   );
@@ -541,7 +541,7 @@ function LoadingState({ label }: { label: string }) {
 
 function EmptyState({ message }: { message: string }) {
   return (
-    <div className="rounded-md border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">
+    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
       {message}
     </div>
   );
@@ -549,7 +549,7 @@ function EmptyState({ message }: { message: string }) {
 
 function ErrorBanner({ message }: { message: string }) {
   return (
-    <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive ring-1 ring-destructive/30">
       {message}
     </div>
   );

--- a/components/chat/session-sidebar.tsx
+++ b/components/chat/session-sidebar.tsx
@@ -2,13 +2,20 @@
 
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   Check,
-  FolderCog,
-  FolderGit2,
+  MessageSquare,
+  PanelLeftClose,
   Pencil,
   Plus,
+  Settings,
   Trash2,
   X,
 } from "lucide-react";
@@ -25,94 +32,210 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
-import {
-  useSessionStore,
-  type SessionSummary,
-} from "./session-store";
-import { ProjectContextDialog } from "./project-context-dialog";
-import {
-  readActiveProjectId,
-  WorkspaceDialog,
-} from "./workspace-dialog";
+import { useSessionStore, type SessionSummary } from "./session-store";
+import { SettingsDialog } from "./settings-dialog";
+import { readActiveProjectId } from "./workspace-dialog";
+
+type SidebarContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+};
+
+const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true);
+  const value = useMemo(
+    () => ({
+      open,
+      setOpen,
+      toggle: () => setOpen((next) => !next),
+    }),
+    [open],
+  );
+
+  return (
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const value = useContext(SidebarContext);
+  if (!value) {
+    throw new Error("useSidebar must be used within SidebarProvider");
+  }
+  return value;
+}
 
 export function SessionSidebar() {
   const { sessions, loading, error } = useSessionStore();
   const params = useParams<{ sessionId?: string }>();
   const activeId = params?.sessionId;
-  const [contextOpen, setContextOpen] = useState(false);
-  const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const { open, setOpen } = useSidebar();
   const [activeProjectId, setActiveProjectId] = useState<string | null>(() =>
     readActiveProjectId(),
   );
 
   return (
-    <aside className="hidden md:flex w-64 shrink-0 flex-col border-r border-border bg-background/80">
-      <div className="flex items-center justify-between gap-2 px-3 py-3 border-b border-border">
-        <span className="text-sm font-semibold tracking-tight">Anton</span>
-        <Button asChild size="sm" variant="outline" className="gap-1 text-xs">
-          <Link href="/">
-            <Plus />
-            New chat
-          </Link>
-        </Button>
-      </div>
+    <aside
+      className={cn(
+        "hidden shrink-0 overflow-hidden border-r border-sidebar-border bg-sidebar transition-[width] duration-200 ease-out md:flex",
+        open ? "w-[300px]" : "w-[41px]",
+      )}
+      data-open={open}
+    >
+      {open ? (
+        <div className="flex h-full w-[300px] shrink-0 flex-col">
+          <div className="grid h-10 grid-cols-[32px_minmax(0,1fr)_32px] items-center gap-1 pl-2 pr-2">
+            <div className="flex items-center justify-center">
+              <span className="flex size-5 items-center justify-center rounded bg-secondary text-[11px] font-semibold text-muted-foreground">
+                A
+              </span>
+            </div>
+            <div className="flex min-w-0 items-center">
+              <span className="truncate text-xs font-semibold tracking-tight">
+                Anton
+              </span>
+            </div>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              aria-label="Collapse sidebar"
+            >
+              <PanelLeftClose />
+            </Button>
+          </div>
 
-      <div className="flex-1 overflow-y-auto py-2">
-        {loading && sessions.length === 0 ? (
-          <div className="px-3 py-2 text-xs text-muted-foreground">
-            Loading…
+          <nav className="space-y-0.5 px-2 pb-2">
+            <SidebarNavItem active icon={<MessageSquare />}>
+              Sessions
+            </SidebarNavItem>
+          </nav>
+
+          <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Recent
+            </span>
+            <Button asChild size="icon-sm" variant="ghost" aria-label="New chat">
+              <Link href="/">
+                <Plus />
+              </Link>
+            </Button>
           </div>
-        ) : sessions.length === 0 ? (
-          <div className="px-3 py-2 text-xs text-muted-foreground">
-            No sessions yet. Send a message to start one.
+
+          <div className="flex-1 overflow-y-auto pb-2">
+          {loading && sessions.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              Loading...
+            </div>
+          ) : sessions.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              No sessions yet. Send a message to start one.
+            </div>
+          ) : (
+            <ul className="space-y-0.5 px-2">
+              {sessions.map((s) => (
+                <SessionRow
+                  key={s.id}
+                  session={s}
+                  isActive={s.id === activeId}
+                />
+              ))}
+            </ul>
+          )}
+          {error && (
+            <div className="mx-3 mt-2 rounded-md bg-destructive/10 px-2 py-1 text-[11px] text-destructive ring-1 ring-destructive/30">
+              {error}
+            </div>
+          )}
           </div>
-        ) : (
-          <ul className="space-y-0.5 px-2">
-            {sessions.map((s) => (
-              <SessionRow
-                key={s.id}
-                session={s}
-                isActive={s.id === activeId}
-              />
-            ))}
-          </ul>
-        )}
-        {error && (
-          <div className="mx-3 mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] text-destructive">
-            {error}
+
+          <div className="border-t border-sidebar-border p-1.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs"
+              onClick={() => setSettingsOpen(true)}
+              aria-label="Settings"
+            >
+              <Settings />
+              Settings
+            </Button>
           </div>
-        )}
-      </div>
-      <div className="border-t border-border p-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start text-xs"
-          onClick={() => setWorkspaceOpen(true)}
-        >
-          <FolderGit2 />
-          Workspaces
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="w-full justify-start text-xs"
-          onClick={() => setContextOpen(true)}
-        >
-          <FolderCog />
-          Project Context
-        </Button>
-      </div>
-      <ProjectContextDialog open={contextOpen} onOpenChange={setContextOpen} />
-      <WorkspaceDialog
-        open={workspaceOpen}
-        onOpenChange={setWorkspaceOpen}
+        </div>
+      ) : (
+        <div className="flex h-full w-[41px] shrink-0 flex-col">
+          <div className="flex h-10 w-full items-center pl-2">
+            <span className="flex size-5 items-center justify-center rounded bg-secondary text-[11px] font-semibold text-muted-foreground">
+              A
+            </span>
+          </div>
+          <nav className="flex w-full flex-col gap-1 pl-2">
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              className="bg-sidebar-accent text-sidebar-accent-foreground"
+              aria-label="Sessions"
+            >
+              <MessageSquare />
+            </Button>
+            <Button asChild size="icon-sm" variant="ghost" aria-label="New chat">
+              <Link href="/">
+                <Plus />
+              </Link>
+            </Button>
+          </nav>
+          <div className="mt-auto w-full border-t border-sidebar-border py-1.5 pl-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setSettingsOpen(true)}
+              aria-label="Settings"
+            >
+              <Settings />
+            </Button>
+          </div>
+        </div>
+      )}
+      <SettingsDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
         activeProjectId={activeProjectId}
         onActiveProjectChange={setActiveProjectId}
       />
     </aside>
+  );
+}
+
+function SidebarNavItem({
+  active,
+  icon,
+  children,
+}: {
+  active?: boolean;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-left text-xs font-medium transition-colors",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-muted-foreground hover:bg-sidebar-accent/70 hover:text-foreground",
+      )}
+    >
+      <span className="text-muted-foreground [&_svg]:size-3.5">{icon}</span>
+      <span>{children}</span>
+    </button>
   );
 }
 
@@ -151,12 +274,7 @@ function SessionRow({
 
   if (editing) {
     return (
-      <li
-        className={cn(
-          "flex items-center gap-1 rounded-md px-2 py-1.5",
-          "bg-accent/60",
-        )}
-      >
+      <li className="flex items-center gap-1 rounded-md bg-sidebar-accent px-2 py-2">
         <input
           autoFocus
           value={draft}
@@ -165,7 +283,7 @@ function SessionRow({
             if (e.key === "Enter") void commit();
             if (e.key === "Escape") cancel();
           }}
-          className="flex-1 min-w-0 bg-transparent text-xs focus:outline-none"
+          className="min-w-0 flex-1 bg-transparent text-xs focus:outline-none"
         />
         <button
           type="button"
@@ -192,37 +310,44 @@ function SessionRow({
       <Link
         href={`/s/${session.id}`}
         className={cn(
-          "group flex items-center gap-1 rounded-md px-2 py-1.5 text-xs",
-          "text-foreground hover:bg-accent",
-          isActive && "bg-accent",
+          "group relative flex min-w-0 items-start rounded-md px-2 py-1.5 text-xs",
+          "text-foreground hover:bg-sidebar-accent/70",
+          isActive && "bg-sidebar-accent",
         )}
       >
-        <span className="flex-1 min-w-0 truncate">{session.title}</span>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            setDraft(session.title);
-            setEditing(true);
-          }}
-          className="shrink-0 rounded p-1 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-accent-foreground/10"
-          aria-label="Rename"
-        >
-          <Pencil className="size-3.5" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            setDeleteOpen(true);
-          }}
-          className="shrink-0 rounded p-1 text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-destructive/20 hover:text-destructive"
-          aria-label="Delete"
-        >
-          <Trash2 className="size-3.5" />
-        </button>
+        <span className="min-w-0 flex-1 pr-0 transition-[padding] group-hover:pr-11 group-focus-within:pr-11">
+          <span className="block truncate font-medium">{session.title}</span>
+          <span className="block truncate text-[10px] text-muted-foreground">
+            {formatRelativeTime(session.updatedAt)}
+          </span>
+        </span>
+        <span className="absolute right-1 top-1 flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setDraft(session.title);
+              setEditing(true);
+            }}
+            className="rounded p-1 text-muted-foreground hover:bg-accent-foreground/10 hover:text-foreground"
+            aria-label="Rename"
+          >
+            <Pencil className="size-3" />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setDeleteOpen(true);
+            }}
+            className="rounded p-1 text-muted-foreground hover:bg-destructive/20 hover:text-destructive"
+            aria-label="Delete"
+          >
+            <Trash2 className="size-3" />
+          </button>
+        </span>
       </Link>
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
@@ -248,4 +373,15 @@ function SessionRow({
       </AlertDialog>
     </li>
   );
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const deltaMs = Date.now() - timestamp;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (deltaMs < minute) return "just now";
+  if (deltaMs < hour) return `${Math.floor(deltaMs / minute)} minutes ago`;
+  if (deltaMs < day) return `${Math.floor(deltaMs / hour)} hours ago`;
+  return `${Math.floor(deltaMs / day)} days ago`;
 }

--- a/components/chat/settings-dialog.tsx
+++ b/components/chat/settings-dialog.tsx
@@ -1,0 +1,1005 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  FolderGit2,
+  GitBranch,
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type { ProjectSummary } from "./workspace-dialog";
+
+const ACTIVE_PROJECT_KEY = "anton.activeProjectId";
+
+type SettingsSection = "workspaces" | "memories" | "skills";
+
+type WorkspaceSettings = {
+  localWorkspacesRoot: string | null;
+  resolvedLocalWorkspacesRoot: string | null;
+  source: "database" | "env" | "default";
+  exists: boolean;
+};
+
+type GitHubRepository = {
+  id: number;
+  installationId: number;
+  fullName: string;
+  private: boolean;
+  defaultBranch: string;
+  clonedProjectId: string | null;
+};
+
+type ProjectMemory = {
+  id: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type SkillSummary = {
+  slug: string;
+  name: string;
+  description: string;
+  path: string;
+};
+
+type SkillDocument = SkillSummary & {
+  body: string;
+};
+
+interface SettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeProjectId: string | null;
+  onActiveProjectChange: (projectId: string | null) => void;
+  initialSection?: SettingsSection;
+}
+
+export function SettingsDialog({
+  open,
+  onOpenChange,
+  activeProjectId,
+  onActiveProjectChange,
+  initialSection = "workspaces",
+}: SettingsDialogProps) {
+  const [section, setSection] = useState<SettingsSection>(initialSection);
+
+  useEffect(() => {
+    // Opening settings should reset the visible panel to the requested entry point.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (open) setSection(initialSection);
+  }, [initialSection, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onOpenChange(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onOpenChange, open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-background"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-title"
+    >
+      <div className="grid h-dvh min-h-0 grid-cols-1 md:grid-cols-[300px_minmax(0,1fr)]">
+        <aside className="hidden min-h-0 border-r border-border bg-sidebar md:flex md:flex-col">
+          <div className="border-b border-border px-3 py-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="-ml-2 mb-3 h-6 text-xs text-muted-foreground"
+              onClick={() => onOpenChange(false)}
+            >
+              <ChevronLeft />
+              Back
+            </Button>
+            <label className="relative block">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <input
+                className="h-8 w-full rounded-md bg-secondary pl-8 pr-2.5 text-xs outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+                placeholder="Search settings..."
+              />
+            </label>
+          </div>
+
+          <nav className="min-h-0 flex-1 overflow-y-auto p-2">
+            <SettingsGroup title="Workspace">
+              <SettingsNavButton
+                active={section === "workspaces"}
+                onClick={() => setSection("workspaces")}
+              >
+                Workspaces
+              </SettingsNavButton>
+            </SettingsGroup>
+            <SettingsGroup title="Project context">
+              <SettingsNavButton
+                active={section === "memories"}
+                onClick={() => setSection("memories")}
+              >
+                Memories
+              </SettingsNavButton>
+              <SettingsNavButton
+                active={section === "skills"}
+                onClick={() => setSection("skills")}
+              >
+                Skills
+              </SettingsNavButton>
+            </SettingsGroup>
+          </nav>
+        </aside>
+
+        <main className="flex min-h-0 min-w-0 flex-col bg-background">
+          <header className="flex h-10 items-center justify-between border-b border-border px-3 md:px-4">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="hidden text-xs text-muted-foreground md:inline">
+                Settings
+              </span>
+              <span className="hidden text-muted-foreground md:inline">/</span>
+              <h1 id="settings-title" className="truncate text-xs font-semibold">
+                {sectionTitle(section)}
+              </h1>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onOpenChange(false)}
+              aria-label="Close settings"
+            >
+              <X />
+            </Button>
+          </header>
+
+          <div className="flex gap-1.5 overflow-x-auto border-b border-border px-2 py-1.5 md:hidden">
+            <MobileTab
+              active={section === "workspaces"}
+              onClick={() => setSection("workspaces")}
+            >
+              Workspaces
+            </MobileTab>
+            <MobileTab
+              active={section === "memories"}
+              onClick={() => setSection("memories")}
+            >
+              Memories
+            </MobileTab>
+            <MobileTab
+              active={section === "skills"}
+              onClick={() => setSection("skills")}
+            >
+              Skills
+            </MobileTab>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-5 md:px-8">
+            {section === "workspaces" && (
+              <WorkspaceSettingsPanel
+                activeProjectId={activeProjectId}
+                onActiveProjectChange={onActiveProjectChange}
+              />
+            )}
+            {section === "memories" && <MemorySettingsPanel active />}
+            {section === "skills" && <SkillsSettingsPanel active />}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function SettingsGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mb-4">
+      <h2 className="mb-1.5 px-2 text-[11px] font-medium text-muted-foreground">
+        {title}
+      </h2>
+      <div className="space-y-0.5">{children}</div>
+    </section>
+  );
+}
+
+function SettingsNavButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-7 w-full items-center rounded-md px-2 text-left text-xs font-medium transition-colors",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-foreground hover:bg-sidebar-accent/70",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MobileTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "shrink-0 rounded-md px-2.5 py-1 text-xs font-medium",
+        active ? "bg-secondary text-foreground" : "text-muted-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function WorkspaceSettingsPanel({
+  activeProjectId,
+  onActiveProjectChange,
+}: {
+  activeProjectId: string | null;
+  onActiveProjectChange: (projectId: string | null) => void;
+}) {
+  const [settings, setSettings] = useState<WorkspaceSettings | null>(null);
+  const [rootDraft, setRootDraft] = useState("");
+  const [repositories, setRepositories] = useState<GitHubRepository[]>([]);
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [cloningRepoId, setCloningRepoId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [settingsRes, projectsRes, reposRes] = await Promise.all([
+        fetch("/api/workspace-settings", { cache: "no-store" }),
+        fetch("/api/projects", { cache: "no-store" }),
+        fetch("/api/github/repositories", { cache: "no-store" }),
+      ]);
+      if (!settingsRes.ok) throw new Error(`Settings HTTP ${settingsRes.status}`);
+      if (!projectsRes.ok) throw new Error(`Projects HTTP ${projectsRes.status}`);
+
+      const settingsData = (await settingsRes.json()) as {
+        settings: WorkspaceSettings;
+      };
+      const projectsData = (await projectsRes.json()) as {
+        projects: ProjectSummary[];
+      };
+      setSettings(settingsData.settings);
+      setRootDraft(
+        settingsData.settings.localWorkspacesRoot ??
+          settingsData.settings.resolvedLocalWorkspacesRoot ??
+          "",
+      );
+      setProjects(projectsData.projects);
+
+      if (reposRes.ok) {
+        const reposData = (await reposRes.json()) as {
+          repositories: GitHubRepository[];
+        };
+        setRepositories(reposData.repositories);
+      } else {
+        setRepositories([]);
+      }
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load workspaces");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial panel hydration updates state after async requests settle.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+  }, [refresh]);
+
+  const saveRoot = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/workspace-settings", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ localWorkspacesRoot: rootDraft.trim() || null }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save root");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectProject = (projectId: string) => {
+    localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+    onActiveProjectChange(projectId);
+    window.dispatchEvent(
+      new CustomEvent("anton-active-project-change", { detail: projectId }),
+    );
+  };
+
+  const cloneRepo = async (repo: GitHubRepository) => {
+    setCloningRepoId(repo.id);
+    try {
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repositoryId: repo.id,
+          installationId: repo.installationId,
+        }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      const data = (await res.json()) as { project: ProjectSummary };
+      selectProject(data.project.id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Clone failed");
+    } finally {
+      setCloningRepoId(null);
+    }
+  };
+
+  const readyProjects = projects.filter((project) => project.status === "ready");
+
+  return (
+    <SettingsPageShell
+      title="Workspaces"
+      description="Choose where Anton clones repositories and which workspace new sessions use."
+    >
+      {error && <ErrorBanner message={error} />}
+      <SettingsCard title="Local workspace root" icon={<FolderGit2 />}>
+        <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+          <input
+            value={rootDraft}
+            onChange={(event) => setRootDraft(event.target.value)}
+            className="h-7 min-w-0 rounded-md bg-secondary px-2.5 font-mono text-xs outline-none focus:ring-1 focus:ring-ring"
+            placeholder="M:\\Projects\\anton-workspaces"
+            aria-label="Local workspace root"
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={saveRoot}
+            disabled={saving || rootDraft.trim().length === 0}
+          >
+            {saving ? <Loader2 className="animate-spin" /> : <Check />}
+            Save
+          </Button>
+        </div>
+        {settings && (
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            Current:{" "}
+            <span className="font-mono">{settings.resolvedLocalWorkspacesRoot}</span>
+            {" · "}
+            {settings.source}
+            {settings.exists ? " · ready" : " · will be created"}
+          </p>
+        )}
+      </SettingsCard>
+
+      <SettingsCard title="Active project" icon={<GitBranch />}>
+        {readyProjects.length === 0 ? (
+          <EmptyState message="No cloned projects yet." />
+        ) : (
+          <ul className="grid gap-2">
+            {readyProjects.map((project) => (
+              <li key={project.id}>
+                <button
+                  type="button"
+                  onClick={() => selectProject(project.id)}
+                  className={cn(
+                    "w-full rounded-md p-2.5 text-left ring-1 transition-colors",
+                    activeProjectId === project.id
+                      ? "bg-primary/10 ring-primary/50"
+                      : "bg-background/45 ring-border hover:bg-accent",
+                  )}
+                >
+                  <span className="block text-xs font-medium">
+                    {project.fullName}
+                  </span>
+                  <span className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">
+                    {project.localPath}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SettingsCard>
+
+      <SettingsCard
+        title="GitHub repositories"
+        icon={<GitBranch />}
+        action={
+          <div className="flex items-center gap-1.5">
+            <Button type="button" size="sm" variant="outline" asChild>
+              <a href="/api/github/connect">Connect GitHub</a>
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => void refresh()}
+              disabled={loading}
+            >
+              <RefreshCw className={cn(loading && "animate-spin")} />
+              Refresh
+            </Button>
+          </div>
+        }
+      >
+        {repositories.length === 0 ? (
+          <EmptyState message="Connect GitHub and refresh to list repositories." />
+        ) : (
+          <ul className="grid gap-2 lg:grid-cols-2">
+            {repositories.map((repo) => (
+              <li
+                key={`${repo.installationId}:${repo.id}`}
+                className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-xs font-medium">
+                      {repo.fullName}
+                    </div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      {repo.private ? "Private" : "Public"} · {repo.defaultBranch}
+                    </div>
+                  </div>
+                  {repo.clonedProjectId ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => selectProject(repo.clonedProjectId as string)}
+                    >
+                      Select
+                    </Button>
+                  ) : (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => void cloneRepo(repo)}
+                      disabled={cloningRepoId === repo.id}
+                    >
+                      {cloningRepoId === repo.id ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <GitBranch />
+                      )}
+                      Clone
+                    </Button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SettingsCard>
+    </SettingsPageShell>
+  );
+}
+
+function MemorySettingsPanel({ active }: { active: boolean }) {
+  const [memories, setMemories] = useState<ProjectMemory[]>([]);
+  const [draft, setDraft] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingDraft, setEditingDraft] = useState("");
+  const [memoryToDelete, setMemoryToDelete] = useState<ProjectMemory | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadMemories = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memories", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { memories: ProjectMemory[] };
+      setMemories(data.memories);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load memories");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Fetching on panel activation updates state after the request settles.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (active) void loadMemories();
+  }, [active, loadMemories]);
+
+  const create = async () => {
+    const content = draft.trim();
+    if (!content) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/memories", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setDraft("");
+      await loadMemories();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Create failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const update = async (id: string) => {
+    const content = editingDraft.trim();
+    if (!content) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setEditingId(null);
+      setEditingDraft("");
+      await loadMemories();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}`);
+      setMemoryToDelete(null);
+      await loadMemories();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsPageShell
+      title="Memories"
+      description="Store durable project preferences and facts that Anton should reuse across sessions."
+    >
+      {error && <ErrorBanner message={error} />}
+      <SettingsCard title="New memory">
+        <Textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          maxLength={1000}
+          placeholder="A durable project preference or fact."
+          className="min-h-16 text-xs"
+          aria-label="New memory"
+        />
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <span className="text-xs text-muted-foreground">
+            {draft.trim().length}/1000
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            onClick={create}
+            disabled={saving || draft.trim().length === 0}
+          >
+            {saving ? <Loader2 className="animate-spin" /> : <Plus />}
+            Add memory
+          </Button>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard title="Saved memories">
+        {loading ? (
+          <LoadingState label="Loading memories" />
+        ) : memories.length === 0 ? (
+          <EmptyState message="No project memories saved." />
+        ) : (
+          <ul className="space-y-1.5">
+            {memories.map((memory) => {
+              const editing = editingId === memory.id;
+              return (
+                <li
+                  key={memory.id}
+                  className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
+                >
+                  {editing ? (
+                    <div className="space-y-2">
+                      <Textarea
+                        value={editingDraft}
+                        onChange={(event) =>
+                          setEditingDraft(event.target.value)
+                        }
+                        maxLength={1000}
+                        className="min-h-16 text-xs"
+                        aria-label="Edit memory"
+                      />
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditingId(null);
+                            setEditingDraft("");
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => update(memory.id)}
+                          disabled={saving || editingDraft.trim().length === 0}
+                        >
+                          Save
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="whitespace-pre-wrap text-xs leading-normal">
+                          {memory.content}
+                        </p>
+                        <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                          {memory.id}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditingId(memory.id);
+                            setEditingDraft(memory.content);
+                          }}
+                          aria-label="Edit memory"
+                        >
+                          <Pencil />
+                        </Button>
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => setMemoryToDelete(memory)}
+                          aria-label="Delete memory"
+                        >
+                          <Trash2 />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </SettingsCard>
+
+      <AlertDialog
+        open={memoryToDelete !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setMemoryToDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete memory?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the selected project memory from future Anton
+              sessions. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={saving || memoryToDelete === null}
+              onClick={(event) => {
+                event.preventDefault();
+                if (memoryToDelete) void remove(memoryToDelete.id);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </SettingsPageShell>
+  );
+}
+
+function SkillsSettingsPanel({ active }: { active: boolean }) {
+  const [skills, setSkills] = useState<SkillSummary[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<SkillDocument | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [skillLoading, setSkillLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const loadSkills = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/skills", { cache: "no-store" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as {
+          skills: SkillSummary[];
+          warnings: string[];
+        };
+        setSkills(data.skills);
+        setWarnings(data.warnings);
+        setSelectedSlug((current) =>
+          current && data.skills.some((skill) => skill.slug === current)
+            ? current
+            : data.skills[0]?.slug ?? null,
+        );
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load skills");
+      } finally {
+        setLoading(false);
+      }
+    };
+    void loadSkills();
+  }, [active]);
+
+  useEffect(() => {
+    if (!selectedSlug) return;
+    const loadSkill = async () => {
+      setSkillLoading(true);
+      try {
+        const res = await fetch(`/api/skills/${encodeURIComponent(selectedSlug)}`, {
+          cache: "no-store",
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { skill: SkillDocument };
+        setSelectedSkill(data.skill);
+        setError(null);
+      } catch (err) {
+        setSelectedSkill(null);
+        setError(err instanceof Error ? err.message : "Failed to load skill");
+      } finally {
+        setSkillLoading(false);
+      }
+    };
+    void loadSkill();
+  }, [selectedSlug]);
+
+  return (
+    <SettingsPageShell
+      title="Skills"
+      description="Review project-local skills available to Anton from the active workspace."
+    >
+      {error && <ErrorBanner message={error} />}
+      {warnings.length > 0 && (
+        <div className="rounded-md bg-amber-500/10 p-2.5 text-xs text-amber-300 ring-1 ring-amber-500/30">
+          <div className="mb-1 flex items-center gap-2 font-medium">
+            <AlertTriangle className="size-3.5" />
+            Skill warnings
+          </div>
+          <ul className="list-disc space-y-1 pl-5">
+            {warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="grid min-h-[440px] overflow-hidden rounded-md bg-card ring-1 ring-border lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside className="min-h-0 border-b border-border bg-background/25 p-2 lg:border-b-0 lg:border-r">
+          {loading ? (
+            <LoadingState label="Loading skills" />
+          ) : skills.length === 0 ? (
+            <EmptyState message="No workspace skills found." />
+          ) : (
+            <ul className="space-y-1">
+              {skills.map((skill) => (
+                <li key={skill.slug}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedSlug(skill.slug)}
+                    className={cn(
+                      "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                      selectedSlug === skill.slug
+                        ? "bg-secondary text-foreground"
+                        : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
+                    )}
+                  >
+                    <span className="block truncate font-medium">
+                      {skill.name}
+                    </span>
+                    <span className="block truncate font-mono text-[10px]">
+                      {skill.slug}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+        <section className="min-h-0 overflow-y-auto p-3">
+          {!selectedSlug ? (
+            <EmptyState message="Select a skill to inspect it." />
+          ) : skillLoading ? (
+            <LoadingState label="Loading skill" />
+          ) : selectedSkill ? (
+            <article>
+              <div className="mb-4">
+                <h3 className="text-xs font-semibold">{selectedSkill.name}</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {selectedSkill.description || "No description."}
+                </p>
+                <p className="mt-2 font-mono text-[10px] text-muted-foreground">
+                  {selectedSkill.path}
+                </p>
+              </div>
+              <pre className="max-h-[440px] overflow-auto rounded-md bg-background/60 p-2.5 text-xs leading-normal whitespace-pre-wrap ring-1 ring-border">
+                {selectedSkill.body || "(empty)"}
+              </pre>
+            </article>
+          ) : null}
+        </section>
+      </div>
+    </SettingsPageShell>
+  );
+}
+
+function SettingsPageShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-3">
+      <div className="mb-5">
+        <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SettingsCard({
+  title,
+  icon,
+  action,
+  children,
+}: {
+  title: string;
+  icon?: ReactNode;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-md bg-card p-3 ring-1 ring-border">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="flex items-center gap-1.5 text-xs font-semibold [&_svg]:size-4">
+          {icon}
+          {title}
+        </h3>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <Loader2 className="size-3.5 animate-spin" />
+      {label}
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
+      {message}
+    </div>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive ring-1 ring-destructive/30">
+      {message}
+    </div>
+  );
+}
+
+function sectionTitle(section: SettingsSection): string {
+  switch (section) {
+    case "workspaces":
+      return "Workspaces";
+    case "memories":
+      return "Memories";
+    case "skills":
+      return "Skills";
+  }
+}

--- a/components/chat/tool-card.tsx
+++ b/components/chat/tool-card.tsx
@@ -38,8 +38,8 @@ export function ToolCard({
   return (
     <details
       className={cn(
-        "rounded-md border text-xs not-prose",
-        "border-border bg-background/60 text-foreground",
+        "rounded-md text-xs not-prose",
+        "bg-card/50 text-foreground ring-1 ring-border",
       )}
     >
       <summary className="flex items-center justify-between gap-2 cursor-pointer select-none px-3 py-2">
@@ -142,7 +142,7 @@ function WriteFileBody({
           <span className="font-mono text-[11px]">{out.path ?? relPath ?? "?"}</span>
         </Section>
         {out.previousTruncated ? (
-          <div className="rounded border border-border bg-background/60 px-3 py-2 text-[11px] text-muted-foreground">
+          <div className="rounded bg-background/60 px-3 py-2 text-[11px] text-muted-foreground ring-1 ring-border">
             Existing file was too large to diff inline ({out.bytesWritten} bytes written).
           </div>
         ) : (
@@ -228,12 +228,12 @@ function stateBadge(state: ToolState): { label: string; tone: string } {
     case "input-streaming":
       return {
         label: "calling…",
-        tone: "bg-muted text-muted-foreground",
+        tone: "bg-secondary text-muted-foreground",
       };
     case "input-available":
       return {
         label: "running…",
-        tone: "bg-muted text-muted-foreground",
+        tone: "bg-secondary text-muted-foreground",
       };
     case "approval-requested":
       return {
@@ -243,7 +243,7 @@ function stateBadge(state: ToolState): { label: string; tone: string } {
     case "approval-responded":
       return {
         label: "approved",
-        tone: "bg-muted text-muted-foreground",
+        tone: "bg-secondary text-muted-foreground",
       };
     case "output-available":
       return {

--- a/components/chat/worklog.tsx
+++ b/components/chat/worklog.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useState } from "react";
+import { getToolName, isToolUIPart, type ChatAddToolApproveResponseFunction } from "ai";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  TerminalSquare,
+  X,
+  XCircle,
+} from "lucide-react";
+
+import type { AntonUIMessage } from "@/src/agent/loop";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { DiffView } from "./diff-view";
+
+type ToolState =
+  | "input-streaming"
+  | "input-available"
+  | "approval-requested"
+  | "approval-responded"
+  | "output-available"
+  | "output-error"
+  | "output-denied";
+
+export type WorklogEntry = {
+  id: string;
+  sourceMessageId: string;
+  name: string;
+  state: ToolState;
+  input: unknown;
+  output: unknown;
+  errorText: string | undefined;
+  approvalId: string | undefined;
+};
+
+interface WorklogProps {
+  messages: AntonUIMessage[];
+  onApproval: ChatAddToolApproveResponseFunction;
+  className?: string;
+  onClose?: () => void;
+}
+
+export function Worklog({
+  messages,
+  onApproval,
+  className,
+  onClose,
+}: WorklogProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const entries = getWorklogEntries(messages);
+  const latest = entries.at(-1);
+  const selected =
+    entries.find((entry) => entry.id === selectedId) ?? latest ?? null;
+
+  return (
+    <aside
+      className={cn(
+        "flex min-h-0 flex-col border-l border-border bg-card/35",
+        className,
+      )}
+      aria-label="Worklog"
+    >
+      <header className="flex h-10 shrink-0 items-center justify-between border-b border-border px-3">
+        <div className="flex items-center gap-1.5 text-xs font-semibold">
+          <TerminalSquare className="size-3.5 text-muted-foreground" />
+          Worklog
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {entries.length}
+          </span>
+          {onClose && (
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              onClick={onClose}
+              aria-label="Close worklog"
+            >
+              <X />
+            </Button>
+          )}
+        </div>
+      </header>
+
+      {entries.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+          Tool activity will appear here when Anton reads, searches, edits, or
+          runs commands.
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <ol className="border-b border-border px-2 py-2">
+            {entries.map((entry) => (
+              <li key={entry.id}>
+                <WorklogRow
+                  entry={entry}
+                  active={entry.id === selected?.id}
+                  onSelect={() => setSelectedId(entry.id)}
+                />
+              </li>
+            ))}
+          </ol>
+          {selected && (
+            <WorklogDetail entry={selected} onApproval={onApproval} />
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
+  const entries: WorklogEntry[] = [];
+  for (const message of messages) {
+    message.parts.forEach((part, index) => {
+      if (!isToolUIPart(part)) return;
+      const state = part.state as ToolState;
+      entries.push({
+        id: `${message.id}:${index}`,
+        sourceMessageId: message.id,
+        name: String(getToolName(part)),
+        state,
+        input: "input" in part ? part.input : undefined,
+        output: "output" in part ? part.output : undefined,
+        errorText: "errorText" in part ? part.errorText : undefined,
+        approvalId:
+          state === "approval-requested" && "approval" in part && part.approval
+            ? part.approval.id
+            : undefined,
+      });
+    });
+  }
+  return entries;
+}
+
+function WorklogRow({
+  entry,
+  active,
+  onSelect,
+}: {
+  entry: WorklogEntry;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const state = stateMeta(entry.state);
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "grid w-full grid-cols-[0.875rem_1fr] gap-1.5 rounded-md px-1.5 py-1 text-left text-xs transition-colors",
+        active ? "bg-accent/70" : "hover:bg-accent/40",
+      )}
+      aria-pressed={active}
+    >
+      <state.Icon
+        className={cn("mt-0.5 size-3", state.iconClass)}
+        aria-hidden
+      />
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate font-mono text-[11px] text-foreground">
+            {entry.name}
+          </span>
+          <span className={cn("shrink-0 text-[10px]", state.textClass)}>
+            {state.label}
+          </span>
+        </div>
+        <p className="truncate font-mono text-[10px] text-muted-foreground">
+          {previewInput(entry.input)}
+        </p>
+      </div>
+    </button>
+  );
+}
+
+function WorklogDetail({
+  entry,
+  onApproval,
+}: {
+  entry: WorklogEntry;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const state = stateMeta(entry.state);
+  const showWriteDiff =
+    entry.name === "write_file" &&
+    entry.state === "output-available" &&
+    isOkWriteFileOutput(entry.output) &&
+    pickString(entry.input, "content") !== undefined;
+
+  return (
+    <section className="space-y-2.5 px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <state.Icon className={cn("size-3.5", state.iconClass)} />
+            <span>{state.label}</span>
+          </div>
+          <h2 className="mt-0.5 truncate font-mono text-xs font-semibold">
+            {entry.name}
+          </h2>
+        </div>
+        {entry.state === "approval-requested" && entry.approvalId && (
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              type="button"
+              size="sm"
+              onClick={() =>
+                onApproval({ id: entry.approvalId as string, approved: true })
+              }
+            >
+              Approve
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() =>
+                onApproval({ id: entry.approvalId as string, approved: false })
+              }
+            >
+              Deny
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <LogBlock title="Input">{safeStringify(entry.input)}</LogBlock>
+
+      {showWriteDiff ? (
+        <DiffView
+          previous={(entry.output as WriteFileOkOutput).previousContent ?? ""}
+          next={pickString(entry.input, "content") ?? ""}
+          newFile={(entry.output as WriteFileOkOutput).existed === false}
+        />
+      ) : entry.state === "output-error" && entry.errorText ? (
+        <LogBlock title="Error" tone="error">
+          {entry.errorText}
+        </LogBlock>
+      ) : entry.output !== undefined ? (
+        <LogBlock title="Output">{safeStringify(entry.output)}</LogBlock>
+      ) : null}
+    </section>
+  );
+}
+
+function LogBlock({
+  title,
+  tone,
+  children,
+}: {
+  title: string;
+  tone?: "error";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          "text-[10px] font-medium uppercase text-muted-foreground",
+          tone === "error" && "text-destructive",
+        )}
+      >
+        {title}
+      </div>
+      <pre className="max-h-56 overflow-auto rounded-md bg-background/70 p-2.5 font-mono text-[10px] leading-relaxed text-foreground/90 whitespace-pre-wrap">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+function stateMeta(state: ToolState) {
+  switch (state) {
+    case "input-streaming":
+      return {
+        label: "streaming",
+        Icon: Loader2,
+        iconClass: "animate-spin text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "input-available":
+      return {
+        label: "running",
+        Icon: Clock3,
+        iconClass: "text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "approval-requested":
+      return {
+        label: "approval",
+        Icon: AlertCircle,
+        iconClass: "text-amber-400",
+        textClass: "text-amber-400",
+      };
+    case "approval-responded":
+      return {
+        label: "approved",
+        Icon: CheckCircle2,
+        iconClass: "text-muted-foreground",
+        textClass: "text-muted-foreground",
+      };
+    case "output-available":
+      return {
+        label: "done",
+        Icon: CheckCircle2,
+        iconClass: "text-emerald-400",
+        textClass: "text-emerald-400",
+      };
+    case "output-error":
+      return {
+        label: "error",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+    case "output-denied":
+      return {
+        label: "denied",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+  }
+}
+
+function previewInput(input: unknown): string {
+  if (typeof input === "object" && input !== null) {
+    const path = pickString(input, "path");
+    const command = pickString(input, "command");
+    const pattern = pickString(input, "pattern");
+    return command ?? path ?? pattern ?? safeStringify(input);
+  }
+  return safeStringify(input);
+}
+
+type WriteFileOkOutput = {
+  ok: true;
+  path?: string;
+  bytesWritten?: number;
+  existed?: boolean;
+  previousContent?: string;
+  previousTruncated?: boolean;
+};
+
+function isOkWriteFileOutput(value: unknown): value is WriteFileOkOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    (value as { ok: unknown }).ok === true
+  );
+}
+
+function pickString(value: unknown, key: string): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const v = (value as Record<string, unknown>)[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/components/chat/workspace-dialog.tsx
+++ b/components/chat/workspace-dialog.tsx
@@ -189,7 +189,7 @@ export function WorkspaceDialog({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/75 p-4 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-labelledby="workspace-dialog-title"
@@ -197,14 +197,14 @@ export function WorkspaceDialog({
         if (event.target === event.currentTarget) onOpenChange(false);
       }}
     >
-      <div className="flex h-[min(760px,calc(100vh-2rem))] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg">
-        <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+      <div className="flex h-[min(720px,calc(100vh-2rem))] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-card shadow-none ring-1 ring-border">
+        <header className="flex h-10 items-center justify-between gap-2 border-b border-border px-3">
           <div className="min-w-0">
-            <h2 id="workspace-dialog-title" className="text-sm font-semibold">
+            <h2 id="workspace-dialog-title" className="text-xs font-semibold">
               Workspaces
             </h2>
             {settings && (
-              <p className="mt-1 truncate text-xs text-muted-foreground">
+              <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
                 {settings.resolvedLocalWorkspacesRoot}
               </p>
             )}
@@ -212,7 +212,7 @@ export function WorkspaceDialog({
           <Button
             type="button"
             variant="ghost"
-            size="icon"
+            size="icon-sm"
             onClick={() => onOpenChange(false)}
             aria-label="Close workspaces"
           >
@@ -220,20 +220,20 @@ export function WorkspaceDialog({
           </Button>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          <div className="grid gap-4 md:grid-cols-[1fr_1fr]">
-            <section className="space-y-3">
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          <div className="grid gap-3 md:grid-cols-[1fr_1fr]">
+            <section className="space-y-2.5">
               <PanelTitle icon={<GitBranch />}>Local root</PanelTitle>
-              <div className="rounded-md border border-border p-3">
+              <div className="rounded-md bg-background/45 p-2.5 ring-1 ring-border">
                 <label className="text-xs font-medium" htmlFor="workspace-root">
                   Absolute path
                 </label>
-                <div className="mt-2 flex gap-2">
+                <div className="mt-1.5 flex gap-2">
                   <input
                     id="workspace-root"
                     value={rootDraft}
                     onChange={(event) => setRootDraft(event.target.value)}
-                    className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs outline-none focus:ring-1 focus:ring-ring"
+                    className="h-7 min-w-0 flex-1 rounded-md border-0 bg-secondary px-2.5 font-mono text-xs outline-none focus:ring-1 focus:ring-ring"
                     placeholder="M:\\Projects\\anton-workspaces"
                   />
                   <Button
@@ -247,7 +247,7 @@ export function WorkspaceDialog({
                   </Button>
                 </div>
                 {settings && (
-                  <p className="mt-2 text-[11px] text-muted-foreground">
+                  <p className="mt-1.5 text-[11px] text-muted-foreground">
                     Source: {settings.source}
                     {settings.exists ? " · ready" : " · will be created"}
                   </p>
@@ -255,7 +255,7 @@ export function WorkspaceDialog({
               </div>
 
               <PanelTitle icon={<GitBranch />}>GitHub</PanelTitle>
-              <div className="flex items-center gap-2 rounded-md border border-border p-3">
+              <div className="flex items-center gap-1.5 rounded-md bg-background/45 p-2.5 ring-1 ring-border">
                 <Button type="button" size="sm" asChild>
                   <a href="/api/github/connect">
                     <GitBranch />
@@ -275,28 +275,28 @@ export function WorkspaceDialog({
               </div>
 
               {error && (
-                <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive ring-1 ring-destructive/30">
                   {error}
                 </div>
               )}
             </section>
 
-            <section className="space-y-3">
+            <section className="space-y-2.5">
               <PanelTitle>Ready projects</PanelTitle>
               {readyProjects.length === 0 ? (
                 <EmptyState message="No cloned projects yet." />
               ) : (
-                <ul className="space-y-2">
+                <ul className="space-y-1.5">
                   {readyProjects.map((project) => (
                     <li key={project.id}>
                       <button
                         type="button"
                         onClick={() => selectProject(project.id)}
                         className={cn(
-                          "w-full rounded-md border px-3 py-2 text-left text-xs",
+                          "w-full rounded-md px-2.5 py-1.5 text-left text-xs ring-1 transition-colors",
                           activeProjectId === project.id
-                            ? "border-primary bg-primary/10"
-                            : "border-border hover:bg-accent",
+                            ? "bg-primary/10 ring-primary/50"
+                            : "bg-background/45 ring-border hover:bg-accent",
                         )}
                       >
                         <span className="block font-medium">{project.fullName}</span>
@@ -311,7 +311,7 @@ export function WorkspaceDialog({
             </section>
           </div>
 
-          <section className="mt-5 space-y-3">
+          <section className="mt-4 space-y-2.5">
             <PanelTitle>Repositories</PanelTitle>
             {repositories.length === 0 ? (
               <EmptyState message="Connect GitHub and refresh to list repositories." />
@@ -320,12 +320,12 @@ export function WorkspaceDialog({
                 {repositories.map((repo) => (
                   <li
                     key={`${repo.installationId}:${repo.id}`}
-                    className="rounded-md border border-border p-3 text-xs"
+                    className="rounded-md bg-background/45 p-2.5 text-xs ring-1 ring-border"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className="truncate font-medium">{repo.fullName}</div>
-                        <div className="mt-1 text-[11px] text-muted-foreground">
+                        <div className="mt-0.5 text-[11px] text-muted-foreground">
                           {repo.private ? "private" : "public"} · {repo.defaultBranch}
                         </div>
                       </div>
@@ -378,7 +378,7 @@ function PanelTitle({
   children: ReactNode;
 }) {
   return (
-    <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    <h3 className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground [&_svg]:size-3.5">
       {icon}
       {children}
     </h3>
@@ -387,7 +387,7 @@ function PanelTitle({
 
 function EmptyState({ message }: { message: string }) {
   return (
-    <div className="rounded-md border border-dashed border-border px-3 py-4 text-xs text-muted-foreground">
+    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
       {message}
     </div>
   );

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronDown } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "inline-flex h-7 min-w-0 items-center justify-between gap-2 rounded-md bg-secondary px-2 text-xs text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="size-3.5 opacity-70" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        position={position}
+        className={cn(
+          "relative z-50 max-h-72 min-w-[8rem] overflow-hidden rounded-md bg-popover text-popover-foreground shadow-none ring-1 ring-border data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        {...props}
+      />
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Viewport>) {
+  return (
+    <SelectPrimitive.Viewport
+      data-slot="select-viewport"
+      className={cn("p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pr-8 pl-2 text-xs outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="size-3.5" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+};

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full resize-none rounded-md border border-input bg-input/20 px-2 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 md:text-xs/relaxed dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex min-h-16 w-full resize-none rounded-md border border-input bg-input/20 px-2 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 md:text-xs/relaxed dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- redesign the chat surface into a compact workbench layout with left navigation, central transcript/composer, and selectable worklog
- add compact settings screens for workspaces, memories, and skills
- tighten global dark theme, composer, tool rows, markdown, dialogs, and sidebar/worklog behavior
- document the GitHub issue + branch workflow in AGENTS.md and CLAUDE.md

Closes #12

## Verification
- pnpm typecheck
- pnpm lint
- browser visual checks for:
  - new chat with no worklog dead space
  - active session transcript
  - left sidebar open and collapsed rail
  - right worklog open/closed
  - selectable worklog rows
  - settings Workspaces, Memories, and Skills
  - hydration overlay absence on localhost root