### PR TITLE
feat: centralize permission policy and improve approval UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ Run `pnpm typecheck` and `pnpm lint` before committing. If you change the schema
 
 - Treat `ROADMAP.md` as the source of truth for ongoing implementation tasks. Before starting implementation, read the relevant roadmap section and keep the work scoped to one checklist item or a small coherent group of related checklist items.
 - Before starting a new implementation, create or identify a GitHub issue that describes the requested change, scope, acceptance criteria, and verification plan. Reference that issue in the branch name, commit message, or PR body when practical.
+- If the GitHub app connector cannot create the required issue, use the GitHub CLI instead: `gh issue create --repo <owner>/<repo> --title "<title>" --body-file -`.
 - When a GitHub issue or PR completes a roadmap item, update `ROADMAP.md` in the same change by marking the item as `[✔️]`. Do not mark roadmap items complete before the related implementation is actually resolved.
 - If implementation reveals missing work, add or refine checklist items in `ROADMAP.md` rather than burying follow-up tasks in chat history.
 - For new implementation work, create a new feature branch before editing code. Use a descriptive prefix such as `codex/<short-topic>` for Codex-driven work.
@@ -111,7 +112,7 @@ Never log the API key. Never commit `.env.local`, `anton.db`, or anything under 
 - Prefer editing existing files over creating new ones; do not scaffold files "for later".
 - No default exports for components — named exports only.
 - Server-only code never imports from `components/` or `app/` client code; client components never import from `src/db/` or `src/agent/`.
-- Tool definitions are `tool({ description, inputSchema: z.object({...}), execute })`. Keep them pure; side-effects live in `execute`. Every risky tool carries `needsApproval: true` so the permission gate can intercept it.
+- Tool definitions are `tool({ description, inputSchema: z.object({...}), execute })`. Keep them pure; side-effects live in `execute`. Native tool approval metadata is applied centrally in `src/agent/permissions.ts`; MCP tool wrappers still carry `needsApproval: true`.
 - UI renders messages from `message.parts` (v6 UIMessage shape), not `message.content`. Tool calls render as collapsible cards, never as raw JSON.
 - Streaming custom data (permission requests, tool progress) uses AI SDK custom data parts through `toUIMessageStreamResponse`, not ad-hoc JSON frames.
 - Comments explain **why**, not what. Default is no comment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Follow the shared agent rules in `AGENTS.md`:
 - Run `pnpm typecheck` and `pnpm lint` before reporting a coding task as done. A green build is the acceptance criterion.
 - Before writing Next.js code, consult `node_modules/next/dist/docs/`; this project pins Next 16, which has breaking changes from older training data.
 - Before implementation, read `ROADMAP.md`, choose the relevant checklist item, create or identify the GitHub issue for the work, and keep the branch/PR tied to that issue.
+- If the GitHub app connector cannot create the required issue, use the GitHub CLI instead: `gh issue create --repo <owner>/<repo> --title "<title>" --body-file -`.
 - When a GitHub issue or PR resolves a roadmap item, update `ROADMAP.md` in the same change by marking it `[✔️]`. Do not mark items complete before the implementation is actually resolved.
 - If new follow-up work is discovered, add or refine checklist items in `ROADMAP.md` instead of leaving the follow-up only in conversation.
 - For new implementation work, create a fresh `claude/*` feature branch before editing. If the change belongs to an existing branch, update that branch from `main` first and continue there.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { convertToModelMessages } from "ai";
 import { z } from "zod";
 
 import { runAgent, type AntonUIMessage } from "@/src/agent/loop";
+import type { PermissionMode } from "@/src/agent/permissions";
 import {
   addSessionTokens,
   createSession,
@@ -21,6 +22,7 @@ const bodySchema = z.object({
   sessionId: z.string().min(1),
   projectId: z.string().min(1).nullable().optional(),
   model: z.string().min(1).optional(),
+  permissionMode: z.enum(["default", "auto-review", "full-access"]).optional(),
   messages: z.array(z.unknown()).min(1),
 });
 
@@ -75,6 +77,7 @@ export async function POST(req: Request) {
     messages: await convertToModelMessages(uiMessages),
     model,
     workspaceRoot: project.localPath,
+    permissionMode: parsed.data.permissionMode as PermissionMode | undefined,
     onFinish: ({ totalUsage }) => {
       const delta = totalUsage.totalTokens;
       if (typeof delta === "number" && delta > 0) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,6 +34,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      suppressHydrationWarning
       className={cn("dark", "h-full", "antialiased", geistSans.variable, geistMono.variable, "font-sans", inter.variable)}
     >
       <body className="h-full w-full overflow-hidden flex flex-col font-sans">

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 
 import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
+import type { PermissionMode } from "@/src/agent/permissions";
 import type { AntonUIMessage } from "@/src/agent/loop";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -59,6 +60,7 @@ export function Chat({
   const [model, setModel] = useState<ModelId>(
     (initialModel ?? DEFAULT_MODEL_ID) as ModelId,
   );
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>("auto-review");
   const effectiveProjectId = initialProjectId ?? activeProjectId;
 
   const transport = useMemo(
@@ -67,11 +69,9 @@ export function Chat({
         api: "/api/chat",
         body: () => ({
           sessionId,
-          model,
-          ...(effectiveProjectId ? { projectId: effectiveProjectId } : {}),
         }),
       }),
-    [sessionId, model, effectiveProjectId],
+    [sessionId],
   );
 
   const {
@@ -211,7 +211,10 @@ export function Chat({
           <Composer
             onSend={(text) => {
               if (!effectiveProjectId) return;
-              sendMessage({ text });
+              void sendMessage(
+                { text },
+                { body: { projectId: effectiveProjectId, model, permissionMode } },
+              );
             }}
             onStop={stop}
             disabled={streaming || !effectiveProjectId}
@@ -220,6 +223,8 @@ export function Chat({
             onModelChange={setModel}
             tokens={tokensTotal}
             project={project}
+            permissionMode={permissionMode}
+            onPermissionModeChange={setPermissionMode}
           />
         </section>
 

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -8,12 +8,23 @@ import {
   Monitor,
   Plus,
   ShieldCheck,
+  ShieldOff,
+  ShieldQuestion,
   Square,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
 import type { ModelId } from "@/src/lib/models";
+import type { PermissionMode } from "@/src/agent/permissions";
 import type { ProjectSummary } from "./workspace-dialog";
 import { ModelPicker } from "./model-picker";
 
@@ -26,6 +37,8 @@ interface ComposerProps {
   onModelChange: (model: ModelId) => void;
   tokens: number;
   project: ProjectSummary | null;
+  permissionMode: PermissionMode;
+  onPermissionModeChange: (mode: PermissionMode) => void;
 }
 
 const MIN_HEIGHT = 24;
@@ -40,6 +53,8 @@ export function Composer({
   onModelChange,
   tokens,
   project,
+  permissionMode,
+  onPermissionModeChange,
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -99,14 +114,10 @@ export function Composer({
               >
                 <Plus />
               </Button>
-              <button
-                type="button"
-                className="inline-flex h-5 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-primary hover:bg-primary/10"
-              >
-                <ShieldCheck className="size-3" />
-                Full access
-                <ChevronDown className="size-3" />
-              </button>
+              <PermissionsDropdown
+                value={permissionMode}
+                onChange={onPermissionModeChange}
+              />
             </div>
 
             <div className="flex min-w-0 items-center gap-1.5">
@@ -166,6 +177,44 @@ export function Composer({
         </div>
       </div>
     </form>
+  );
+}
+
+const PERMISSION_MODE_ITEMS = [
+  { value: "default", label: "Ask every time", Icon: ShieldQuestion },
+  { value: "auto-review", label: "Auto-review", Icon: ShieldCheck },
+  { value: "full-access", label: "Full access", Icon: ShieldOff },
+] as const satisfies readonly {
+  value: PermissionMode;
+  label: string;
+  Icon: typeof ShieldCheck;
+}[];
+
+function PermissionsDropdown({
+  value,
+  onChange,
+}: {
+  value: PermissionMode;
+  onChange: (mode: PermissionMode) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as PermissionMode)}>
+      <SelectTrigger className="h-5 gap-1 border-0 bg-transparent px-1.5 text-[11px] font-medium text-primary hover:bg-primary/10">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectViewport>
+          {PERMISSION_MODE_ITEMS.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              <span className="inline-flex items-center gap-1.5">
+                <item.Icon className="size-3.5" />
+                {item.label}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectViewport>
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -8,15 +8,16 @@ import {
 } from "ai";
 import {
   Check,
+  CheckCircle2,
   Copy,
   ChevronDown,
   ChevronRight,
   Loader2,
   TerminalSquare,
+  XCircle,
 } from "lucide-react";
 
 import type { AntonUIMessage } from "@/src/agent/loop";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
 
@@ -50,7 +51,7 @@ export function MessageList({ messages, status, onApproval }: MessageListProps) 
       ref={scrollRef}
       className="flex-1 overflow-y-auto px-3 py-3 sm:px-4 lg:px-6"
     >
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 pb-8">
         {messages.map((message) => (
           <MessageEvent
             key={message.id}
@@ -58,7 +59,7 @@ export function MessageList({ messages, status, onApproval }: MessageListProps) 
             onApproval={onApproval}
           />
         ))}
-        {status === "submitted" && (
+        {status !== "ready" && status !== "error" && (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 className="size-3.5 animate-spin text-sky-400" />
             Anton is thinking
@@ -163,6 +164,7 @@ function InlineToolEvent({
   approvalId: string | undefined;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
+  const needsApproval = state === "approval-requested" && approvalId;
   return (
     <details className="group/tool my-1 text-xs text-muted-foreground">
       <summary
@@ -171,35 +173,57 @@ function InlineToolEvent({
           "transition-colors hover:bg-card/40 [&::-webkit-details-marker]:hidden",
         )}
         aria-label={`${name} tool details`}
+        onClick={(e) => {
+          if (needsApproval) {
+            const target = e.target as HTMLElement;
+            if (target.closest("[data-approval-action]")) {
+              e.preventDefault();
+            }
+          }
+        }}
       >
         <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
         <span className="truncate">{name}</span>
-        <ChevronRight className="size-3 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:hidden" />
-        <ChevronDown className="hidden size-3 shrink-0 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:block group-open/tool:opacity-100" />
+        <span className="ml-auto shrink-0">
+          {needsApproval ? (
+            <span className="inline-flex items-center gap-0.5">
+              <button
+                type="button"
+                data-approval-action="approve"
+                className="inline-flex items-center justify-center size-5 rounded hover:bg-emerald-500/15"
+                title="Approve"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApproval({ id: approvalId, approved: true });
+                }}
+              >
+                <CheckCircle2 className="size-3.5 text-emerald-400" />
+              </button>
+              <button
+                type="button"
+                data-approval-action="deny"
+                className="inline-flex items-center justify-center size-5 rounded hover:bg-destructive/15"
+                title="Deny"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApproval({ id: approvalId, approved: false });
+                }}
+              >
+                <XCircle className="size-3.5 text-destructive" />
+              </button>
+            </span>
+          ) : (
+            <>
+              <ChevronRight className="size-3 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:hidden" />
+              <ChevronDown className="hidden size-3 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:block group-open/tool:opacity-100" />
+            </>
+          )}
+        </span>
       </summary>
       <div className="ml-5 mt-1 rounded-md bg-card/50 px-2.5 py-2 ring-1 ring-border/70">
         <p className="truncate font-mono text-[11px]">
           {previewInput(input)}
         </p>
-        {state === "approval-requested" && approvalId && (
-          <div className="mt-2 flex items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => onApproval({ id: approvalId, approved: true })}
-            >
-              Approve
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="destructive"
-              onClick={() => onApproval({ id: approvalId, approved: false })}
-            >
-              Deny
-            </Button>
-          </div>
-        )}
         {state === "output-error" && errorText && (
           <p className="mt-1 line-clamp-2 text-destructive">{errorText}</p>
         )}

--- a/components/chat/worklog.tsx
+++ b/components/chat/worklog.tsx
@@ -206,26 +206,27 @@ function WorklogDetail({
           </h2>
         </div>
         {entry.state === "approval-requested" && entry.approvalId && (
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
+          <div className="flex shrink-0 items-center gap-0.5">
+            <button
               type="button"
-              size="sm"
+              className="inline-flex items-center justify-center size-6 rounded hover:bg-emerald-500/15"
+              title="Approve"
               onClick={() =>
                 onApproval({ id: entry.approvalId as string, approved: true })
               }
             >
-              Approve
-            </Button>
-            <Button
+              <CheckCircle2 className="size-4 text-emerald-400" />
+            </button>
+            <button
               type="button"
-              size="sm"
-              variant="destructive"
+              className="inline-flex items-center justify-center size-6 rounded hover:bg-destructive/15"
+              title="Deny"
               onClick={() =>
                 onApproval({ id: entry.approvalId as string, approved: false })
               }
             >
-              Deny
-            </Button>
+              <XCircle className="size-4 text-destructive" />
+            </button>
           </div>
         )}
       </div>

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -17,6 +17,7 @@ import {
   workspaceRelative,
   workspaceRelativeTo,
 } from "./sandbox";
+import type { PermissionMode } from "./permissions";
 
 const MAX_STEPS = 20;
 
@@ -132,11 +133,13 @@ export async function runAgent({
   messages,
   model,
   workspaceRoot,
+  permissionMode,
   onFinish,
 }: {
   messages: ModelMessage[];
   model?: string;
   workspaceRoot?: string;
+  permissionMode?: PermissionMode;
   onFinish?: (result: { totalUsage: LanguageModelUsage }) => void;
 }) {
   const mcpTools = await loadMcpTools(workspaceRoot);
@@ -157,6 +160,7 @@ export async function runAgent({
       model: selectedModel,
       mcpTools: mcpTools.tools,
       workspaceRoot,
+      permissionMode,
     }),
     stopWhen: stepCountIs(MAX_STEPS),
     onFinish: async ({ totalUsage }) => {

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -1,14 +1,21 @@
+import type { ToolSet } from "ai";
+
 // Permission gate helpers for tool execution.
 //
-// "safe" tools (`read_file`, `grep`, `glob`) run automatically. "risky" tools
-// (`write_file`, `bash`) are tagged with `needsApproval: true` on the tool
-// definition itself, which causes `streamText` to emit a
-// `tool-approval-request` part; the client UI then approves or denies via
-// `addToolApprovalResponse` and the harness resumes the loop.
+// Permission modes:
+// - "default": all native tools require user approval (most conservative).
+// - "auto-review": safe tools auto-run, risky tools require approval (default).
+// - "full-access": no native tools require approval.
+//
+// `needsApproval: true` causes `streamText` to emit a `tool-approval-request`
+// part; the client UI then approves or denies via `addToolApprovalResponse`
+// and the harness resumes the loop.
 
 export type RiskLevel = "safe" | "risky";
 
-export const RISK_LEVELS: Record<string, RiskLevel> = {
+export type PermissionMode = "default" | "auto-review" | "full-access";
+
+export const NATIVE_TOOL_RISK_LEVELS = {
   read_file: "safe",
   grep: "safe",
   glob: "safe",
@@ -21,7 +28,58 @@ export const RISK_LEVELS: Record<string, RiskLevel> = {
   list_skills: "safe",
   read_skill: "safe",
   delegate_task: "safe",
+} as const satisfies Record<string, RiskLevel>;
+
+export const RISK_LEVELS: Record<string, RiskLevel> = NATIVE_TOOL_RISK_LEVELS;
+
+type ToolWithApproval = ToolSet[string] & {
+  needsApproval?: boolean;
 };
+
+export function applyNativeToolPermissionPolicy<TTools extends ToolSet>(
+  tools: TTools,
+  mode: PermissionMode = "auto-review",
+): TTools {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, toolValue]) => {
+      const risk = RISK_LEVELS[name];
+      if (!risk) {
+        throw new Error(`missing native tool permission policy: ${name}`);
+      }
+
+      const toolWithoutApproval: ToolWithApproval = {
+        ...(toolValue as ToolWithApproval),
+      };
+      delete toolWithoutApproval.needsApproval;
+
+      if (mode === "full-access") {
+        return [name, toolWithoutApproval];
+      }
+
+      if (mode === "default") {
+        return [name, { ...toolWithoutApproval, needsApproval: true }];
+      }
+
+      if (risk === "risky") {
+        return [name, { ...toolWithoutApproval, needsApproval: true }];
+      }
+
+      return [name, toolWithoutApproval];
+    }),
+  ) as TTools;
+}
+
+export function stripApprovalFlags<TTools extends ToolSet>(
+  tools: TTools,
+): TTools {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, toolValue]) => {
+      const stripped: ToolWithApproval = { ...(toolValue as ToolWithApproval) };
+      delete stripped.needsApproval;
+      return [name, stripped];
+    }),
+  ) as TTools;
+}
 
 // Commands we refuse to execute in `bash` even after approval — the user
 // should never be able to approve these by accident.

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -24,7 +24,6 @@ export function createBashTool(workspaceRoot?: string) {
         `Maximum time to wait before the command is killed. Defaults to ${DEFAULT_TIMEOUT_MS}ms, capped at ${MAX_TIMEOUT_MS}ms.`,
       ),
   }),
-  needsApproval: true,
   execute: async ({ command, timeoutMs }) => {
     const forbidden = isForbiddenBashCommand(command);
     if (forbidden) {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -1,4 +1,9 @@
 import type { ToolSet } from "ai";
+import {
+  applyNativeToolPermissionPolicy,
+  stripApprovalFlags,
+  type PermissionMode,
+} from "../permissions";
 import { createReadFileTool, readFileTool } from "./read-file";
 import { createWriteFileTool, writeFileTool } from "./write-file";
 import { bashTool, createBashTool } from "./bash";
@@ -18,7 +23,7 @@ import {
 } from "./skills";
 import { createDelegateTaskTool } from "./delegate";
 
-export const nativeAntonTools = {
+export const nativeAntonTools = applyNativeToolPermissionPolicy({
   read_file: readFileTool,
   write_file: writeFileTool,
   bash: bashTool,
@@ -30,18 +35,20 @@ export const nativeAntonTools = {
   forget_memory: forgetMemoryTool,
   list_skills: listSkillsTool,
   read_skill: readSkillTool,
-} as const;
+} as const);
 
 export function createAntonTools({
   model,
   mcpTools,
   workspaceRoot,
+  permissionMode,
 }: {
   model?: string;
   mcpTools?: ToolSet;
   workspaceRoot?: string;
+  permissionMode?: PermissionMode;
 }) {
-  return {
+  const nativeTools = applyNativeToolPermissionPolicy({
     ...nativeAntonTools,
     read_file: createReadFileTool(workspaceRoot),
     write_file: createWriteFileTool(workspaceRoot),
@@ -51,7 +58,13 @@ export function createAntonTools({
     list_skills: createListSkillsTool(workspaceRoot),
     read_skill: createReadSkillTool(workspaceRoot),
     delegate_task: createDelegateTaskTool({ model, workspaceRoot }),
-    ...(mcpTools ?? {}),
+  }, permissionMode);
+
+  return {
+    ...nativeTools,
+    ...(permissionMode === "full-access" && mcpTools
+      ? stripApprovalFlags(mcpTools)
+      : (mcpTools ?? {})),
   };
 }
 

--- a/src/agent/tools/memory.ts
+++ b/src/agent/tools/memory.ts
@@ -47,7 +47,6 @@ export const rememberTool = tool({
       .max(MAX_MEMORY_CHARS)
       .describe("A concise memory to preserve across sessions."),
   }),
-  needsApproval: true,
   execute: async ({ content }) => {
     try {
       return {
@@ -66,7 +65,6 @@ export const forgetMemoryTool = tool({
   inputSchema: z.object({
     id: z.string().min(1).describe("The memory ID to delete."),
   }),
-  needsApproval: true,
   execute: async ({ id }) => {
     try {
       const deleted = deleteMemory(id);
@@ -92,7 +90,6 @@ export const updateMemoryTool = tool({
       .max(MAX_MEMORY_CHARS)
       .describe("Replacement memory content."),
   }),
-  needsApproval: true,
   execute: async ({ id, content }) => {
     try {
       const memory = updateMemory(id, content);

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -16,7 +16,6 @@ export function createWriteFileTool(workspaceRoot?: string) {
     path: z.string().describe("File path relative to the workspace root."),
     content: z.string().describe("Full file contents to write."),
   }),
-  needsApproval: true,
   execute: async ({ path: relPath, content }) => {
     try {
       if (Buffer.byteLength(content, "utf8") > MAX_BYTES) {


### PR DESCRIPTION
## Summary
- Centralizes native tool approval policy into `src/agent/permissions.ts` via `applyNativeToolPermissionPolicy()` with 3 user-selectable permission modes
- Moves approve/deny actions from accordion interiors to inline icons next to tool names
- Fixes layout shift during tool approval transitions

## Changes

### Central permission policy (core issue #18)
- Removed scattered `needsApproval` from `bash.ts`, `write-file.ts`, `memory.ts`
- `applyNativeToolPermissionPolicy(tools, mode)` applies approval centrally based on `NATIVE_TOOL_RISK_LEVELS` and permission mode
- Three modes: `default` (ask for everything), `auto-review` (safe auto-run, risky ask), `full-access` (no approvals)
- MCP tools stripped of `needsApproval` in full-access mode; otherwise unaffected
- Threaded `permissionMode` from client → `/api/chat` → `runAgent` → `createAntonTools`

### Approval UX improvements
- **Inline icons**: `CheckCircle2` (green) and `XCircle` (red) appear next to tool names in message list and worklog -- no accordion expansion needed
- **Permission dropdown**: Replaced static "Full access" badge in Composer with a functional Select dropdown
- **Layout fix**: Thinking indicator persists through `streaming` state (not just `submitted`), with `pb-8` padding to prevent jumps
- **Hydration fix**: Added `suppressHydrationWarning` to root `<html>` to silence extension-injected attributes

### Verification
- `pnpm typecheck` → clean
- `pnpm lint` → clean
- `rg needsApproval src/agent` → only in `permissions.ts` (policy) and `mcp.ts` (MCP wrapper)

Closes #18
