### PR TITLE
Add reasoning and activity trace UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Anton Roadmap
 
-Last reviewed: 2026-05-02
+Last reviewed: 2026-05-03
 
 This roadmap is the working backlog for turning Anton from a learning harness into a reliable local AI coding agent. Use each checklist item as the source for future GitHub issues. Mark finished items as `[✔️]` after the related GitHub issue or PR is resolved.
 
@@ -43,6 +43,10 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Added active project selection backed by local storage.
 - [✔️] Added collapsible sidebar.
 - [✔️] Added Worklog panel for tool activity, approvals, inputs, outputs, and diffs.
+- [✔️] Added persistent run metadata and ordered run events for `/api/chat` executions.
+- [✔️] Added Devin/Codex-style inline reasoning and activity traces above assistant responses.
+- [✔️] Added provider reasoning streaming support while filtering trace data out of model replay.
+- [✔️] Updated Worklog and inline traces to share normalized trace helpers for consistent tool, approval, and timing UI.
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -72,15 +76,17 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 ## Phase 3: Durable Runs And Audit Trail
 
-- [] Add `runs` table for each `/api/chat` execution.
+- [✔️] Add `runs` table for each `/api/chat` execution.
+- [✔️] Add durable `run_events` for ordered reasoning, tool, approval, progress, and error trace rows.
 - [] Add `tool_calls` table with tool name, input summary, approval decision, output summary, timestamps, exit code, and error state.
 - [] Add `approvals` table or structured approval fields tied to tool calls.
-- [] Persist Worklog from database state instead of reconstructing only from message parts.
+- [] Persist Worklog from database state instead of reconstructing from message parts and trace data.
 - [] Stop replacing entire message transcripts on every finish; append messages or use optimistic concurrency.
 - [] Add concurrency protection for two browser tabs writing the same session.
 - [] Add indexes for `messages.session_id`, `sessions.updated_at`, `sessions.project_id`, `projects.github_repo_id`, and `memories.updated_at`.
-- [] Track model, provider, usage, finish reason, step count, and abort/error status for each run.
-- [] Add database migrations for all run and tool-call persistence changes.
+- [✔️] Track model, usage, finish reason, and abort/error status for each run.
+- [✔️] Add database migrations for run and run-event persistence changes.
+- [] Track provider, step count, and cost metadata for each run.
 
 ## Phase 4: Agent Loop Quality
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,10 +1,21 @@
-import { convertToModelMessages } from "ai";
+import {
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  type FinishReason,
+  type LanguageModelUsage,
+  type TextStreamPart,
+  type ToolSet,
+  type UIMessageStreamWriter,
+} from "ai";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
-import { runAgent, type AntonUIMessage } from "@/src/agent/loop";
+import { runAgent } from "@/src/agent/loop";
 import type { PermissionMode } from "@/src/agent/permissions";
 import {
   addSessionTokens,
+  createRun,
   createSession,
   deriveTitleFromMessages,
   getProject,
@@ -12,8 +23,19 @@ import {
   replaceMessages,
   setSessionProject,
   touchSession,
+  updateRun,
+  upsertRunEvent,
 } from "@/src/db/queries";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
+import type {
+  AntonActivityEvent,
+  AntonActivityKind,
+  AntonActivityStatus,
+  AntonMessageMetadata,
+  AntonRunData,
+  AntonRunStatus,
+  AntonUIMessage,
+} from "@/src/lib/trace";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
@@ -73,24 +95,376 @@ export async function POST(req: Request) {
     }
   }
 
-  const result = await runAgent({
-    messages: await convertToModelMessages(uiMessages),
-    model,
-    workspaceRoot: project.localPath,
-    permissionMode: parsed.data.permissionMode as PermissionMode | undefined,
-    onFinish: ({ totalUsage }) => {
-      const delta = totalUsage.totalTokens;
-      if (typeof delta === "number" && delta > 0) {
-        addSessionTokens(sessionId, delta);
-      }
+  const modelMessages = await convertToModelMessages(
+    prepareMessagesForModel(uiMessages),
+    {
+      convertDataPart: () => undefined,
     },
+  );
+
+  const runId = randomUUID();
+  const startedAt = Date.now();
+  createRun({
+    id: runId,
+    sessionId,
+    model,
+    status: "running",
+    startedAt: new Date(startedAt),
   });
 
-  return result.toUIMessageStreamResponse<AntonUIMessage>({
+  const stream = createUIMessageStream<AntonUIMessage>({
     originalMessages: uiMessages,
+    execute: async ({ writer }) => {
+      const trace = createTraceWriter({
+        writer,
+        runId,
+        model,
+        startedAt,
+      });
+      trace.writeRun("running");
+
+      try {
+        const result = await runAgent({
+          messages: modelMessages,
+          model,
+          workspaceRoot: project.localPath,
+          permissionMode: parsed.data.permissionMode as
+            | PermissionMode
+            | undefined,
+          onStepStart: ({ stepNumber }) => trace.startStep(stepNumber),
+          onStepFinish: ({ stepNumber }) => trace.finishStep(stepNumber),
+          onToolCallStart: (event) => trace.startTool(event),
+          onToolCallFinish: (event) => trace.finishTool(event),
+          onStreamPart: (part) => trace.handleStreamPart(part),
+          onAbort: () => trace.finalize("aborted"),
+          onError: (error) => trace.fail(error),
+          onFinish: ({ totalUsage, finishReason }) => {
+            trace.finalize("completed", totalUsage, finishReason);
+            const delta = totalUsage.totalTokens;
+            if (typeof delta === "number" && delta > 0) {
+              addSessionTokens(sessionId, delta);
+            }
+          },
+        });
+
+        writer.merge(
+          result.toUIMessageStream<AntonUIMessage>({
+            sendReasoning: true,
+            sendStart: false,
+            sendFinish: false,
+          }),
+        );
+      } catch (err) {
+        trace.fail(err);
+        throw err;
+      }
+    },
     onFinish: ({ messages, isAborted }) => {
       if (isAborted) return;
       replaceMessages<AntonUIMessage>(sessionId, messages);
     },
   });
+
+  return createUIMessageStreamResponse({ stream });
+}
+
+function prepareMessagesForModel(messages: AntonUIMessage[]): AntonUIMessage[] {
+  return messages.flatMap((message) => {
+    const parts = message.parts
+      .filter(isModelContextPart)
+      .map(stripProviderReplayMetadata);
+    if (!parts.some(isSubstantiveModelContextPart)) return [];
+    return [{ ...message, parts }];
+  });
+}
+
+function isModelContextPart(
+  part: AntonUIMessage["parts"][number],
+): boolean {
+  if (part.type === "reasoning") return false;
+  return !part.type.startsWith("data-");
+}
+
+function isSubstantiveModelContextPart(
+  part: AntonUIMessage["parts"][number],
+): boolean {
+  return part.type !== "step-start";
+}
+
+function stripProviderReplayMetadata(
+  part: AntonUIMessage["parts"][number],
+): AntonUIMessage["parts"][number] {
+  const clone = { ...part } as Record<string, unknown>;
+  delete clone.providerMetadata;
+  delete clone.callProviderMetadata;
+  delete clone.resultProviderMetadata;
+  return clone as AntonUIMessage["parts"][number];
+}
+
+function createTraceWriter({
+  writer,
+  runId,
+  model,
+  startedAt,
+}: {
+  writer: UIMessageStreamWriter<AntonUIMessage>;
+  runId: string;
+  model: string;
+  startedAt: number;
+}) {
+  let sequence = 0;
+  let finalized = false;
+  const events = new Map<string, AntonActivityEvent>();
+
+  const metadata = (
+    status: AntonRunStatus,
+    extra: Partial<AntonMessageMetadata> = {},
+  ): AntonMessageMetadata => ({
+    runId,
+    model,
+    status,
+    startedAt,
+    ...extra,
+  });
+
+  const writeMetadata = (
+    status: AntonRunStatus,
+    extra: Partial<AntonMessageMetadata> = {},
+  ) => {
+    writer.write({
+      type: "message-metadata",
+      messageMetadata: metadata(status, extra),
+    });
+  };
+
+  const writeRun = (
+    status: AntonRunStatus,
+    extra: Partial<Omit<AntonRunData, "runId" | "model" | "status" | "startedAt">> = {},
+  ) => {
+    const data: AntonRunData = {
+      runId,
+      model,
+      status,
+      startedAt,
+      ...extra,
+    };
+    writeMetadata(status, extra);
+    writer.write({ type: "data-run", id: runId, data });
+  };
+
+  const persistEvent = (event: AntonActivityEvent) => {
+    upsertRunEvent({
+      id: event.id,
+      runId: event.runId,
+      sequence: event.sequence,
+      kind: event.kind,
+      status: event.status,
+      label: event.label,
+      summary: event.summary ?? null,
+      startedAt: new Date(event.startedAt),
+      finishedAt: event.finishedAt ? new Date(event.finishedAt) : null,
+      durationMs: event.durationMs ?? null,
+      toolCallId: event.toolCallId ?? null,
+      details: event.details ?? null,
+    });
+  };
+
+  const writeEvent = (event: AntonActivityEvent) => {
+    events.set(event.id, event);
+    persistEvent(event);
+    writer.write({ type: "data-activity", id: event.id, data: event });
+  };
+
+  const startEvent = ({
+    id,
+    kind,
+    label,
+    summary,
+    status = "running",
+    toolCallId,
+    details,
+  }: {
+    id: string;
+    kind: AntonActivityKind;
+    label: string;
+    summary?: string;
+    status?: AntonActivityStatus;
+    toolCallId?: string;
+    details?: Record<string, unknown>;
+  }) => {
+    const event: AntonActivityEvent = {
+      id,
+      runId,
+      sequence: ++sequence,
+      kind,
+      status,
+      label,
+      summary,
+      startedAt: Date.now(),
+      toolCallId,
+      details,
+    };
+    writeEvent(event);
+    return event;
+  };
+
+  const finishEvent = (
+    id: string,
+    patch: Partial<
+      Pick<
+        AntonActivityEvent,
+        "status" | "label" | "summary" | "details" | "toolCallId"
+      >
+    > = {},
+  ) => {
+    const current = events.get(id);
+    if (!current) return;
+    const finishedAt = Date.now();
+    writeEvent({
+      ...current,
+      ...patch,
+      finishedAt,
+      durationMs: Math.max(0, finishedAt - current.startedAt),
+    });
+  };
+
+  const settleRunningEvents = (status: "completed" | "error") => {
+    for (const event of Array.from(events.values())) {
+      if (event.status !== "running") continue;
+      finishEvent(event.id, { status });
+    }
+  };
+
+  const summarizeInput = (input: unknown): string | undefined => {
+    if (typeof input !== "object" || input === null) return undefined;
+    const record = input as Record<string, unknown>;
+    for (const key of ["command", "path", "pattern", "slug", "task"]) {
+      if (typeof record[key] === "string") return record[key];
+    }
+    return undefined;
+  };
+
+  const toolLabel = (name: string, input: unknown): string => {
+    const summary = summarizeInput(input);
+    if (name === "bash" && summary) return `Ran ${summary}`;
+    if (name === "read_file" && summary) return `Read ${summary}`;
+    if (name === "grep" && summary) return `Searched for ${summary}`;
+    if (name === "glob" && summary) return `Listed ${summary}`;
+    if (name === "write_file" && summary) return `Edited ${summary}`;
+    return name;
+  };
+
+  const finalize = (
+    status: Exclude<AntonRunStatus, "running">,
+    usage?: LanguageModelUsage,
+    finishReason?: FinishReason,
+  ) => {
+    if (finalized) return;
+    finalized = true;
+    settleRunningEvents(status === "completed" ? "completed" : "error");
+    const finishedAt = Date.now();
+    const durationMs = Math.max(0, finishedAt - startedAt);
+    const totalTokens = usage?.totalTokens;
+    writeRun(status, { finishedAt, durationMs, totalTokens });
+    updateRun(runId, {
+      status,
+      finishedAt: new Date(finishedAt),
+      durationMs,
+      totalTokens: totalTokens ?? null,
+      finishReason: finishReason ?? null,
+    });
+  };
+
+  return {
+    writeRun,
+    startStep(stepNumber: number) {
+      startEvent({
+        id: `${runId}:step:${stepNumber}`,
+        kind: "step",
+        label: `Step ${stepNumber + 1}`,
+      });
+    },
+    finishStep(stepNumber: number) {
+      finishEvent(`${runId}:step:${stepNumber}`, {
+        status: "completed",
+        label: `Step ${stepNumber + 1} completed`,
+      });
+    },
+    startTool(event: {
+      stepNumber: number | undefined;
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+    }) {
+      startEvent({
+        id: `${runId}:tool:${event.toolCallId}`,
+        kind: "tool",
+        label: toolLabel(event.toolName, event.input),
+        summary: summarizeInput(event.input),
+        toolCallId: event.toolCallId,
+        details: { toolName: event.toolName, stepNumber: event.stepNumber },
+      });
+    },
+    finishTool(event: {
+      stepNumber: number | undefined;
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      success: boolean;
+      durationMs: number;
+      output?: unknown;
+      error?: unknown;
+    }) {
+      finishEvent(`${runId}:tool:${event.toolCallId}`, {
+        status: event.success ? "completed" : "error",
+        label: toolLabel(event.toolName, event.input),
+        summary: summarizeInput(event.input),
+        details: {
+          toolName: event.toolName,
+          stepNumber: event.stepNumber,
+          success: event.success,
+        },
+      });
+    },
+    handleStreamPart(part: TextStreamPart<ToolSet>) {
+      if (part.type === "reasoning-start") {
+        startEvent({
+          id: `${runId}:reasoning:${part.id}`,
+          kind: "reasoning",
+          label: "Thinking",
+        });
+      }
+      if (part.type === "reasoning-end") {
+        finishEvent(`${runId}:reasoning:${part.id}`, {
+          status: "completed",
+          label: "Thought",
+        });
+      }
+      if (part.type === "error") {
+        startEvent({
+          id: `${runId}:error:${sequence + 1}`,
+          kind: "error",
+          status: "error",
+          label: "Stream error",
+          summary: errorMessage(part.error),
+        });
+      }
+    },
+    fail(error: unknown) {
+      startEvent({
+        id: `${runId}:error:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Run failed",
+        summary: errorMessage(error),
+      });
+      finalize("error");
+    },
+    finalize,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -6,7 +6,7 @@ import {
   loadMessages,
   renameSession,
 } from "@/src/db/queries";
-import type { AntonUIMessage } from "@/src/agent/loop";
+import type { AntonUIMessage } from "@/src/lib/trace";
 
 export const runtime = "nodejs";
 

--- a/app/s/[sessionId]/page.tsx
+++ b/app/s/[sessionId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 
 import { Chat } from "@/components/chat/chat";
 import { getSession, loadMessages } from "@/src/db/queries";
-import type { AntonUIMessage } from "@/src/agent/loop";
+import type { AntonUIMessage } from "@/src/lib/trace";
 import type { ModelId } from "@/src/lib/models";
 
 export const dynamic = "force-dynamic";

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -14,7 +14,7 @@ import {
 
 import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
 import type { PermissionMode } from "@/src/agent/permissions";
-import type { AntonUIMessage } from "@/src/agent/loop";
+import type { AntonUIMessage } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MessageList } from "./message-list";

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -1,25 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  getToolName,
-  isToolUIPart,
-  type ChatAddToolApproveResponseFunction,
-} from "ai";
-import {
-  Check,
-  CheckCircle2,
-  Copy,
-  ChevronDown,
-  ChevronRight,
-  Loader2,
-  TerminalSquare,
-  XCircle,
-} from "lucide-react";
+import type { ChatAddToolApproveResponseFunction } from "ai";
+import { Check, Copy } from "lucide-react";
 
-import type { AntonUIMessage } from "@/src/agent/loop";
+import {
+  getToolTraceEntries,
+  type AntonUIMessage,
+} from "@/src/lib/trace";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
+import { RunTraceAccordion } from "./run-trace";
 
 interface MessageListProps {
   messages: AntonUIMessage[];
@@ -56,15 +47,10 @@ export function MessageList({ messages, status, onApproval }: MessageListProps) 
           <MessageEvent
             key={message.id}
             message={message}
+            status={status}
             onApproval={onApproval}
           />
         ))}
-        {status !== "ready" && status !== "error" && (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="size-3.5 animate-spin text-sky-400" />
-            Anton is thinking
-          </div>
-        )}
       </div>
     </div>
   );
@@ -72,9 +58,11 @@ export function MessageList({ messages, status, onApproval }: MessageListProps) 
 
 function MessageEvent({
   message,
+  status,
   onApproval,
 }: {
   message: AntonUIMessage;
+  status: "submitted" | "streaming" | "ready" | "error";
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
   const isUser = message.role === "user";
@@ -83,11 +71,15 @@ function MessageEvent({
     .map((p) => (p as { text: string }).text)
     .join("\n\n")
     .trim();
+  const fallbackText = !isUser && plainText.length === 0
+    ? toolResultFallbackText(message)
+    : "";
+  const finalText = plainText || fallbackText;
 
   return (
     <div
       className={cn(
-          "group/msg flex flex-col gap-1",
+        "group/msg flex flex-col gap-1",
         isUser ? "items-end" : "items-start",
       )}
     >
@@ -99,142 +91,61 @@ function MessageEvent({
             : "w-full text-foreground",
         )}
       >
+        {!isUser && (
+          <RunTraceAccordion
+            message={message}
+            status={status}
+            onApproval={onApproval}
+          />
+        )}
         {message.parts.map((part, i) => {
-          if (part.type === "text") {
-            if (isUser) {
-              return (
-                <div key={i} className="whitespace-pre-wrap leading-normal">
-                  {part.text}
-                </div>
-              );
-            }
-            return <Markdown key={i} className="text-xs">{part.text}</Markdown>;
-          }
-          if (isToolUIPart(part)) {
+          if (part.type !== "text") return null;
+          if (isUser) {
             return (
-              <InlineToolEvent
-                key={i}
-                name={String(getToolName(part))}
-                state={part.state as ToolState}
-                input={"input" in part ? part.input : undefined}
-                output={"output" in part ? part.output : undefined}
-                errorText={"errorText" in part ? part.errorText : undefined}
-                approvalId={
-                  part.state === "approval-requested"
-                    ? part.approval.id
-                    : undefined
-                }
-                onApproval={onApproval}
-              />
+              <div key={i} className="whitespace-pre-wrap leading-normal">
+                {part.text}
+              </div>
             );
           }
-          return null;
+          return <Markdown key={i} className="text-xs">{part.text}</Markdown>;
         })}
+        {!isUser && plainText.length === 0 && fallbackText.length > 0 && (
+          <Markdown className="text-xs">{fallbackText}</Markdown>
+        )}
       </div>
-      {!isUser && plainText.length > 0 && (
-        <CopyMessageButton text={plainText} />
+      {!isUser && finalText.length > 0 && (
+        <CopyMessageButton text={finalText} />
       )}
     </div>
   );
 }
 
-type ToolState =
-  | "input-streaming"
-  | "input-available"
-  | "approval-requested"
-  | "approval-responded"
-  | "output-available"
-  | "output-error"
-  | "output-denied";
-
-function InlineToolEvent({
-  name,
-  state,
-  input,
-  output,
-  errorText,
-  approvalId,
-  onApproval,
-}: {
-  name: string;
-  state: ToolState;
-  input: unknown;
-  output: unknown;
-  errorText: string | undefined;
-  approvalId: string | undefined;
-  onApproval: ChatAddToolApproveResponseFunction;
-}) {
-  const needsApproval = state === "approval-requested" && approvalId;
-  return (
-    <details className="group/tool my-1 text-xs text-muted-foreground">
-      <summary
-        className={cn(
-          "inline-flex max-w-full cursor-pointer list-none items-center gap-1.5 rounded px-1 py-0.5 font-mono text-[11px] text-foreground select-none",
-          "transition-colors hover:bg-card/40 [&::-webkit-details-marker]:hidden",
-        )}
-        aria-label={`${name} tool details`}
-        onClick={(e) => {
-          if (needsApproval) {
-            const target = e.target as HTMLElement;
-            if (target.closest("[data-approval-action]")) {
-              e.preventDefault();
-            }
-          }
-        }}
-      >
-        <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="truncate">{name}</span>
-        <span className="ml-auto shrink-0">
-          {needsApproval ? (
-            <span className="inline-flex items-center gap-0.5">
-              <button
-                type="button"
-                data-approval-action="approve"
-                className="inline-flex items-center justify-center size-5 rounded hover:bg-emerald-500/15"
-                title="Approve"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onApproval({ id: approvalId, approved: true });
-                }}
-              >
-                <CheckCircle2 className="size-3.5 text-emerald-400" />
-              </button>
-              <button
-                type="button"
-                data-approval-action="deny"
-                className="inline-flex items-center justify-center size-5 rounded hover:bg-destructive/15"
-                title="Deny"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onApproval({ id: approvalId, approved: false });
-                }}
-              >
-                <XCircle className="size-3.5 text-destructive" />
-              </button>
-            </span>
-          ) : (
-            <>
-              <ChevronRight className="size-3 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:hidden" />
-              <ChevronDown className="hidden size-3 opacity-0 transition-opacity group-hover/tool:opacity-100 group-focus-within/tool:opacity-100 group-open/tool:block group-open/tool:opacity-100" />
-            </>
-          )}
-        </span>
-      </summary>
-      <div className="ml-5 mt-1 rounded-md bg-card/50 px-2.5 py-2 ring-1 ring-border/70">
-        <p className="truncate font-mono text-[11px]">
-          {previewInput(input)}
-        </p>
-        {state === "output-error" && errorText && (
-          <p className="mt-1 line-clamp-2 text-destructive">{errorText}</p>
-        )}
-        {state === "output-available" && output !== undefined && (
-          <p className="mt-1 line-clamp-2 font-mono text-[10px] text-muted-foreground">
-            {safeStringify(output)}
-          </p>
-        )}
-      </div>
-    </details>
+function toolResultFallbackText(message: AntonUIMessage): string {
+  const entries = getToolTraceEntries([message]);
+  const lastOutput = entries.findLast(
+    (entry) => entry.state === "output-available" && entry.output !== undefined,
   );
+  if (!lastOutput) return "";
+
+  if (lastOutput.name === "bash") {
+    return bashOutputFallback(lastOutput.output);
+  }
+
+  if (typeof lastOutput.output === "string") return lastOutput.output.trim();
+
+  return "";
+}
+
+function bashOutputFallback(output: unknown): string {
+  if (typeof output !== "object" || output === null) return "";
+  const record = output as Record<string, unknown>;
+  const stdout = typeof record.stdout === "string" ? record.stdout.trim() : "";
+  const stderr = typeof record.stderr === "string" ? record.stderr.trim() : "";
+  if (stdout) return `\`${stdout}\``;
+  if (stderr) return `\`${stderr}\``;
+  const exitCode = record.exitCode;
+  if (typeof exitCode === "number") return `Command exited with code ${exitCode}.`;
+  return "";
 }
 
 function CopyMessageButton({ text }: { text: string }) {
@@ -266,24 +177,4 @@ function CopyMessageButton({ text }: { text: string }) {
       )}
     </button>
   );
-}
-
-function previewInput(input: unknown): string {
-  if (typeof input === "object" && input !== null) {
-    const record = input as Record<string, unknown>;
-    for (const key of ["command", "path", "pattern", "slug", "task"]) {
-      if (typeof record[key] === "string") return record[key];
-    }
-  }
-  return safeStringify(input);
-}
-
-function safeStringify(value: unknown): string {
-  if (value === undefined) return "";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
 }

--- a/components/chat/run-trace.tsx
+++ b/components/chat/run-trace.tsx
@@ -1,0 +1,703 @@
+"use client";
+
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { ChatAddToolApproveResponseFunction } from "ai";
+import {
+  AlertCircle,
+  Brain,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock3,
+  Loader2,
+  TerminalSquare,
+  XCircle,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  getActivityEvents,
+  getReasoningTexts,
+  getRunData,
+  getToolTraceEntries,
+  type AntonActivityEvent,
+  type AntonRunStatus,
+  type AntonUIMessage,
+  type ToolTraceEntry,
+} from "@/src/lib/trace";
+
+const DISCLOSURE_ANIMATION =
+  "overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
+
+interface RunTraceAccordionProps {
+  message: AntonUIMessage;
+  status: "submitted" | "streaming" | "ready" | "error";
+  onApproval: ChatAddToolApproveResponseFunction;
+}
+
+type TraceRow =
+  | {
+      id: string;
+      order: number;
+      kind: "activity";
+      event: AntonActivityEvent;
+    }
+  | {
+      id: string;
+      order: number;
+      kind: "reasoning";
+      event?: AntonActivityEvent;
+      text: string;
+    }
+  | {
+      id: string;
+      order: number;
+      kind: "tool";
+      tool: ToolTraceEntry;
+    };
+
+export function RunTraceAccordion({
+  message,
+  status,
+  onApproval,
+}: RunTraceAccordionProps) {
+  const run = getRunData(message);
+  const metadata = message.metadata;
+  const isRunning =
+    (run?.status ?? metadata?.status) === "running" &&
+    (status === "submitted" || status === "streaming");
+  const now = useTick(isRunning);
+  const rows = useMemo(() => getTraceRows(message), [message]);
+  const modelTurnSummary = useMemo(() => getModelTurnSummary(message), [message]);
+
+  if (!run && rows.length === 0) return null;
+
+  const startedAt = run?.startedAt ?? metadata?.startedAt;
+  const durationMs =
+    run?.durationMs ??
+    metadata?.durationMs ??
+    getTraceDurationMs(rows) ??
+    (startedAt === undefined ? 0 : Math.max(0, now - startedAt));
+  const runStatus = run?.status ?? metadata?.status ?? "completed";
+  const header =
+    runStatus === "running"
+      ? `Working for ${formatDuration(durationMs)}`
+      : runStatus === "completed"
+        ? `Worked for ${formatDuration(durationMs)}`
+        : `Stopped after ${formatDuration(durationMs)}`;
+
+  return (
+    <Disclosure
+      className="mb-2 w-full text-xs text-muted-foreground"
+      defaultOpen={isRunning}
+      forceOpen={isRunning}
+      trigger={({ open }) => (
+        <span className="inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-[11px]">
+          {runStatus === "running" ? (
+            <Loader2 className="size-3.5 animate-spin text-sky-400" />
+          ) : runStatus === "completed" ? (
+            <CheckCircle2 className="size-3.5 text-emerald-400" />
+          ) : (
+            <AlertCircle className="size-3.5 text-amber-400" />
+          )}
+          <span className="font-medium text-foreground/90" title={modelTurnSummary}>
+            {header}
+          </span>
+          {open ? (
+            <ChevronDown className="size-3 opacity-70" />
+          ) : (
+            <ChevronRight className="size-3 opacity-70" />
+          )}
+        </span>
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+          <ol className="ml-2 mt-1 space-y-0 border-l border-border/70 pl-3">
+            {rows.map((row) => (
+              <li key={row.id}>
+                <TraceRowView
+                  row={row}
+                  runStatus={runStatus}
+                  onApproval={onApproval}
+                />
+              </li>
+            ))}
+          </ol>
+      </div>
+    </Disclosure>
+  );
+}
+
+function TraceRowView({
+  row,
+  runStatus,
+  onApproval,
+}: {
+  row: TraceRow;
+  runStatus: AntonRunStatus;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  if (row.kind === "tool") {
+    return <ToolRow entry={row.tool} onApproval={onApproval} />;
+  }
+  if (row.kind === "reasoning") {
+    return (
+      <ReasoningRow event={row.event} runStatus={runStatus} text={row.text} />
+    );
+  }
+  return <ActivityRow event={row.event} runStatus={runStatus} />;
+}
+
+function ActivityRow({
+  event,
+  runStatus,
+}: {
+  event: AntonActivityEvent;
+  runStatus: AntonRunStatus;
+}) {
+  const displayEvent = displayEventForRun(event, runStatus);
+  const meta = eventMeta(displayEvent);
+  return (
+    <div className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2 py-0.5">
+      <meta.Icon className={cn("mt-0.5 size-3.5", meta.iconClass)} />
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate text-foreground/85">
+            {eventLabel(displayEvent)}
+          </span>
+          {displayEvent.durationMs !== undefined && (
+            <span className="shrink-0 text-[10px]">
+              {formatDuration(displayEvent.durationMs)}
+            </span>
+          )}
+        </div>
+        {displayEvent.summary && (
+          <p className="truncate font-mono text-[10px]">
+            {displayEvent.summary}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ReasoningRow({
+  event,
+  runStatus,
+  text,
+}: {
+  event: AntonActivityEvent | undefined;
+  runStatus: AntonRunStatus;
+  text: string;
+}) {
+  const displayEvent = event
+    ? displayEventForRun(event, runStatus)
+    : undefined;
+  const running = displayEvent?.status === "running";
+  return (
+    <Disclosure
+      className="py-0.5"
+      trigger={({ open }) => (
+        <span className="inline-grid max-w-full grid-cols-[0.875rem_auto_0.75rem] items-start gap-2 rounded px-0 py-0">
+          {running ? (
+            <Loader2 className="mt-0.5 size-3.5 animate-spin text-sky-400" />
+          ) : (
+            <Brain className="mt-0.5 size-3.5 text-muted-foreground" />
+          )}
+          <span className="truncate text-foreground/85">
+            {displayEvent?.durationMs !== undefined
+              ? `Thought for ${formatDuration(displayEvent.durationMs)}`
+              : running
+                ? "Thinking"
+                : "Thought"}
+          </span>
+          {open ? (
+            <ChevronDown className="mt-0.5 size-3" />
+          ) : (
+            <ChevronRight className="mt-0.5 size-3" />
+          )}
+        </span>
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+          <pre className="ml-5 mt-1 max-h-40 overflow-y-auto pr-2 font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
+            {text}
+          </pre>
+      </div>
+    </Disclosure>
+  );
+}
+
+function ToolRow({
+  entry,
+  onApproval,
+}: {
+  entry: ToolTraceEntry;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const meta = toolStateMeta(entry.state);
+  const approvalId =
+    entry.state === "approval-requested" &&
+    typeof entry.approvalId === "string"
+      ? entry.approvalId
+      : undefined;
+  const needsApproval = approvalId !== undefined;
+  const showDetails = entry.name === "bash";
+  const title = toolTitle(entry);
+  const preview = previewInput(entry.input);
+  const showPreview = preview.length > 0 && preview !== title.target;
+  return (
+    <Disclosure
+      className="py-0.5"
+      disabled={needsApproval || !showDetails}
+      trigger={({ open }) => (
+        <span className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2 rounded px-0 py-0">
+          <meta.Icon className={cn("mt-0.5 size-3.5", meta.iconClass)} />
+          <span className="min-w-0">
+            <span className="flex min-w-0 items-center gap-1.5">
+              <ToolTitle title={title} />
+              {showDetails &&
+                !needsApproval &&
+                (open ? (
+                  <ChevronDown className="size-3 shrink-0" />
+                ) : (
+                  <ChevronRight className="size-3 shrink-0" />
+                ))}
+              {entry.name !== "bash" && (
+                <span className={cn("shrink-0 text-[10px]", meta.textClass)}>
+                  {meta.label}
+                </span>
+              )}
+              {approvalId && (
+                <ApprovalControls approvalId={approvalId} onApproval={onApproval} />
+              )}
+              {entry.activity?.durationMs !== undefined && (
+                <span className="shrink-0 text-[10px]">
+                  {formatDuration(entry.activity.durationMs)}
+                </span>
+              )}
+            </span>
+            {showPreview && (
+              <span className="block truncate font-mono text-[10px]">
+                {preview}
+              </span>
+            )}
+          </span>
+        </span>
+      )}
+    >
+      {showDetails && (
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-5 mt-1 rounded-md bg-card/50 px-2.5 py-2 ring-1 ring-border/70">
+            <LogLine title="Input">{safeStringify(entry.input)}</LogLine>
+            {entry.state === "output-error" && entry.errorText ? (
+              <LogLine title="Error" tone="error">
+                {entry.errorText}
+              </LogLine>
+            ) : entry.output !== undefined ? (
+              <LogLine title="Output">{safeStringify(entry.output)}</LogLine>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </Disclosure>
+  );
+}
+
+function ToolTitle({
+  title,
+}: {
+  title: { verb: string; target?: string };
+}) {
+  return (
+    <span className="min-w-0 truncate text-foreground/85">
+      {title.verb}
+      {title.target && (
+        <>
+          {" "}
+          <code className="rounded bg-card px-1 py-0.5 font-mono text-[10px] text-foreground/90">
+            {title.target}
+          </code>
+        </>
+      )}
+    </span>
+  );
+}
+
+function ApprovalControls({
+  approvalId,
+  onApproval,
+}: {
+  approvalId: string;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      <button
+        type="button"
+        data-approval-action="approve"
+        className="inline-flex size-5 items-center justify-center rounded hover:bg-emerald-500/15"
+        title="Approve"
+        onClick={(e) => {
+          e.stopPropagation();
+          onApproval({ id: approvalId, approved: true });
+        }}
+      >
+        <CheckCircle2 className="size-3.5 text-emerald-400" />
+      </button>
+      <button
+        type="button"
+        data-approval-action="deny"
+        className="inline-flex size-5 items-center justify-center rounded hover:bg-destructive/15"
+        title="Deny"
+        onClick={(e) => {
+          e.stopPropagation();
+          onApproval({ id: approvalId, approved: false });
+        }}
+      >
+        <XCircle className="size-3.5 text-destructive" />
+      </button>
+    </span>
+  );
+}
+
+function LogLine({
+  title,
+  tone,
+  children,
+}: {
+  title: string;
+  tone?: "error";
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1 py-1">
+      <div
+        className={cn(
+          "text-[10px] font-medium uppercase text-muted-foreground",
+          tone === "error" && "text-destructive",
+        )}
+      >
+        {title}
+      </div>
+      <pre className="max-h-32 overflow-auto font-mono text-[10px] leading-relaxed text-foreground/85 whitespace-pre-wrap">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+function getTraceRows(message: AntonUIMessage): TraceRow[] {
+  const activities = getActivityEvents(message);
+  const reasoningTexts = getReasoningTexts(message);
+  const reasoningActivities = activities.filter(
+    (event) => event.kind === "reasoning",
+  );
+  const toolEntries = getToolTraceEntries([message]);
+  const rows: TraceRow[] = [];
+
+  for (const event of activities) {
+    if (event.kind === "tool" || event.kind === "reasoning") continue;
+    if (event.kind === "step") continue;
+    rows.push({
+      id: event.id,
+      order: event.sequence,
+      kind: "activity",
+      event,
+    });
+  }
+
+  if (reasoningActivities.length > 0) {
+    reasoningActivities.forEach((event, index) => {
+      const text = reasoningTexts[index] ?? reasoningTexts.join("\n\n");
+      if (!text) return;
+      rows.push({
+        id: event.id,
+        order: event.sequence,
+        kind: "reasoning",
+        event,
+        text,
+      });
+    });
+  } else {
+    reasoningTexts.forEach((text, index) => {
+      rows.push({
+        id: `${message.id}:reasoning:${index}`,
+        order: 200 + index,
+        kind: "reasoning",
+        text,
+      });
+    });
+  }
+
+  toolEntries.forEach((tool, index) => {
+    rows.push({
+      id: tool.id,
+      order: tool.activity?.sequence ?? 500 + index,
+      kind: "tool",
+      tool,
+    });
+  });
+
+  return rows.sort((a, b) => a.order - b.order);
+}
+
+function getTraceDurationMs(rows: TraceRow[]): number | undefined {
+  const durations = rows
+    .map((row) => {
+      if (row.kind === "activity") return row.event.durationMs;
+      if (row.kind === "reasoning") return row.event?.durationMs;
+      return row.tool.activity?.durationMs;
+    })
+    .filter((duration): duration is number => duration !== undefined);
+  if (durations.length === 0) return undefined;
+  return durations.reduce((sum, duration) => sum + duration, 0);
+}
+
+function getModelTurnSummary(message: AntonUIMessage): string | undefined {
+  const turns = getActivityEvents(message).filter(
+    (event) => event.kind === "step",
+  );
+  if (turns.length === 0) return undefined;
+  return `Model turns: ${turns
+    .map((turn, index) => {
+      const duration = turn.durationMs;
+      return duration === undefined
+        ? `${index + 1}`
+        : `${index + 1} ${formatDuration(duration)}`;
+    })
+    .join(", ")}`;
+}
+
+function Disclosure({
+  className,
+  defaultOpen = false,
+  forceOpen = false,
+  disabled = false,
+  trigger,
+  children,
+}: {
+  className?: string;
+  defaultOpen?: boolean;
+  forceOpen?: boolean;
+  disabled?: boolean;
+  trigger: (state: { open: boolean }) => ReactNode;
+  children: ReactNode;
+}) {
+  const id = useId();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(defaultOpen);
+  const effectiveOpen = forceOpen || open;
+
+  useEffect(() => {
+    const content = contentRef.current;
+    const panel = content?.parentElement;
+    if (!content || !panel) return;
+
+    const updateHeight = () => {
+      panel.style.setProperty(
+        "--disclosure-height",
+        `${content.scrollHeight}px`,
+      );
+    };
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(content);
+    window.addEventListener("resize", updateHeight);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateHeight);
+    };
+  }, [children]);
+
+  if (disabled) {
+    return <div className={className}>{trigger({ open: false })}</div>;
+  }
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        className="block max-w-full cursor-pointer text-left select-none"
+        aria-expanded={effectiveOpen}
+        aria-controls={id}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {trigger({ open: effectiveOpen })}
+      </button>
+      <div
+        id={id}
+        className={cn(
+          DISCLOSURE_ANIMATION,
+          effectiveOpen ? "opacity-100" : "opacity-0",
+        )}
+        style={{
+          maxHeight: effectiveOpen ? "var(--disclosure-height, 0px)" : "0px",
+        }}
+      >
+        <div ref={contentRef}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function eventLabel(event: AntonActivityEvent): string {
+  return event.label;
+}
+
+function displayEventForRun(
+  event: AntonActivityEvent,
+  runStatus: AntonRunStatus,
+): AntonActivityEvent {
+  if (event.status !== "running" || runStatus === "running") return event;
+  return {
+    ...event,
+    status: runStatus === "completed" ? "completed" : "error",
+  };
+}
+
+function eventMeta(event: AntonActivityEvent) {
+  if (event.status === "running") {
+    return {
+      Icon: Loader2,
+      iconClass: "animate-spin text-sky-400",
+    };
+  }
+  if (event.status === "error" || event.kind === "error") {
+    return { Icon: AlertCircle, iconClass: "text-destructive" };
+  }
+  return { Icon: CheckCircle2, iconClass: "text-emerald-400" };
+}
+
+function toolStateMeta(state: ToolTraceEntry["state"]) {
+  switch (state) {
+    case "input-streaming":
+      return {
+        label: "streaming",
+        Icon: Loader2,
+        iconClass: "animate-spin text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "input-available":
+      return {
+        label: "running",
+        Icon: Clock3,
+        iconClass: "text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "approval-requested":
+      return {
+        label: "approval",
+        Icon: AlertCircle,
+        iconClass: "text-amber-400",
+        textClass: "text-amber-400",
+      };
+    case "approval-responded":
+      return {
+        label: "approved",
+        Icon: CheckCircle2,
+        iconClass: "text-muted-foreground",
+        textClass: "text-muted-foreground",
+      };
+    case "output-available":
+      return {
+        label: "done",
+        Icon: iconForTool,
+        iconClass: "text-emerald-400",
+        textClass: "text-emerald-400",
+      };
+    case "output-error":
+      return {
+        label: "error",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+    case "output-denied":
+      return {
+        label: "denied",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+  }
+}
+
+function iconForTool({ className }: { className?: string }) {
+  return <TerminalSquare className={className} />;
+}
+
+function toolTitle(entry: ToolTraceEntry): { verb: string; target?: string } {
+  const target = previewInput(entry.input);
+  switch (entry.name) {
+    case "bash":
+      return { verb: "Ran", target };
+    case "read_file":
+      return { verb: "Read", target };
+    case "glob":
+      return { verb: "Listed", target };
+    case "grep":
+      return { verb: "Searched", target };
+    case "write_file":
+      return { verb: "Edited", target };
+    default:
+      return {
+        verb: entry.activity?.label ?? entry.name,
+        target: target.length > 0 ? target : undefined,
+      };
+  }
+}
+
+function previewInput(input: unknown): string {
+  if (typeof input === "object" && input !== null) {
+    const record = input as Record<string, unknown>;
+    const command = pickString(record, "command");
+    const path = pickString(record, "path");
+    const pattern = pickString(record, "pattern");
+    if (command) return command;
+    if (path) return path;
+    if (pattern) return pattern;
+  }
+  return safeStringify(input);
+}
+
+function pickString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
+}
+
+function useTick(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return now;
+}

--- a/components/chat/worklog.tsx
+++ b/components/chat/worklog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { getToolName, isToolUIPart, type ChatAddToolApproveResponseFunction } from "ai";
+import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   AlertCircle,
   CheckCircle2,
@@ -12,30 +12,17 @@ import {
   XCircle,
 } from "lucide-react";
 
-import type { AntonUIMessage } from "@/src/agent/loop";
+import {
+  getToolTraceEntries,
+  type AntonUIMessage,
+  type ToolTraceEntry,
+  type ToolState,
+} from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { DiffView } from "./diff-view";
 
-type ToolState =
-  | "input-streaming"
-  | "input-available"
-  | "approval-requested"
-  | "approval-responded"
-  | "output-available"
-  | "output-error"
-  | "output-denied";
-
-export type WorklogEntry = {
-  id: string;
-  sourceMessageId: string;
-  name: string;
-  state: ToolState;
-  input: unknown;
-  output: unknown;
-  errorText: string | undefined;
-  approvalId: string | undefined;
-};
+export type WorklogEntry = ToolTraceEntry;
 
 interface WorklogProps {
   messages: AntonUIMessage[];
@@ -115,27 +102,7 @@ export function Worklog({
 }
 
 export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
-  const entries: WorklogEntry[] = [];
-  for (const message of messages) {
-    message.parts.forEach((part, index) => {
-      if (!isToolUIPart(part)) return;
-      const state = part.state as ToolState;
-      entries.push({
-        id: `${message.id}:${index}`,
-        sourceMessageId: message.id,
-        name: String(getToolName(part)),
-        state,
-        input: "input" in part ? part.input : undefined,
-        output: "output" in part ? part.output : undefined,
-        errorText: "errorText" in part ? part.errorText : undefined,
-        approvalId:
-          state === "approval-requested" && "approval" in part && part.approval
-            ? part.approval.id
-            : undefined,
-      });
-    });
-  }
-  return entries;
+  return getToolTraceEntries(messages);
 }
 
 function WorklogRow({

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -3,8 +3,9 @@ import {
   stepCountIs,
   type LanguageModelUsage,
   type ModelMessage,
-  type UIMessage,
-  type UITools,
+  type TextStreamPart,
+  type ToolSet,
+  type FinishReason,
 } from "ai";
 import { openrouter, DEFAULT_MODEL } from "@/src/lib/providers";
 import { listMemories } from "@/src/db/queries";
@@ -123,24 +124,49 @@ function projectSkillPromptLines(workspaceRoot?: string): string[] {
   return lines;
 }
 
-export type AntonUIMessage = UIMessage<
-  never,
-  never,
-  UITools
->;
-
 export async function runAgent({
   messages,
   model,
   workspaceRoot,
   permissionMode,
+  onStepStart,
+  onStepFinish,
+  onToolCallStart,
+  onToolCallFinish,
+  onStreamPart,
+  onError,
+  onAbort,
   onFinish,
 }: {
   messages: ModelMessage[];
   model?: string;
   workspaceRoot?: string;
   permissionMode?: PermissionMode;
-  onFinish?: (result: { totalUsage: LanguageModelUsage }) => void;
+  onStepStart?: (event: { stepNumber: number }) => void;
+  onStepFinish?: (event: { stepNumber: number }) => void;
+  onToolCallStart?: (event: {
+    stepNumber: number | undefined;
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }) => void;
+  onToolCallFinish?: (event: {
+    stepNumber: number | undefined;
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    success: boolean;
+    durationMs: number;
+    output?: unknown;
+    error?: unknown;
+  }) => void;
+  onStreamPart?: (part: TextStreamPart<ToolSet>) => void;
+  onError?: (error: unknown) => void;
+  onAbort?: () => void;
+  onFinish?: (result: {
+    totalUsage: LanguageModelUsage;
+    finishReason: FinishReason;
+  }) => void;
 }) {
   const mcpTools = await loadMcpTools(workspaceRoot);
   let closed = false;
@@ -151,23 +177,72 @@ export async function runAgent({
   };
 
   const selectedModel = model ?? DEFAULT_MODEL;
+  const tools = createAntonTools({
+    model: selectedModel,
+    mcpTools: mcpTools.tools,
+    workspaceRoot,
+    permissionMode,
+  });
 
   return streamText({
     model: openrouter(selectedModel),
     system: systemPrompt(mcpTools, workspaceRoot),
     messages,
-    tools: createAntonTools({
-      model: selectedModel,
-      mcpTools: mcpTools.tools,
-      workspaceRoot,
-      permissionMode,
-    }),
+    tools,
     stopWhen: stepCountIs(MAX_STEPS),
-    onFinish: async ({ totalUsage }) => {
-      onFinish?.({ totalUsage });
+    providerOptions: {
+      openrouter: {
+        reasoning: { enabled: true, effort: "low", exclude: false },
+      },
+    },
+    experimental_transform: onStreamPart
+      ? () =>
+          new TransformStream({
+            transform(part, controller) {
+              onStreamPart(part as TextStreamPart<ToolSet>);
+              controller.enqueue(part);
+            },
+          })
+      : undefined,
+    experimental_onStepStart: ({ stepNumber }) => {
+      onStepStart?.({ stepNumber });
+    },
+    onStepFinish: ({ stepNumber }) => {
+      onStepFinish?.({ stepNumber });
+    },
+    experimental_onToolCallStart: ({ stepNumber, toolCall }) => {
+      onToolCallStart?.({
+        stepNumber,
+        toolCallId: toolCall.toolCallId,
+        toolName: toolCall.toolName,
+        input: toolCall.input,
+      });
+    },
+    experimental_onToolCallFinish: (event) => {
+      onToolCallFinish?.({
+        stepNumber: event.stepNumber,
+        toolCallId: event.toolCall.toolCallId,
+        toolName: event.toolCall.toolName,
+        input: event.toolCall.input,
+        success: event.success,
+        durationMs: event.durationMs,
+        output: event.success ? event.output : undefined,
+        error: event.success ? undefined : event.error,
+      });
+    },
+    onFinish: async ({ totalUsage, finishReason }) => {
+      onFinish?.({ totalUsage, finishReason });
       await closeMcpTools();
     },
-    onAbort: closeMcpTools,
-    onError: closeMcpTools,
+    onAbort: async () => {
+      onAbort?.();
+      await closeMcpTools();
+    },
+    onError: async ({ error }) => {
+      onError?.(error);
+      await closeMcpTools();
+    },
   });
 }
+
+export type { AntonUIMessage } from "@/src/lib/trace";

--- a/src/db/migrations/0004_public_umar.sql
+++ b/src/db/migrations/0004_public_umar.sql
@@ -1,0 +1,34 @@
+CREATE TABLE `run_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`run_id` text NOT NULL,
+	`sequence` integer NOT NULL,
+	`kind` text NOT NULL,
+	`status` text NOT NULL,
+	`label` text NOT NULL,
+	`summary` text,
+	`started_at` integer NOT NULL,
+	`finished_at` integer,
+	`duration_ms` integer,
+	`tool_call_id` text,
+	`details` text,
+	FOREIGN KEY (`run_id`) REFERENCES `runs`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `run_events_run_id_sequence_idx` ON `run_events` (`run_id`,`sequence`);--> statement-breakpoint
+CREATE INDEX `run_events_tool_call_id_idx` ON `run_events` (`tool_call_id`);--> statement-breakpoint
+CREATE TABLE `runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`model` text NOT NULL,
+	`status` text NOT NULL,
+	`started_at` integer NOT NULL,
+	`finished_at` integer,
+	`duration_ms` integer,
+	`total_tokens` integer,
+	`finish_reason` text,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `runs_session_id_idx` ON `runs` (`session_id`);--> statement-breakpoint
+CREATE INDEX `runs_started_at_idx` ON `runs` (`started_at`);--> statement-breakpoint
+ALTER TABLE `messages` ADD `metadata` text;

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,654 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8dfc70d2-2300-4320-9f7a-619a135e6e9f",
+  "prevId": "0e09e182-b977-4a6b-808c-2b8070cb5a0c",
+  "tables": {
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777628679023,
       "tag": "0003_lush_tinkerer",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777742922807,
+      "tag": "0004_public_umar",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -8,11 +8,17 @@ import {
   memories,
   messages,
   projects,
+  runEvents,
+  runs,
   sessions,
   workspaceSettings,
   type GithubInstallation,
   type Memory,
+  type NewRun,
+  type NewRunEvent,
   type Project,
+  type Run,
+  type RunEvent,
   type Session,
   type WorkspaceSettings,
 } from "./schema";
@@ -22,6 +28,7 @@ export type StoredMessage<UI extends UIMessage = UIMessage> = {
   sessionId: string;
   role: UI["role"];
   parts: UI["parts"];
+  metadata: UI["metadata"] | null;
   createdAt: Date;
 };
 
@@ -337,6 +344,7 @@ export function loadMessages<UI extends UIMessage>(
       id: row.id,
       role: row.role as UI["role"],
       parts,
+      metadata: (row.metadata ?? undefined) as UI["metadata"],
     } as UI;
   });
 }
@@ -356,6 +364,7 @@ export function replaceMessages<UI extends UIMessage>(
           sessionId,
           role: m.role,
           parts: m.parts as unknown,
+          metadata: (m.metadata ?? null) as unknown,
           // Preserve ordering even when created_at ticks collide.
           createdAt: new Date(Date.now() + idx),
         })),
@@ -367,6 +376,43 @@ export function replaceMessages<UI extends UIMessage>(
       .where(eq(sessions.id, sessionId))
       .run();
   });
+}
+
+export function createRun(input: NewRun): Run {
+  db.insert(runs).values(input).run();
+  return db.select().from(runs).where(eq(runs.id, input.id)).get() as Run;
+}
+
+export function updateRun(
+  id: string,
+  input: Partial<Omit<NewRun, "id" | "sessionId" | "model" | "startedAt">>,
+): Run | undefined {
+  db.update(runs).set(input).where(eq(runs.id, id)).run();
+  return db.select().from(runs).where(eq(runs.id, id)).get();
+}
+
+export function upsertRunEvent(input: NewRunEvent): RunEvent {
+  db
+    .insert(runEvents)
+    .values(input)
+    .onConflictDoUpdate({
+      target: runEvents.id,
+      set: {
+        status: input.status,
+        label: input.label,
+        summary: input.summary ?? null,
+        finishedAt: input.finishedAt ?? null,
+        durationMs: input.durationMs ?? null,
+        toolCallId: input.toolCallId ?? null,
+        details: input.details ?? null,
+      },
+    })
+    .run();
+  return db
+    .select()
+    .from(runEvents)
+    .where(eq(runEvents.id, input.id))
+    .get() as RunEvent;
 }
 
 export function deriveTitleFromMessages(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const workspaceSettings = sqliteTable("workspace_settings", {
   id: text("id").primaryKey(),
@@ -78,10 +78,62 @@ export const messages = sqliteTable("messages", {
     .references(() => sessions.id, { onDelete: "cascade" }),
   role: text("role", { enum: ["user", "assistant", "system"] }).notNull(),
   parts: text("parts", { mode: "json" }).notNull(),
+  metadata: text("metadata", { mode: "json" }),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .default(sql`(unixepoch('now') * 1000)`),
 });
+
+export const runs = sqliteTable(
+  "runs",
+  {
+    id: text("id").primaryKey(),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    model: text("model").notNull(),
+    status: text("status", {
+      enum: ["running", "completed", "error", "aborted"],
+    }).notNull(),
+    startedAt: integer("started_at", { mode: "timestamp_ms" }).notNull(),
+    finishedAt: integer("finished_at", { mode: "timestamp_ms" }),
+    durationMs: integer("duration_ms"),
+    totalTokens: integer("total_tokens"),
+    finishReason: text("finish_reason"),
+  },
+  (table) => [
+    index("runs_session_id_idx").on(table.sessionId),
+    index("runs_started_at_idx").on(table.startedAt),
+  ],
+);
+
+export const runEvents = sqliteTable(
+  "run_events",
+  {
+    id: text("id").primaryKey(),
+    runId: text("run_id")
+      .notNull()
+      .references(() => runs.id, { onDelete: "cascade" }),
+    sequence: integer("sequence").notNull(),
+    kind: text("kind", {
+      enum: ["step", "reasoning", "tool", "approval", "error", "progress"],
+    }).notNull(),
+    status: text("status", {
+      enum: ["running", "completed", "waiting", "error", "denied"],
+    }).notNull(),
+    label: text("label").notNull(),
+    summary: text("summary"),
+    startedAt: integer("started_at", { mode: "timestamp_ms" }).notNull(),
+    finishedAt: integer("finished_at", { mode: "timestamp_ms" }),
+    durationMs: integer("duration_ms"),
+    toolCallId: text("tool_call_id"),
+    details: text("details", { mode: "json" }),
+  },
+  (table) => [
+    index("run_events_run_id_sequence_idx").on(table.runId, table.sequence),
+    index("run_events_tool_call_id_idx").on(table.toolCallId),
+  ],
+);
 
 export const memories = sqliteTable("memories", {
   id: text("id").primaryKey(),
@@ -104,5 +156,9 @@ export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
+export type Run = typeof runs.$inferSelect;
+export type NewRun = typeof runs.$inferInsert;
+export type RunEvent = typeof runEvents.$inferSelect;
+export type NewRunEvent = typeof runEvents.$inferInsert;
 export type Memory = typeof memories.$inferSelect;
 export type NewMemory = typeof memories.$inferInsert;

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -1,0 +1,169 @@
+import {
+  getToolName,
+  isDataUIPart,
+  isReasoningUIPart,
+  isToolUIPart,
+  type UIMessage,
+  type UITools,
+} from "ai";
+
+export type AntonRunStatus = "running" | "completed" | "error" | "aborted";
+
+export type AntonActivityKind =
+  | "step"
+  | "reasoning"
+  | "tool"
+  | "approval"
+  | "error"
+  | "progress";
+
+export type AntonActivityStatus =
+  | "running"
+  | "completed"
+  | "waiting"
+  | "error"
+  | "denied";
+
+export type AntonMessageMetadata = {
+  runId?: string;
+  model?: string;
+  status?: AntonRunStatus;
+  startedAt?: number;
+  finishedAt?: number;
+  durationMs?: number;
+  totalTokens?: number;
+};
+
+export type AntonRunData = {
+  runId: string;
+  model: string;
+  status: AntonRunStatus;
+  startedAt: number;
+  finishedAt?: number;
+  durationMs?: number;
+  totalTokens?: number;
+};
+
+export type AntonActivityEvent = {
+  id: string;
+  runId: string;
+  sequence: number;
+  kind: AntonActivityKind;
+  status: AntonActivityStatus;
+  label: string;
+  summary?: string;
+  startedAt: number;
+  finishedAt?: number;
+  durationMs?: number;
+  toolCallId?: string;
+  details?: Record<string, unknown>;
+};
+
+export type AntonDataParts = {
+  run: AntonRunData;
+  activity: AntonActivityEvent;
+};
+
+export type AntonUIMessage = UIMessage<
+  AntonMessageMetadata,
+  AntonDataParts,
+  UITools
+>;
+
+export type ToolState =
+  | "input-streaming"
+  | "input-available"
+  | "approval-requested"
+  | "approval-responded"
+  | "output-available"
+  | "output-error"
+  | "output-denied";
+
+export type ToolTraceEntry = {
+  id: string;
+  sourceMessageId: string;
+  name: string;
+  state: ToolState;
+  input: unknown;
+  output: unknown;
+  errorText: string | undefined;
+  approvalId: string | undefined;
+  activity?: AntonActivityEvent;
+};
+
+export function getRunData(message: AntonUIMessage): AntonRunData | undefined {
+  let run: AntonRunData | undefined;
+  for (const part of message.parts) {
+    if (isRunDataPart(part)) run = part.data;
+  }
+  return run;
+}
+
+export function getActivityEvents(
+  message: AntonUIMessage,
+): AntonActivityEvent[] {
+  const byId = new Map<string, AntonActivityEvent>();
+  for (const part of message.parts) {
+    if (isActivityDataPart(part)) byId.set(part.data.id, part.data);
+  }
+  return Array.from(byId.values()).sort((a, b) => a.sequence - b.sequence);
+}
+
+export function getToolTraceEntries(
+  messages: AntonUIMessage[],
+): ToolTraceEntry[] {
+  const entries: ToolTraceEntry[] = [];
+  for (const message of messages) {
+    const activityByToolCallId = new Map<string, AntonActivityEvent>();
+    for (const activity of getActivityEvents(message)) {
+      if (activity.kind === "tool" && activity.toolCallId) {
+        activityByToolCallId.set(activity.toolCallId, activity);
+      }
+    }
+
+    message.parts.forEach((part, index) => {
+      if (!isToolUIPart(part)) return;
+      const state = part.state as ToolState;
+      const toolCallId =
+        "toolCallId" in part && typeof part.toolCallId === "string"
+          ? part.toolCallId
+          : undefined;
+      entries.push({
+        id: `${message.id}:${index}`,
+        sourceMessageId: message.id,
+        name: String(getToolName(part)),
+        state,
+        input: "input" in part ? part.input : undefined,
+        output: "output" in part ? part.output : undefined,
+        errorText: "errorText" in part ? part.errorText : undefined,
+        approvalId:
+          state === "approval-requested" && "approval" in part && part.approval
+            ? part.approval.id
+            : undefined,
+        activity: toolCallId
+          ? activityByToolCallId.get(toolCallId)
+          : undefined,
+      });
+    });
+  }
+  return entries;
+}
+
+export function getReasoningTexts(message: AntonUIMessage): string[] {
+  return message.parts
+    .filter(isReasoningUIPart)
+    .map((part) => part.text.trim())
+    .filter((text) => text.length > 0);
+}
+
+export function isRunDataPart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-run" }> {
+  return isDataUIPart(part) && part.type === "data-run";
+}
+
+export function isActivityDataPart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-activity" }> {
+  return isDataUIPart(part) && part.type === "data-activity";
+}


### PR DESCRIPTION
## Summary
- add persisted run metadata and ordered run activity events for chat executions
- stream provider reasoning and harness activity into a Devin/Codex-style inline trace accordion
- share normalized trace helpers between the inline trace and Worklog, including approval controls and compact tool rows
- update ROADMAP.md with the shipped durable-run and trace work

## Verification
- pnpm typecheck
- pnpm lint
- browser-checked trace rows for compact tool labels, scroll-capped thinking text, disclosure animation, and approval control placement

## Notes
- OpenRouter reasoning is requested at low effort and gracefully degrades when providers omit reasoning.
- Full tool input/output remains in message parts; run events persist only summaries and timing metadata.

Closes #22