### PR TITLE
Classify Anton tools and commands by risk

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -37,7 +37,7 @@ function systemPrompt(mcpTools: LoadedMcpTools, workspaceRoot?: string): string 
     "Tools available:",
     "- `read_file(path, startLine?, endLine?)` - read a text file. Prefer narrow ranges for large files.",
     "- `write_file(path, content)` - overwrite a file. Classified as write risk; the user must approve each call.",
-    "- `bash(command, timeoutMs?)` - run a shell command in the workspace. Commands are conservatively classified for write, delete, network, package-install, git, long-running-process, and external-integration risk; requires approval. `sudo` is forbidden.",
+    "- `bash(command, timeoutMs?)` - run a shell command in the workspace. Commands are conservatively classified by risk category before execution; shell execution requires approval. `sudo` is forbidden.",
     "- `grep(pattern, path?, glob?, caseInsensitive?)` - ripgrep-style search. Use this before reading large files.",
     "- `glob(pattern, path?)` - list files matching a glob like `**/*.ts`.",
     "- `list_memory(limit?)` - list project-wide memories that apply across sessions.",

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -13,7 +13,7 @@ import type { ToolSet } from "ai";
 
 export type PermissionMode = "default" | "auto-review" | "full-access";
 
-export const RISK_CATEGORIES = [
+export const TOOL_RISK_CATEGORIES = [
   "read-only",
   "write",
   "delete",
@@ -24,23 +24,36 @@ export const RISK_CATEGORIES = [
   "external-integration",
 ] as const;
 
-export type RiskCategory = (typeof RISK_CATEGORIES)[number];
+export type ToolRiskCategory = (typeof TOOL_RISK_CATEGORIES)[number];
 
-export type RiskClassification = {
-  categories: readonly RiskCategory[];
+export type ToolPermissionMetadata = {
+  categories: readonly ToolRiskCategory[];
   requiresApproval: boolean;
+  summary: string;
 };
 
-export type RiskLevel = "safe" | "risky";
+export type BashCommandClassification = {
+  categories: readonly ToolRiskCategory[];
+  forbidden: boolean;
+  reason: string;
+};
 
-const READ_ONLY = classify(["read-only"], false);
+const READ_ONLY = toolMetadata(
+  ["read-only"],
+  false,
+  "Reads workspace or project context without changing state.",
+);
 
-export const NATIVE_TOOL_RISK_CLASSIFICATIONS = {
+export const NATIVE_TOOL_PERMISSION_METADATA = {
   read_file: READ_ONLY,
   grep: READ_ONLY,
   glob: READ_ONLY,
-  write_file: classify(["write"], true),
-  bash: classify(
+  write_file: toolMetadata(
+    ["write"],
+    true,
+    "Writes or replaces a workspace file.",
+  ),
+  bash: toolMetadata(
     [
       "write",
       "delete",
@@ -51,26 +64,36 @@ export const NATIVE_TOOL_RISK_CLASSIFICATIONS = {
       "external-integration",
     ],
     true,
+    "Runs a shell command with command-specific risk classification.",
   ),
   list_memory: READ_ONLY,
-  remember: classify(["write"], true),
-  update_memory: classify(["write"], true),
-  forget_memory: classify(["delete"], true),
+  remember: toolMetadata(
+    ["write"],
+    true,
+    "Creates a durable project memory.",
+  ),
+  update_memory: toolMetadata(
+    ["write"],
+    true,
+    "Updates a durable project memory.",
+  ),
+  forget_memory: toolMetadata(
+    ["delete"],
+    true,
+    "Deletes a durable project memory.",
+  ),
   list_skills: READ_ONLY,
   read_skill: READ_ONLY,
-  delegate_task: classify(["read-only", "external-integration"], false),
-} as const satisfies Record<string, RiskClassification>;
+  delegate_task: READ_ONLY,
+} as const satisfies Record<string, ToolPermissionMetadata>;
 
-export const NATIVE_TOOL_RISK_LEVELS = Object.fromEntries(
-  Object.entries(NATIVE_TOOL_RISK_CLASSIFICATIONS).map(([name, risk]) => [
-    name,
-    risk.requiresApproval ? "risky" : "safe",
-  ]),
-) as Record<keyof typeof NATIVE_TOOL_RISK_CLASSIFICATIONS, RiskLevel>;
-
-export const RISK_LEVELS: Record<string, RiskLevel> = NATIVE_TOOL_RISK_LEVELS;
-export const RISK_CLASSIFICATIONS: Record<string, RiskClassification> =
-  NATIVE_TOOL_RISK_CLASSIFICATIONS;
+export function getNativeToolPermissionMetadata(
+  name: string,
+): ToolPermissionMetadata | undefined {
+  return NATIVE_TOOL_PERMISSION_METADATA[
+    name as keyof typeof NATIVE_TOOL_PERMISSION_METADATA
+  ];
+}
 
 type ToolWithApproval = ToolSet[string] & {
   needsApproval?: boolean;
@@ -82,8 +105,8 @@ export function applyNativeToolPermissionPolicy<TTools extends ToolSet>(
 ): TTools {
   return Object.fromEntries(
     Object.entries(tools).map(([name, toolValue]) => {
-      const risk = RISK_CLASSIFICATIONS[name];
-      if (!risk) {
+      const metadata = getNativeToolPermissionMetadata(name);
+      if (!metadata) {
         throw new Error(`missing native tool permission policy: ${name}`);
       }
 
@@ -100,7 +123,7 @@ export function applyNativeToolPermissionPolicy<TTools extends ToolSet>(
         return [name, { ...toolWithoutApproval, needsApproval: true }];
       }
 
-      if (risk.requiresApproval) {
+      if (metadata.requiresApproval) {
         return [name, { ...toolWithoutApproval, needsApproval: true }];
       }
 
@@ -121,11 +144,26 @@ export function stripApprovalFlags<TTools extends ToolSet>(
   ) as TTools;
 }
 
-export function classifyBashCommand(command: string): RiskClassification {
+export function classifyBashCommand(command: string): BashCommandClassification {
   const normalized = command.trim();
-  if (!normalized) return READ_ONLY;
+  if (!normalized) {
+    return {
+      categories: ["read-only"],
+      forbidden: false,
+      reason: "empty command",
+    };
+  }
 
-  const categories = new Set<RiskCategory>();
+  const forbidden = isForbiddenBashCommand(normalized);
+  if (forbidden) {
+    return {
+      categories: ["external-integration"],
+      forbidden: true,
+      reason: `forbidden command pattern: ${forbidden}`,
+    };
+  }
+
+  const categories = new Set<ToolRiskCategory>();
 
   if (isGitCommand(normalized)) categories.add("git");
   if (hasNetworkPattern(normalized)) categories.add("network");
@@ -146,10 +184,12 @@ export function classifyBashCommand(command: string): RiskClassification {
     categories.add("write");
   }
 
-  return classify(
-    [...categories],
-    [...categories].some((category) => category !== "read-only"),
-  );
+  const orderedCategories = orderedRiskCategories(categories);
+  return {
+    categories: orderedCategories,
+    forbidden: false,
+    reason: reasonForCategories(orderedCategories),
+  };
 }
 
 // Commands we refuse to execute in `bash` even after approval — the user
@@ -166,11 +206,26 @@ export function isForbiddenBashCommand(command: string): RegExp | null {
   return null;
 }
 
-function classify(
-  categories: readonly RiskCategory[],
+function toolMetadata(
+  categories: readonly ToolRiskCategory[],
   requiresApproval: boolean,
-): RiskClassification {
-  return { categories, requiresApproval };
+  summary: string,
+): ToolPermissionMetadata {
+  return { categories, requiresApproval, summary };
+}
+
+function orderedRiskCategories(
+  categories: ReadonlySet<ToolRiskCategory>,
+): ToolRiskCategory[] {
+  return TOOL_RISK_CATEGORIES.filter((category) => categories.has(category));
+}
+
+function reasonForCategories(categories: readonly ToolRiskCategory[]): string {
+  if (categories.length === 1 && categories[0] === "read-only") {
+    return "matched read-only command patterns";
+  }
+
+  return `matched ${categories.join(", ")} command risk patterns`;
 }
 
 function isGitCommand(command: string): boolean {

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { execa } from "execa";
 import { tool } from "ai";
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt } from "../sandbox";
-import { classifyBashCommand, isForbiddenBashCommand } from "../permissions";
+import { classifyBashCommand } from "../permissions";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -11,7 +11,7 @@ const MAX_TIMEOUT_MS = 120_000;
 export function createBashTool(workspaceRoot?: string) {
   return tool({
   description:
-    "Run a shell command inside the workspace directory. The command inherits a restricted environment, runs with a timeout, and has its output truncated. `sudo` is forbidden. Requires user approval.",
+    "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. `sudo` is forbidden. Requires user approval.",
   inputSchema: z.object({
     command: z.string().describe("Shell command to execute via `bash -lc`."),
     timeoutMs: z
@@ -25,13 +25,13 @@ export function createBashTool(workspaceRoot?: string) {
       ),
   }),
   execute: async ({ command, timeoutMs }) => {
-    const risk = classifyBashCommand(command);
-    const forbidden = isForbiddenBashCommand(command);
-    if (forbidden) {
+    const classification = classifyBashCommand(command);
+    if (classification.forbidden) {
       return {
         ok: false as const,
-        riskCategories: risk.categories,
-        error: `forbidden command pattern: ${forbidden}`,
+        classification,
+        riskCategories: classification.categories,
+        error: classification.reason,
       };
     }
 
@@ -51,7 +51,8 @@ export function createBashTool(workspaceRoot?: string) {
 
       return {
         ok: true as const,
-        riskCategories: risk.categories,
+        classification,
+        riskCategories: classification.categories,
         exitCode: result.exitCode ?? null,
         timedOut: result.timedOut ?? false,
         killed: result.isCanceled ?? false,
@@ -61,7 +62,8 @@ export function createBashTool(workspaceRoot?: string) {
     } catch (err) {
       return {
         ok: false as const,
-        riskCategories: risk.categories,
+        classification,
+        riskCategories: classification.categories,
         error: errorMessage(err),
       };
     }


### PR DESCRIPTION
## Summary
- Replaces the binary native tool risk model with category-aware `ToolPermissionMetadata`.
- Adds central metadata for native tools and exports `NATIVE_TOOL_PERMISSION_METADATA`, `getNativeToolPermissionMetadata`, and `classifyBashCommand`.
- Classifies bash commands before execution and returns non-breaking classification metadata in bash tool results.
- Updates the agent prompt/tool description to reflect category-aware shell command classification.

Refs #20

## Verification
- Manual classifier probe for `ls`, `rg`, `touch`, `rm`, `pnpm add`, `curl`, `git status`, `git push`, `pnpm dev`, and `sudo`.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Note: `pnpm build` passed with an existing Turbopack NFT warning in the `next.config.ts -> src/workspace/local.ts -> app/api/projects/route.ts` trace.