### PR TITLE
Docs: make ROADMAP.md the implementation backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,10 @@ Run `pnpm typecheck` and `pnpm lint` before committing. If you change the schema
 
 ## GitHub workflow
 
+- Treat `ROADMAP.md` as the source of truth for ongoing implementation tasks. Before starting implementation, read the relevant roadmap section and keep the work scoped to one checklist item or a small coherent group of related checklist items.
 - Before starting a new implementation, create or identify a GitHub issue that describes the requested change, scope, acceptance criteria, and verification plan. Reference that issue in the branch name, commit message, or PR body when practical.
+- When a GitHub issue or PR completes a roadmap item, update `ROADMAP.md` in the same change by marking the item as `[✔️]`. Do not mark roadmap items complete before the related implementation is actually resolved.
+- If implementation reveals missing work, add or refine checklist items in `ROADMAP.md` rather than burying follow-up tasks in chat history.
 - For new implementation work, create a new feature branch before editing code. Use a descriptive prefix such as `codex/<short-topic>` for Codex-driven work.
 - If the work clearly belongs to an existing feature branch, update that branch from `main` first, then continue on the existing branch instead of creating a duplicate branch.
 - Never commit directly to `main`. Open a pull request for review after the branch is pushed.
@@ -113,9 +116,9 @@ Never log the API key. Never commit `.env.local`, `anton.db`, or anything under 
 - Streaming custom data (permission requests, tool progress) uses AI SDK custom data parts through `toUIMessageStreamResponse`, not ad-hoc JSON frames.
 - Comments explain **why**, not what. Default is no comment.
 
-## Roadmap phase
+## Roadmap
 
-Phases 1-5 (streaming chat MVP, agent loop + tools + permission gate, persistent sessions, markdown, diff viewer, token counter, QoL, memory, skills, read-only sub-agents, MCP tools) are shipped. See `README.md` for the full roadmap.
+See `ROADMAP.md` for shipped capability, known gaps, and future implementation tasks. Use it when choosing work, creating GitHub issues, and marking completed items after issues are resolved.
 
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@ Follow the shared agent rules in `AGENTS.md`:
 - When a task spans many files, prefer a single `Agent` delegation with `subagent_type: "Explore"` over many serial reads.
 - Run `pnpm typecheck` and `pnpm lint` before reporting a coding task as done. A green build is the acceptance criterion.
 - Before writing Next.js code, consult `node_modules/next/dist/docs/`; this project pins Next 16, which has breaking changes from older training data.
-- Before implementation, create or identify the GitHub issue for the work and keep the branch/PR tied to that issue.
+- Before implementation, read `ROADMAP.md`, choose the relevant checklist item, create or identify the GitHub issue for the work, and keep the branch/PR tied to that issue.
+- When a GitHub issue or PR resolves a roadmap item, update `ROADMAP.md` in the same change by marking it `[✔️]`. Do not mark items complete before the implementation is actually resolved.
+- If new follow-up work is discovered, add or refine checklist items in `ROADMAP.md` instead of leaving the follow-up only in conversation.
 - For new implementation work, create a fresh `claude/*` feature branch before editing. If the change belongs to an existing branch, update that branch from `main` first and continue there.
 - Never push to `main`. Work on `claude/*` feature branches and open PRs only when explicitly asked.
 - Never commit `.env.local`, `anton.db`, `anton.db-shm`, `anton.db-wal`, or anything under `workspace/`.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,4 @@ pnpm dev                            # http://localhost:3000
 
 ## Roadmap
 
-- **Phase 0** - scaffold (done)
-- **Phase 1** - streaming chat MVP (no tools) (done)
-- **Phase 2** - agent loop + tools (`read_file`, `write_file`, `bash`, `grep`, `glob`) + permission gate (done)
-- **Phase 3** - persistent sessions (done)
-- **Phase 4** - markdown, diff viewer, token counter, QoL (done)
-- **Phase 5** - memory / skills / sub-agents / MCP (done)
+See [`ROADMAP.md`](ROADMAP.md) for shipped capabilities, known implementation risks, and the ongoing backlog. New implementation work should start from a roadmap checklist item and a matching GitHub issue.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,159 @@
+# Anton Roadmap
+
+Last reviewed: 2026-05-02
+
+This roadmap is the working backlog for turning Anton from a learning harness into a reliable local AI coding agent. Use each checklist item as the source for future GitHub issues. Mark finished items as `[✔️]` after the related GitHub issue or PR is resolved.
+
+## Current Baseline
+
+- [✔️] Next.js 16 App Router application with React 19 and TypeScript strict mode.
+- [✔️] Tailwind CSS v4 dark UI using shadcn-style primitives.
+- [✔️] OpenRouter provider integration through Vercel AI SDK v6.
+- [✔️] Streaming chat endpoint at `/api/chat` using `streamText`.
+- [✔️] Multi-step tool loop bounded by `stepCountIs(20)`.
+- [✔️] SQLite persistence through `better-sqlite3` and Drizzle ORM.
+- [✔️] Session persistence with title, selected model, token total, and messages.
+- [✔️] Basic markdown rendering for assistant messages.
+- [✔️] Tool calls rendered as UI parts instead of raw JSON.
+- [✔️] Tool approval flow using AI SDK approval response parts.
+- [✔️] Diff display for `write_file` tool output.
+- [✔️] Token counter displayed in the chat composer/header UI.
+- [✔️] Project memories with create, list, update, delete support.
+- [✔️] Workspace-local skills discovery and reading from `skills/<slug>/SKILL.md`.
+- [✔️] Read-only delegate sub-agent for bounded investigation.
+- [✔️] MCP tool loading from workspace `.mcp.json`.
+
+## Latest Implemented Work
+
+- [✔️] Added persistent workspace settings for local GitHub-backed project roots.
+- [✔️] Added GitHub App configuration helpers and installation-token flow.
+- [✔️] Added GitHub installation callback persistence.
+- [✔️] Added repository listing across connected GitHub App installations.
+- [✔️] Added project persistence for cloned GitHub repositories.
+- [✔️] Added local clone/fetch flow for GitHub repositories using installation tokens.
+- [✔️] Added project APIs for listing, creating, and fetching projects.
+- [✔️] Added workspace settings API for reading and updating local workspace root.
+- [✔️] Added session-to-project association through `projectId`.
+- [✔️] Made new chat sessions require a ready project before agent execution.
+- [✔️] Passed selected project `localPath` into the agent tool sandbox.
+- [✔️] Updated native tools to accept a per-session workspace root.
+- [✔️] Updated MCP and skills loading to use the active project workspace.
+- [✔️] Added Settings UI for workspaces, memories, and skills.
+- [✔️] Added GitHub repository clone/select UI.
+- [✔️] Added active project selection backed by local storage.
+- [✔️] Added collapsible sidebar.
+- [✔️] Added Worklog panel for tool activity, approvals, inputs, outputs, and diffs.
+
+## Phase 1: Trust Boundaries And Safety
+
+- [] Replace scattered `needsApproval` usage with a central server-side permission policy.
+- [] Classify tools and commands by risk: read-only, write, delete, network, package install, git, long-running process, and external integration.
+- [] Add per-tool and per-command approval metadata that explains exactly what will happen before execution.
+- [] Require explicit approval before starting stdio MCP servers, not only before invoking MCP tools.
+- [] Add a trust store for approved MCP server configs, commands, environment variables, and workspace roots.
+- [] Scrub shell environment by default and pass only an allowlist of required variables.
+- [] Add command policy checks for absolute paths, shell redirection outside workspace, destructive filesystem operations, network access, and secret-printing commands.
+- [] Replace the current `sudo`/`su` denylist with a parser-backed or policy-backed command classifier.
+- [] Add secret redaction for tool inputs, tool outputs, logs, and UI rendering.
+- [] Add workspace-root validation that prevents using Anton source, `.git`, dependency folders, build output, system directories, and user home as agent workspaces.
+- [] Add tests for sandbox traversal, symlink escapes, workspace root validation, and command policy behavior.
+
+## Phase 2: Real Coding-Agent Editing
+
+- [] Add a patch-based edit tool and make it the default editing primitive.
+- [] Keep `write_file` only for new small files or explicit full-file replacement.
+- [] Add atomic writes with conflict detection based on previous file hash or version.
+- [] Show proposed diffs before approval, not only after `write_file` completes.
+- [] Add file operation tools: `read_dir`, `stat`, `mkdir`, `delete`, `rename`, and `copy`.
+- [] Add guardrails for binary files, generated files, lockfiles, migrations, and large files.
+- [] Add formatting integration that follows the target repo package manager and scripts.
+- [] Add a revert-last-agent-change workflow based on git diff or tool-call history.
+- [] Add first-class git tools for `status`, `diff`, `show`, `branch`, `commit`, and `restore` with scoped approvals.
+
+## Phase 3: Durable Runs And Audit Trail
+
+- [] Add `runs` table for each `/api/chat` execution.
+- [] Add `tool_calls` table with tool name, input summary, approval decision, output summary, timestamps, exit code, and error state.
+- [] Add `approvals` table or structured approval fields tied to tool calls.
+- [] Persist Worklog from database state instead of reconstructing only from message parts.
+- [] Stop replacing entire message transcripts on every finish; append messages or use optimistic concurrency.
+- [] Add concurrency protection for two browser tabs writing the same session.
+- [] Add indexes for `messages.session_id`, `sessions.updated_at`, `sessions.project_id`, `projects.github_repo_id`, and `memories.updated_at`.
+- [] Track model, provider, usage, finish reason, step count, and abort/error status for each run.
+- [] Add database migrations for all run and tool-call persistence changes.
+
+## Phase 4: Agent Loop Quality
+
+- [] Add structured todo/planning state for multi-step coding tasks.
+- [] Add explicit handling when the model reaches the max-step limit.
+- [] Add automatic verification policy after edits: detect package manager, run relevant tests, typecheck, lint, and build when appropriate.
+- [] Add stack/repo inspection summary before the first coding action in a project.
+- [] Add context budgeting with repo map, recent diff summary, selected file summaries, and transcript pruning.
+- [] Add model selection validation on the server; reject unsupported or disabled model IDs.
+- [] Add per-run token, cost, and step budgets.
+- [] Add resumable runs after tool approval, refresh, or network interruption.
+- [] Add better system prompts for coding workflow: inspect, plan, edit, verify, summarize.
+- [] Add final response structure that reports changed files, verification, and unresolved risks.
+
+## Phase 5: GitHub And Project Workflow
+
+- [] Support importing existing local repositories without cloning from GitHub.
+- [] Support refreshing project metadata from GitHub.
+- [] Support multiple installations and account filtering in the UI.
+- [] Add project removal/archive behavior without deleting local files by default.
+- [] Add branch creation with default `codex/` prefix for agent work.
+- [] Add PR creation flow after successful local changes.
+- [] Add issue selection and branch naming from GitHub issues.
+- [] Add GitHub check/CI status display for pushed branches and PRs.
+- [] Add retry/debug workflow for failing GitHub Actions logs.
+- [] Store GitHub token expiry metadata and refresh tokens only when needed.
+
+## Phase 6: Developer Experience
+
+- [] Add file tree and file search panel for the active project.
+- [] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
+- [] Add live terminal output streaming for long-running commands.
+- [] Add cancellable background command sessions for dev servers and watchers.
+- [] Add command history with rerun support.
+- [] Add settings for default model, max steps, approval strictness, and workspace root.
+- [] Add mobile-friendly workspace and worklog controls.
+- [] Add accessible keyboard navigation for settings, sessions, worklog, approvals, and message actions.
+- [] Replace duplicate workspace/settings UI paths with one canonical Settings implementation.
+- [] Clean up layout formatting and UI polish issues that are not core behavior.
+
+## Phase 7: Testing And Evaluation
+
+- [] Add unit test framework and `pnpm test` script.
+- [] Add unit tests for sandbox, permissions, workspace local root logic, GitHub helpers, DB queries, and tool factories.
+- [] Add integration tests for `/api/chat`, approvals, sessions, projects, memories, and workspace settings.
+- [] Add Playwright tests for chat, settings, GitHub repository listing states, project selection, approvals, worklog, and diff rendering.
+- [] Add mocked GitHub API tests for installation, repository listing, token creation, clone failure, and clone success.
+- [] Add agent eval tasks: fix failing test, add small feature, refactor safely, deny dangerous command, and summarize existing code.
+- [] Add CI workflow running typecheck, lint, build, tests, and Playwright smoke tests.
+- [] Add regression tests for every bug fixed after this roadmap lands.
+
+## Phase 8: Documentation And Operating Model
+
+- [✔️] Update `README.md` to point to this roadmap and remove the old five-phase completed roadmap.
+- [✔️] Update `AGENTS.md` and `CLAUDE.md` to use `ROADMAP.md` as the source for implementation tasks and roadmap completion updates.
+- [] Document the current architecture in `docs/architecture.md`.
+- [] Add ADR for workspace/project separation and why target repos live outside Anton source.
+- [] Add ADR for permission policy and tool-risk classification.
+- [] Add ADR for GitHub App authentication and local clone strategy.
+- [] Add setup guide for GitHub App environment variables.
+- [] Add local development guide for migrations, workspaces, and test data.
+- [] Add contributor guide for turning roadmap items into GitHub issues.
+- [] Add security notes covering tool execution, workspace trust, MCP trust, and secrets handling.
+
+## Known Implementation Risks
+
+- [] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
+- [] Shell tool still runs through `bash -lc` with broad process capability and no environment allowlist.
+- [] MCP stdio server startup can execute configured commands before user approval.
+- [] Full-file `write_file` remains the main write primitive.
+- [] Message persistence still deletes and reinserts the full session transcript.
+- [] There is no durable tool-call audit table yet.
+- [] There is no automated test suite yet.
+- [] GitHub clone/fetch runs synchronously inside request handling and may exceed request duration for large repositories.
+- [] Installation tokens are injected into git through extra headers; logs and errors need explicit secret redaction guarantees.
+- [] Active project selection is client-local and not yet a durable user/workspace preference.


### PR DESCRIPTION
## Summary
- Add ROADMAP.md as the canonical backlog for shipped capabilities, implementation phases, and known risks.
- Update AGENTS.md and CLAUDE.md so agents create/identify GitHub issues from roadmap items and mark ROADMAP.md items complete when issues/PRs resolve them.
- Replace README's stale inline roadmap with a pointer to ROADMAP.md.

Closes #16

## Verification
- pnpm typecheck
- pnpm lint
