### PR TITLE
Refactor duplicated settings and trace helpers

### DIFF
--- a/app/api/memories/[id]/route.ts
+++ b/app/api/memories/[id]/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { deleteMemory, updateMemory } from "@/src/db/queries";
-import type { Memory } from "@/src/db/schema";
+import { serializeMemory } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
 
@@ -38,13 +38,4 @@ export async function DELETE(_req: Request, { params }: Ctx) {
     return Response.json({ error: "memory not found" }, { status: 404 });
   }
   return new Response(null, { status: 204 });
-}
-
-function serializeMemory(memory: Memory) {
-  return {
-    id: memory.id,
-    content: memory.content,
-    createdAt: memory.createdAt.getTime(),
-    updatedAt: memory.updatedAt.getTime(),
-  };
 }

--- a/app/api/memories/route.ts
+++ b/app/api/memories/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { createMemory, listMemories } from "@/src/db/queries";
-import type { Memory } from "@/src/db/schema";
+import { serializeMemory } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
 
@@ -31,13 +31,4 @@ export async function POST(req: Request) {
     { memory: serializeMemory(createMemory(parsed.data.content)) },
     { status: 201 },
   );
-}
-
-function serializeMemory(memory: Memory) {
-  return {
-    id: memory.id,
-    content: memory.content,
-    createdAt: memory.createdAt.getTime(),
-    updatedAt: memory.updatedAt.getTime(),
-  };
 }

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,5 +1,5 @@
 import { getProject } from "@/src/db/queries";
-import type { Project } from "@/src/db/schema";
+import { serializeProject } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
 
@@ -12,23 +12,4 @@ export async function GET(_req: Request, { params }: Ctx) {
     return Response.json({ error: "project not found" }, { status: 404 });
   }
   return Response.json({ project: serializeProject(project) });
-}
-
-function serializeProject(project: Project) {
-  return {
-    id: project.id,
-    provider: project.provider,
-    githubRepoId: project.githubRepoId,
-    githubInstallationId: project.githubInstallationId,
-    owner: project.owner,
-    name: project.name,
-    fullName: project.fullName,
-    defaultBranch: project.defaultBranch,
-    cloneUrl: project.cloneUrl,
-    localPath: project.localPath,
-    status: project.status,
-    lastError: project.lastError,
-    createdAt: project.createdAt.getTime(),
-    updatedAt: project.updatedAt.getTime(),
-  };
 }

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -4,7 +4,7 @@ import { getLocalWorkspacesRoot } from "@/src/workspace/local";
 import { cloneGitHubRepository, CloneError } from "@/src/workspace/clone";
 import { listProjects } from "@/src/db/queries";
 import { listInstallationRepositories } from "@/src/github/app";
-import type { Project } from "@/src/db/schema";
+import { serializeProject } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
 
@@ -46,25 +46,6 @@ export async function POST(req: Request) {
     const status = err instanceof CloneError ? 400 : 500;
     return Response.json({ error: errorMessage(err) }, { status });
   }
-}
-
-function serializeProject(project: Project) {
-  return {
-    id: project.id,
-    provider: project.provider,
-    githubRepoId: project.githubRepoId,
-    githubInstallationId: project.githubInstallationId,
-    owner: project.owner,
-    name: project.name,
-    fullName: project.fullName,
-    defaultBranch: project.defaultBranch,
-    cloneUrl: project.cloneUrl,
-    localPath: project.localPath,
-    status: project.status,
-    lastError: project.lastError,
-    createdAt: project.createdAt.getTime(),
-    updatedAt: project.updatedAt.getTime(),
-  };
 }
 
 function errorMessage(err: unknown): string {

--- a/components/chat/active-project.ts
+++ b/components/chat/active-project.ts
@@ -1,0 +1,24 @@
+"use client";
+
+const ACTIVE_PROJECT_KEY = "anton.activeProjectId";
+const ACTIVE_PROJECT_EVENT = "anton-active-project-change";
+
+export function readActiveProjectId(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(ACTIVE_PROJECT_KEY);
+}
+
+export function writeActiveProjectId(projectId: string): void {
+  localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+  window.dispatchEvent(
+    new CustomEvent(ACTIVE_PROJECT_EVENT, { detail: projectId }),
+  );
+}
+
+export function isActiveProjectChangeEvent(
+  event: Event,
+): event is CustomEvent<string> {
+  return event instanceof CustomEvent && typeof event.detail === "string";
+}
+
+export { ACTIVE_PROJECT_EVENT };

--- a/components/chat/chat.tsx
+++ b/components/chat/chat.tsx
@@ -23,9 +23,12 @@ import { Worklog } from "./worklog";
 import { useSessionStore } from "./session-store";
 import { useSidebar } from "./session-sidebar";
 import {
+  ACTIVE_PROJECT_EVENT,
+  isActiveProjectChangeEvent,
   readActiveProjectId,
-  type ProjectSummary,
-} from "./workspace-dialog";
+} from "./active-project";
+import type { ProjectSummary } from "@/src/lib/api-types";
+import { getJson } from "@/src/lib/client-fetch";
 import { SettingsDialog } from "./settings-dialog";
 
 interface ChatProps {
@@ -123,13 +126,12 @@ export function Chat({
   useEffect(() => {
     const onActiveProjectChange = (event: Event) => {
       if (initialProjectId) return;
-      const next = (event as CustomEvent<string>).detail;
-      setActiveProjectId(next);
+      if (isActiveProjectChangeEvent(event)) setActiveProjectId(event.detail);
     };
-    window.addEventListener("anton-active-project-change", onActiveProjectChange);
+    window.addEventListener(ACTIVE_PROJECT_EVENT, onActiveProjectChange);
     return () =>
       window.removeEventListener(
-        "anton-active-project-change",
+        ACTIVE_PROJECT_EVENT,
         onActiveProjectChange,
       );
   }, [initialProjectId]);
@@ -137,12 +139,14 @@ export function Chat({
   useEffect(() => {
     if (!effectiveProjectId) return;
     const loadProject = async () => {
-      const res = await fetch(`/api/projects/${effectiveProjectId}`, {
-        cache: "no-store",
-      });
-      if (!res.ok) return;
-      const data = (await res.json()) as { project: ProjectSummary };
-      setProject(data.project);
+      try {
+        const data = await getJson<{ project: ProjectSummary }>(
+          `/api/projects/${effectiveProjectId}`,
+        );
+        setProject(data.project);
+      } catch {
+        setProject(null);
+      }
     };
     void loadProject();
   }, [effectiveProjectId]);

--- a/components/chat/composer.tsx
+++ b/components/chat/composer.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/select";
 import type { ModelId } from "@/src/lib/models";
 import type { PermissionMode } from "@/src/agent/permissions";
-import type { ProjectSummary } from "./workspace-dialog";
+import type { ProjectSummary } from "@/src/lib/api-types";
 import { ModelPicker } from "./model-picker";
 
 interface ComposerProps {

--- a/components/chat/feedback-states.tsx
+++ b/components/chat/feedback-states.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+export function LoadingState({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <Loader2 className="size-3.5 animate-spin" />
+      {label}
+    </div>
+  );
+}
+
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
+      {message}
+    </div>
+  );
+}
+
+export function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive ring-1 ring-destructive/30">
+      {message}
+    </div>
+  );
+}

--- a/components/chat/memory-manager.tsx
+++ b/components/chat/memory-manager.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { Check, Loader2, Pencil, Plus, Trash2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProjectMemory } from "@/src/lib/api-types";
+import {
+  errorMessage,
+  getJson,
+  jsonHeaders,
+  requestJson,
+  requestOk,
+} from "@/src/lib/client-fetch";
+import { EmptyState, ErrorBanner, LoadingState } from "./feedback-states";
+
+type MemoryManagerVariant = "settings" | "compact";
+
+export function useMemories(active: boolean) {
+  const [memories, setMemories] = useState<ProjectMemory[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadMemories = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getJson<{ memories: ProjectMemory[] }>("/api/memories");
+      setMemories(data.memories);
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to load memories"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Fetching on activation updates state after the request settles.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (active) void loadMemories();
+  }, [active, loadMemories]);
+
+  const create = useCallback(
+    async (content: string) => {
+      const trimmed = content.trim();
+      if (!trimmed) return false;
+      setSaving(true);
+      try {
+        await requestJson<{ memory: ProjectMemory }>("/api/memories", {
+          method: "POST",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ content: trimmed }),
+        });
+        await loadMemories();
+        return true;
+      } catch (err) {
+        setError(errorMessage(err, "Create failed"));
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadMemories],
+  );
+
+  const update = useCallback(
+    async (id: string, content: string) => {
+      const trimmed = content.trim();
+      if (!trimmed) return false;
+      setSaving(true);
+      try {
+        await requestJson<{ memory: ProjectMemory }>(
+          `/api/memories/${encodeURIComponent(id)}`,
+          {
+            method: "PATCH",
+            headers: jsonHeaders(),
+            body: JSON.stringify({ content: trimmed }),
+          },
+        );
+        await loadMemories();
+        return true;
+      } catch (err) {
+        setError(errorMessage(err, "Update failed"));
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadMemories],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      setSaving(true);
+      try {
+        await requestOk(`/api/memories/${encodeURIComponent(id)}`, {
+          method: "DELETE",
+        });
+        await loadMemories();
+        return true;
+      } catch (err) {
+        setError(errorMessage(err, "Delete failed"));
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [loadMemories],
+  );
+
+  return {
+    memories,
+    loading,
+    saving,
+    error,
+    create,
+    update,
+    remove,
+  };
+}
+
+export function MemoryManager({
+  active,
+  variant = "compact",
+}: {
+  active: boolean;
+  variant?: MemoryManagerVariant;
+}) {
+  const { memories, loading, saving, error, create, update, remove } =
+    useMemories(active);
+  const [draft, setDraft] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingDraft, setEditingDraft] = useState("");
+  const [memoryToDelete, setMemoryToDelete] = useState<ProjectMemory | null>(
+    null,
+  );
+
+  const createMemory = async () => {
+    const ok = await create(draft);
+    if (ok) setDraft("");
+  };
+
+  const updateMemory = async (id: string) => {
+    const ok = await update(id, editingDraft);
+    if (ok) {
+      setEditingId(null);
+      setEditingDraft("");
+    }
+  };
+
+  const deleteMemory = async (id: string) => {
+    const ok = await remove(id);
+    if (ok) setMemoryToDelete(null);
+  };
+
+  const content = (
+    <>
+      {error && <ErrorBanner message={error} />}
+      <MemorySection title="New memory" variant={variant}>
+        <Textarea
+          id={variant === "compact" ? "new-memory" : undefined}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          maxLength={1000}
+          placeholder="A durable project preference or fact."
+          className="min-h-16 resize-none text-xs"
+          aria-label="New memory"
+        />
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <span className="text-xs text-muted-foreground">
+            {draft.trim().length}/1000
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void createMemory()}
+            disabled={saving || draft.trim().length === 0}
+          >
+            {saving ? <Loader2 className="animate-spin" /> : <Plus />}
+            {variant === "settings" ? "Add memory" : "Add"}
+          </Button>
+        </div>
+      </MemorySection>
+
+      <MemorySection title="Saved memories" variant={variant}>
+        {loading ? (
+          <LoadingState label="Loading memories" />
+        ) : memories.length === 0 ? (
+          <EmptyState message="No project memories saved." />
+        ) : (
+          <ul className="space-y-1.5">
+            {memories.map((memory) => {
+              const editing = editingId === memory.id;
+              return (
+                <li
+                  key={memory.id}
+                  className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
+                >
+                  {editing ? (
+                    <div className="space-y-2">
+                      <Textarea
+                        value={editingDraft}
+                        onChange={(event) =>
+                          setEditingDraft(event.target.value)
+                        }
+                        maxLength={1000}
+                        className="min-h-16 resize-none text-xs"
+                        aria-label="Edit memory"
+                      />
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditingId(null);
+                            setEditingDraft("");
+                          }}
+                        >
+                          {variant === "compact" && <X />}
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => void updateMemory(memory.id)}
+                          disabled={saving || editingDraft.trim().length === 0}
+                        >
+                          {variant === "compact" && <Check />}
+                          Save
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className={variant === "settings" ? "flex items-start justify-between gap-3" : "space-y-2"}>
+                      <div className="min-w-0">
+                        <p className="whitespace-pre-wrap text-xs leading-normal">
+                          {memory.content}
+                        </p>
+                        <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                          {memory.id}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditingId(memory.id);
+                            setEditingDraft(memory.content);
+                          }}
+                          aria-label="Edit memory"
+                        >
+                          <Pencil />
+                        </Button>
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => setMemoryToDelete(memory)}
+                          aria-label="Delete memory"
+                        >
+                          <Trash2 />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </MemorySection>
+
+      <AlertDialog
+        open={memoryToDelete !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) setMemoryToDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete memory?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the selected project memory from future Anton
+              sessions. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={saving || memoryToDelete === null}
+              onClick={(event) => {
+                event.preventDefault();
+                if (memoryToDelete) void deleteMemory(memoryToDelete.id);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+
+  if (variant === "compact") {
+    return (
+      <div className="flex h-full flex-col gap-2.5 overflow-y-auto p-3">
+        {content}
+      </div>
+    );
+  }
+
+  return <>{content}</>;
+}
+
+function MemorySection({
+  title,
+  variant,
+  children,
+}: {
+  title: string;
+  variant: MemoryManagerVariant;
+  children: ReactNode;
+}) {
+  if (variant === "settings") {
+    return (
+      <section className="rounded-md bg-card p-3 ring-1 ring-border">
+        <h3 className="mb-3 text-xs font-semibold">{title}</h3>
+        {children}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-1.5">
+      <h3 className="text-xs font-medium">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/components/chat/project-context-dialog.tsx
+++ b/components/chat/project-context-dialog.tsx
@@ -1,51 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import {
-  AlertTriangle,
-  BookOpenText,
-  Brain,
-  Check,
-  Loader2,
-  Pencil,
-  Plus,
-  Trash2,
-  X,
-} from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { BookOpenText, Brain, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { MemoryManager } from "./memory-manager";
+import { SkillsBrowser } from "./skills-browser";
 
 type Tab = "memories" | "skills";
-
-type ProjectMemory = {
-  id: string;
-  content: string;
-  createdAt: number;
-  updatedAt: number;
-};
-
-type SkillSummary = {
-  slug: string;
-  name: string;
-  description: string;
-  path: string;
-};
-
-type SkillDocument = SkillSummary & {
-  body: string;
-};
 
 interface ProjectContextDialogProps {
   open: boolean;
@@ -81,14 +44,12 @@ export function ProjectContextDialog({
     >
       <div className="flex h-[min(680px,calc(100vh-2rem))] w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-card shadow-none ring-1 ring-border">
         <header className="flex h-10 items-center justify-between gap-2 border-b border-border px-3">
-          <div className="min-w-0">
-            <h2
-              id="project-context-title"
-              className="text-xs font-semibold tracking-tight"
-            >
-              Project Context
-            </h2>
-          </div>
+          <h2
+            id="project-context-title"
+            className="truncate text-xs font-semibold tracking-tight"
+          >
+            Project Context
+          </h2>
           <Button
             type="button"
             variant="ghost"
@@ -116,9 +77,9 @@ export function ProjectContextDialog({
 
         <div className="min-h-0 flex-1 overflow-hidden">
           {tab === "memories" ? (
-            <MemoryPanel active={open && tab === "memories"} />
+            <MemoryManager active={open && tab === "memories"} />
           ) : (
-            <SkillsPanel active={open && tab === "skills"} />
+            <SkillsBrowser active={open && tab === "skills"} />
           )}
         </div>
       </div>
@@ -133,7 +94,7 @@ function TabButton({
 }: {
   active: boolean;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button
@@ -148,409 +109,5 @@ function TabButton({
     >
       {children}
     </button>
-  );
-}
-
-function MemoryPanel({ active }: { active: boolean }) {
-  const [memories, setMemories] = useState<ProjectMemory[]>([]);
-  const [draft, setDraft] = useState("");
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingDraft, setEditingDraft] = useState("");
-  const [memoryToDelete, setMemoryToDelete] = useState<ProjectMemory | null>(
-    null,
-  );
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadMemories = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/memories", { cache: "no-store" });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as { memories: ProjectMemory[] };
-      setMemories(data.memories);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load memories");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    // Fetching on tab activation updates state after the request settles.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (active) void loadMemories();
-  }, [active]);
-
-  const create = async () => {
-    const content = draft.trim();
-    if (!content) return;
-    setSaving(true);
-    try {
-      const res = await fetch("/api/memories", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDraft("");
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Create failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const update = async (id: string) => {
-    const content = editingDraft.trim();
-    if (!content) return;
-    setSaving(true);
-    try {
-      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setEditingId(null);
-      setEditingDraft("");
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Update failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const remove = async (id: string) => {
-    setSaving(true);
-    try {
-      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-      if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}`);
-      setMemoryToDelete(null);
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Delete failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <>
-      <div className="flex h-full flex-col gap-2.5 overflow-y-auto p-3">
-        <div className="space-y-1.5">
-          <label htmlFor="new-memory" className="text-xs font-medium">
-            New memory
-          </label>
-          <Textarea
-            id="new-memory"
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            maxLength={1000}
-            placeholder="A durable project preference or fact."
-            className="min-h-16 resize-none text-xs"
-          />
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-[11px] text-muted-foreground">
-              {draft.trim().length}/1000
-            </span>
-            <Button
-              type="button"
-              size="sm"
-              onClick={create}
-              disabled={saving || draft.trim().length === 0}
-            >
-              {saving ? <Loader2 className="animate-spin" /> : <Plus />}
-              Add
-            </Button>
-          </div>
-        </div>
-
-        {error && <ErrorBanner message={error} />}
-
-        {loading ? (
-          <LoadingState label="Loading memories" />
-        ) : memories.length === 0 ? (
-          <EmptyState message="No project memories saved." />
-        ) : (
-          <ul className="space-y-1.5">
-            {memories.map((memory) => {
-              const editing = editingId === memory.id;
-              return (
-                <li
-                  key={memory.id}
-                  className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
-                >
-                  {editing ? (
-                    <div className="space-y-2">
-                      <Textarea
-                        value={editingDraft}
-                        onChange={(event) =>
-                          setEditingDraft(event.target.value)
-                        }
-                        maxLength={1000}
-                        className="min-h-16 resize-none text-xs"
-                        aria-label="Edit memory"
-                      />
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => {
-                            setEditingId(null);
-                            setEditingDraft("");
-                          }}
-                        >
-                          <X />
-                          Cancel
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          onClick={() => update(memory.id)}
-                          disabled={saving || editingDraft.trim().length === 0}
-                        >
-                          <Check />
-                          Save
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="space-y-2">
-                      <p className="whitespace-pre-wrap text-xs leading-normal">
-                        {memory.content}
-                      </p>
-                      <div className="flex items-center justify-between gap-3">
-                        <span className="font-mono text-[10px] text-muted-foreground">
-                          {memory.id}
-                        </span>
-                        <div className="flex items-center gap-1">
-                          <Button
-                            type="button"
-                            size="icon-sm"
-                            variant="ghost"
-                            onClick={() => {
-                              setEditingId(memory.id);
-                              setEditingDraft(memory.content);
-                            }}
-                            aria-label="Edit memory"
-                          >
-                            <Pencil />
-                          </Button>
-                          <Button
-                            type="button"
-                            size="icon-sm"
-                            variant="ghost"
-                            onClick={() => setMemoryToDelete(memory)}
-                            aria-label="Delete memory"
-                          >
-                            <Trash2 />
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-      <AlertDialog
-        open={memoryToDelete !== null}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setMemoryToDelete(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete memory?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This removes the selected project memory from future Anton
-              sessions. This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={saving || memoryToDelete === null}
-              onClick={(event) => {
-                event.preventDefault();
-                if (memoryToDelete) void remove(memoryToDelete.id);
-              }}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
-}
-
-function SkillsPanel({ active }: { active: boolean }) {
-  const [skills, setSkills] = useState<SkillSummary[]>([]);
-  const [warnings, setWarnings] = useState<string[]>([]);
-  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
-  const [selectedSkill, setSelectedSkill] = useState<SkillDocument | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [skillLoading, setSkillLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!active) return;
-    const loadSkills = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch("/api/skills", { cache: "no-store" });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = (await res.json()) as {
-          skills: SkillSummary[];
-          warnings: string[];
-        };
-        setSkills(data.skills);
-        setWarnings(data.warnings);
-        setSelectedSlug((current) =>
-          current && data.skills.some((skill) => skill.slug === current)
-            ? current
-            : data.skills[0]?.slug ?? null,
-        );
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load skills");
-      } finally {
-        setLoading(false);
-      }
-    };
-    void loadSkills();
-  }, [active]);
-
-  useEffect(() => {
-    if (!selectedSlug) {
-      return;
-    }
-    const loadSkill = async () => {
-      setSkillLoading(true);
-      try {
-        const res = await fetch(`/api/skills/${encodeURIComponent(selectedSlug)}`, {
-          cache: "no-store",
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = (await res.json()) as { skill: SkillDocument };
-        setSelectedSkill(data.skill);
-        setError(null);
-      } catch (err) {
-        setSelectedSkill(null);
-        setError(err instanceof Error ? err.message : "Failed to load skill");
-      } finally {
-        setSkillLoading(false);
-      }
-    };
-    void loadSkill();
-  }, [selectedSlug]);
-
-  return (
-    <div className="grid h-full min-h-0 grid-cols-1 md:grid-cols-[210px_1fr]">
-      <aside className="min-h-0 overflow-y-auto border-b border-border bg-background/20 p-2 md:border-b-0 md:border-r">
-        {loading ? (
-          <LoadingState label="Loading skills" />
-        ) : skills.length === 0 ? (
-          <EmptyState message="No workspace skills found." />
-        ) : (
-          <ul className="space-y-1">
-            {skills.map((skill) => (
-              <li key={skill.slug}>
-                <button
-                  type="button"
-                  onClick={() => setSelectedSlug(skill.slug)}
-                  className={cn(
-                    "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
-                    selectedSlug === skill.slug
-                      ? "bg-secondary text-foreground"
-                      : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
-                  )}
-                >
-                  <span className="block truncate font-medium">{skill.name}</span>
-                  <span className="block truncate font-mono text-[10px]">
-                    {skill.slug}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </aside>
-
-      <section className="min-h-0 overflow-y-auto p-3">
-        {error && <ErrorBanner message={error} />}
-
-        {warnings.length > 0 && (
-          <div className="mb-2.5 space-y-1 rounded-md bg-amber-500/10 p-2.5 text-xs text-amber-700 ring-1 ring-amber-500/30 dark:text-amber-300">
-            <div className="flex items-center gap-2 font-medium">
-              <AlertTriangle className="size-3.5" />
-              Skill warnings
-            </div>
-            <ul className="list-disc space-y-1 pl-5">
-              {warnings.map((warning) => (
-                <li key={warning}>{warning}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {!selectedSlug ? (
-          <EmptyState message="Select a skill to inspect it." />
-        ) : skillLoading ? (
-          <LoadingState label="Loading skill" />
-        ) : selectedSkill ? (
-          <article className="space-y-3">
-            <div>
-              <h3 className="text-xs font-semibold">{selectedSkill.name}</h3>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {selectedSkill.description || "No description."}
-              </p>
-              <p className="mt-1 font-mono text-[10px] text-muted-foreground">
-                {selectedSkill.path}
-              </p>
-            </div>
-            <pre className="max-h-[420px] overflow-auto rounded-md bg-background/60 p-2.5 text-xs leading-normal whitespace-pre-wrap ring-1 ring-border">
-              {selectedSkill.body || "(empty)"}
-            </pre>
-          </article>
-        ) : null}
-      </section>
-    </div>
-  );
-}
-
-function LoadingState({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <Loader2 className="size-3.5 animate-spin" />
-      {label}
-    </div>
-  );
-}
-
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
-      {message}
-    </div>
-  );
-}
-
-function ErrorBanner({ message }: { message: string }) {
-  return (
-    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive ring-1 ring-destructive/30">
-      {message}
-    </div>
   );
 }

--- a/components/chat/run-trace.tsx
+++ b/components/chat/run-trace.tsx
@@ -15,9 +15,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
-  Clock3,
   Loader2,
-  TerminalSquare,
   XCircle,
 } from "lucide-react";
 
@@ -32,6 +30,11 @@ import {
   type AntonUIMessage,
   type ToolTraceEntry,
 } from "@/src/lib/trace";
+import {
+  previewToolInput,
+  safeStringify,
+  traceToolStateMeta,
+} from "./tool-display";
 
 const DISCLOSURE_ANIMATION =
   "overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
@@ -242,7 +245,7 @@ function ToolRow({
   entry: ToolTraceEntry;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
-  const meta = toolStateMeta(entry.state);
+  const meta = traceToolStateMeta(entry.state);
   const approvalId =
     entry.state === "approval-requested" &&
     typeof entry.approvalId === "string"
@@ -251,7 +254,7 @@ function ToolRow({
   const needsApproval = approvalId !== undefined;
   const showDetails = entry.name === "bash";
   const title = toolTitle(entry);
-  const preview = previewInput(entry.input);
+  const preview = previewToolInput(entry.input);
   const showPreview = preview.length > 0 && preview !== title.target;
   return (
     <Disclosure
@@ -577,66 +580,8 @@ function eventMeta(event: AntonActivityEvent) {
   return { Icon: CheckCircle2, iconClass: "text-emerald-400" };
 }
 
-function toolStateMeta(state: ToolTraceEntry["state"]) {
-  switch (state) {
-    case "input-streaming":
-      return {
-        label: "streaming",
-        Icon: Loader2,
-        iconClass: "animate-spin text-sky-400",
-        textClass: "text-sky-400",
-      };
-    case "input-available":
-      return {
-        label: "running",
-        Icon: Clock3,
-        iconClass: "text-sky-400",
-        textClass: "text-sky-400",
-      };
-    case "approval-requested":
-      return {
-        label: "approval",
-        Icon: AlertCircle,
-        iconClass: "text-amber-400",
-        textClass: "text-amber-400",
-      };
-    case "approval-responded":
-      return {
-        label: "approved",
-        Icon: CheckCircle2,
-        iconClass: "text-muted-foreground",
-        textClass: "text-muted-foreground",
-      };
-    case "output-available":
-      return {
-        label: "done",
-        Icon: iconForTool,
-        iconClass: "text-emerald-400",
-        textClass: "text-emerald-400",
-      };
-    case "output-error":
-      return {
-        label: "error",
-        Icon: XCircle,
-        iconClass: "text-destructive",
-        textClass: "text-destructive",
-      };
-    case "output-denied":
-      return {
-        label: "denied",
-        Icon: XCircle,
-        iconClass: "text-destructive",
-        textClass: "text-destructive",
-      };
-  }
-}
-
-function iconForTool({ className }: { className?: string }) {
-  return <TerminalSquare className={className} />;
-}
-
 function toolTitle(entry: ToolTraceEntry): { verb: string; target?: string } {
-  const target = previewInput(entry.input);
+  const target = previewToolInput(entry.input);
   switch (entry.name) {
     case "bash":
       return { verb: "Ran", target };
@@ -653,34 +598,6 @@ function toolTitle(entry: ToolTraceEntry): { verb: string; target?: string } {
         verb: entry.activity?.label ?? entry.name,
         target: target.length > 0 ? target : undefined,
       };
-  }
-}
-
-function previewInput(input: unknown): string {
-  if (typeof input === "object" && input !== null) {
-    const record = input as Record<string, unknown>;
-    const command = pickString(record, "command");
-    const path = pickString(record, "path");
-    const pattern = pickString(record, "pattern");
-    if (command) return command;
-    if (path) return path;
-    if (pattern) return pattern;
-  }
-  return safeStringify(input);
-}
-
-function pickString(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-function safeStringify(value: unknown): string {
-  if (value === undefined) return "";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
   }
 }
 

--- a/components/chat/session-sidebar.tsx
+++ b/components/chat/session-sidebar.tsx
@@ -34,7 +34,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useSessionStore, type SessionSummary } from "./session-store";
 import { SettingsDialog } from "./settings-dialog";
-import { readActiveProjectId } from "./workspace-dialog";
+import { readActiveProjectId } from "./active-project";
 
 type SidebarContextValue = {
   open: boolean;

--- a/components/chat/settings-dialog.tsx
+++ b/components/chat/settings-dialog.tsx
@@ -2,72 +2,35 @@
 
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import {
-  AlertTriangle,
   Check,
   ChevronLeft,
   FolderGit2,
   GitBranch,
   Loader2,
-  Pencil,
-  Plus,
   RefreshCw,
   Search,
-  Trash2,
   X,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import type { ProjectSummary } from "./workspace-dialog";
-
-const ACTIVE_PROJECT_KEY = "anton.activeProjectId";
+import type {
+  GitHubRepositorySummary,
+  ProjectSummary,
+  WorkspaceSettingsSummary,
+} from "@/src/lib/api-types";
+import {
+  errorMessage,
+  getJson,
+  jsonHeaders,
+  requestJson,
+} from "@/src/lib/client-fetch";
+import { EmptyState, ErrorBanner } from "./feedback-states";
+import { MemoryManager } from "./memory-manager";
+import { SkillsBrowser } from "./skills-browser";
+import { writeActiveProjectId } from "./active-project";
 
 type SettingsSection = "workspaces" | "memories" | "skills";
-
-type WorkspaceSettings = {
-  localWorkspacesRoot: string | null;
-  resolvedLocalWorkspacesRoot: string | null;
-  source: "database" | "env" | "default";
-  exists: boolean;
-};
-
-type GitHubRepository = {
-  id: number;
-  installationId: number;
-  fullName: string;
-  private: boolean;
-  defaultBranch: string;
-  clonedProjectId: string | null;
-};
-
-type ProjectMemory = {
-  id: string;
-  content: string;
-  createdAt: number;
-  updatedAt: number;
-};
-
-type SkillSummary = {
-  slug: string;
-  name: string;
-  description: string;
-  path: string;
-};
-
-type SkillDocument = SkillSummary & {
-  body: string;
-};
 
 interface SettingsDialogProps {
   open: boolean;
@@ -208,8 +171,22 @@ export function SettingsDialog({
                 onActiveProjectChange={onActiveProjectChange}
               />
             )}
-            {section === "memories" && <MemorySettingsPanel active />}
-            {section === "skills" && <SkillsSettingsPanel active />}
+            {section === "memories" && (
+              <SettingsPageShell
+                title="Memories"
+                description="Store durable project preferences and facts that Anton should reuse across sessions."
+              >
+                <MemoryManager active variant="settings" />
+              </SettingsPageShell>
+            )}
+            {section === "skills" && (
+              <SettingsPageShell
+                title="Skills"
+                description="Review project-local skills available to Anton from the active workspace."
+              >
+                <SkillsBrowser active variant="settings" />
+              </SettingsPageShell>
+            )}
           </div>
         </main>
       </div>
@@ -289,9 +266,9 @@ function WorkspaceSettingsPanel({
   activeProjectId: string | null;
   onActiveProjectChange: (projectId: string | null) => void;
 }) {
-  const [settings, setSettings] = useState<WorkspaceSettings | null>(null);
+  const [settings, setSettings] = useState<WorkspaceSettingsSummary | null>(null);
   const [rootDraft, setRootDraft] = useState("");
-  const [repositories, setRepositories] = useState<GitHubRepository[]>([]);
+  const [repositories, setRepositories] = useState<GitHubRepositorySummary[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -301,20 +278,16 @@ function WorkspaceSettingsPanel({
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const [settingsRes, projectsRes, reposRes] = await Promise.all([
-        fetch("/api/workspace-settings", { cache: "no-store" }),
-        fetch("/api/projects", { cache: "no-store" }),
-        fetch("/api/github/repositories", { cache: "no-store" }),
+      const [settingsData, projectsData, reposData] = await Promise.all([
+        getJson<{ settings: WorkspaceSettingsSummary }>(
+          "/api/workspace-settings",
+        ),
+        getJson<{ projects: ProjectSummary[] }>("/api/projects"),
+        getJson<{ repositories: GitHubRepositorySummary[] }>(
+          "/api/github/repositories",
+        ).catch(() => null),
       ]);
-      if (!settingsRes.ok) throw new Error(`Settings HTTP ${settingsRes.status}`);
-      if (!projectsRes.ok) throw new Error(`Projects HTTP ${projectsRes.status}`);
 
-      const settingsData = (await settingsRes.json()) as {
-        settings: WorkspaceSettings;
-      };
-      const projectsData = (await projectsRes.json()) as {
-        projects: ProjectSummary[];
-      };
       setSettings(settingsData.settings);
       setRootDraft(
         settingsData.settings.localWorkspacesRoot ??
@@ -322,18 +295,10 @@ function WorkspaceSettingsPanel({
           "",
       );
       setProjects(projectsData.projects);
-
-      if (reposRes.ok) {
-        const reposData = (await reposRes.json()) as {
-          repositories: GitHubRepository[];
-        };
-        setRepositories(reposData.repositories);
-      } else {
-        setRepositories([]);
-      }
+      setRepositories(reposData?.repositories ?? []);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load workspaces");
+      setError(errorMessage(err, "Failed to load workspaces"));
     } finally {
       setLoading(false);
     }
@@ -348,55 +313,42 @@ function WorkspaceSettingsPanel({
   const saveRoot = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/workspace-settings", {
+      await requestJson<{ settings: WorkspaceSettingsSummary }>(
+        "/api/workspace-settings",
+        {
         method: "PATCH",
-        headers: { "content-type": "application/json" },
+        headers: jsonHeaders(),
         body: JSON.stringify({ localWorkspacesRoot: rootDraft.trim() || null }),
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as
-          | { error?: string }
-          | null;
-        throw new Error(data?.error ?? `HTTP ${res.status}`);
-      }
+        },
+      );
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save root");
+      setError(errorMessage(err, "Failed to save root"));
     } finally {
       setSaving(false);
     }
   };
 
   const selectProject = (projectId: string) => {
-    localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+    writeActiveProjectId(projectId);
     onActiveProjectChange(projectId);
-    window.dispatchEvent(
-      new CustomEvent("anton-active-project-change", { detail: projectId }),
-    );
   };
 
-  const cloneRepo = async (repo: GitHubRepository) => {
+  const cloneRepo = async (repo: GitHubRepositorySummary) => {
     setCloningRepoId(repo.id);
     try {
-      const res = await fetch("/api/projects", {
+      const data = await requestJson<{ project: ProjectSummary }>("/api/projects", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: jsonHeaders(),
         body: JSON.stringify({
           repositoryId: repo.id,
           installationId: repo.installationId,
         }),
       });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as
-          | { error?: string }
-          | null;
-        throw new Error(data?.error ?? `HTTP ${res.status}`);
-      }
-      const data = (await res.json()) as { project: ProjectSummary };
       selectProject(data.project.id);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Clone failed");
+      setError(errorMessage(err, "Clone failed"));
     } finally {
       setCloningRepoId(null);
     }
@@ -514,7 +466,9 @@ function WorkspaceSettingsPanel({
                       type="button"
                       size="sm"
                       variant="outline"
-                      onClick={() => selectProject(repo.clonedProjectId as string)}
+                      onClick={() => {
+                        if (repo.clonedProjectId) selectProject(repo.clonedProjectId);
+                      }}
                     >
                       Select
                     </Button>
@@ -539,386 +493,6 @@ function WorkspaceSettingsPanel({
           </ul>
         )}
       </SettingsCard>
-    </SettingsPageShell>
-  );
-}
-
-function MemorySettingsPanel({ active }: { active: boolean }) {
-  const [memories, setMemories] = useState<ProjectMemory[]>([]);
-  const [draft, setDraft] = useState("");
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingDraft, setEditingDraft] = useState("");
-  const [memoryToDelete, setMemoryToDelete] = useState<ProjectMemory | null>(
-    null,
-  );
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const loadMemories = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/memories", { cache: "no-store" });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as { memories: ProjectMemory[] };
-      setMemories(data.memories);
-      setError(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load memories");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // Fetching on panel activation updates state after the request settles.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (active) void loadMemories();
-  }, [active, loadMemories]);
-
-  const create = async () => {
-    const content = draft.trim();
-    if (!content) return;
-    setSaving(true);
-    try {
-      const res = await fetch("/api/memories", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDraft("");
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Create failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const update = async (id: string) => {
-    const content = editingDraft.trim();
-    if (!content) return;
-    setSaving(true);
-    try {
-      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ content }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setEditingId(null);
-      setEditingDraft("");
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Update failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const remove = async (id: string) => {
-    setSaving(true);
-    try {
-      const res = await fetch(`/api/memories/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
-      if (!res.ok && res.status !== 204) throw new Error(`HTTP ${res.status}`);
-      setMemoryToDelete(null);
-      await loadMemories();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Delete failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <SettingsPageShell
-      title="Memories"
-      description="Store durable project preferences and facts that Anton should reuse across sessions."
-    >
-      {error && <ErrorBanner message={error} />}
-      <SettingsCard title="New memory">
-        <Textarea
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          maxLength={1000}
-          placeholder="A durable project preference or fact."
-          className="min-h-16 text-xs"
-          aria-label="New memory"
-        />
-        <div className="mt-2 flex items-center justify-between gap-2">
-          <span className="text-xs text-muted-foreground">
-            {draft.trim().length}/1000
-          </span>
-          <Button
-            type="button"
-            size="sm"
-            onClick={create}
-            disabled={saving || draft.trim().length === 0}
-          >
-            {saving ? <Loader2 className="animate-spin" /> : <Plus />}
-            Add memory
-          </Button>
-        </div>
-      </SettingsCard>
-
-      <SettingsCard title="Saved memories">
-        {loading ? (
-          <LoadingState label="Loading memories" />
-        ) : memories.length === 0 ? (
-          <EmptyState message="No project memories saved." />
-        ) : (
-          <ul className="space-y-1.5">
-            {memories.map((memory) => {
-              const editing = editingId === memory.id;
-              return (
-                <li
-                  key={memory.id}
-                  className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
-                >
-                  {editing ? (
-                    <div className="space-y-2">
-                      <Textarea
-                        value={editingDraft}
-                        onChange={(event) =>
-                          setEditingDraft(event.target.value)
-                        }
-                        maxLength={1000}
-                        className="min-h-16 text-xs"
-                        aria-label="Edit memory"
-                      />
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => {
-                            setEditingId(null);
-                            setEditingDraft("");
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          onClick={() => update(memory.id)}
-                          disabled={saving || editingDraft.trim().length === 0}
-                        >
-                          Save
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="whitespace-pre-wrap text-xs leading-normal">
-                          {memory.content}
-                        </p>
-                        <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
-                          {memory.id}
-                        </p>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1">
-                        <Button
-                          type="button"
-                          size="icon-sm"
-                          variant="ghost"
-                          onClick={() => {
-                            setEditingId(memory.id);
-                            setEditingDraft(memory.content);
-                          }}
-                          aria-label="Edit memory"
-                        >
-                          <Pencil />
-                        </Button>
-                        <Button
-                          type="button"
-                          size="icon-sm"
-                          variant="ghost"
-                          onClick={() => setMemoryToDelete(memory)}
-                          aria-label="Delete memory"
-                        >
-                          <Trash2 />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </SettingsCard>
-
-      <AlertDialog
-        open={memoryToDelete !== null}
-        onOpenChange={(nextOpen) => {
-          if (!nextOpen) setMemoryToDelete(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete memory?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This removes the selected project memory from future Anton
-              sessions. This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={saving || memoryToDelete === null}
-              onClick={(event) => {
-                event.preventDefault();
-                if (memoryToDelete) void remove(memoryToDelete.id);
-              }}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </SettingsPageShell>
-  );
-}
-
-function SkillsSettingsPanel({ active }: { active: boolean }) {
-  const [skills, setSkills] = useState<SkillSummary[]>([]);
-  const [warnings, setWarnings] = useState<string[]>([]);
-  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
-  const [selectedSkill, setSelectedSkill] = useState<SkillDocument | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [skillLoading, setSkillLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!active) return;
-    const loadSkills = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch("/api/skills", { cache: "no-store" });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = (await res.json()) as {
-          skills: SkillSummary[];
-          warnings: string[];
-        };
-        setSkills(data.skills);
-        setWarnings(data.warnings);
-        setSelectedSlug((current) =>
-          current && data.skills.some((skill) => skill.slug === current)
-            ? current
-            : data.skills[0]?.slug ?? null,
-        );
-        setError(null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load skills");
-      } finally {
-        setLoading(false);
-      }
-    };
-    void loadSkills();
-  }, [active]);
-
-  useEffect(() => {
-    if (!selectedSlug) return;
-    const loadSkill = async () => {
-      setSkillLoading(true);
-      try {
-        const res = await fetch(`/api/skills/${encodeURIComponent(selectedSlug)}`, {
-          cache: "no-store",
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = (await res.json()) as { skill: SkillDocument };
-        setSelectedSkill(data.skill);
-        setError(null);
-      } catch (err) {
-        setSelectedSkill(null);
-        setError(err instanceof Error ? err.message : "Failed to load skill");
-      } finally {
-        setSkillLoading(false);
-      }
-    };
-    void loadSkill();
-  }, [selectedSlug]);
-
-  return (
-    <SettingsPageShell
-      title="Skills"
-      description="Review project-local skills available to Anton from the active workspace."
-    >
-      {error && <ErrorBanner message={error} />}
-      {warnings.length > 0 && (
-        <div className="rounded-md bg-amber-500/10 p-2.5 text-xs text-amber-300 ring-1 ring-amber-500/30">
-          <div className="mb-1 flex items-center gap-2 font-medium">
-            <AlertTriangle className="size-3.5" />
-            Skill warnings
-          </div>
-          <ul className="list-disc space-y-1 pl-5">
-            {warnings.map((warning) => (
-              <li key={warning}>{warning}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      <div className="grid min-h-[440px] overflow-hidden rounded-md bg-card ring-1 ring-border lg:grid-cols-[240px_minmax(0,1fr)]">
-        <aside className="min-h-0 border-b border-border bg-background/25 p-2 lg:border-b-0 lg:border-r">
-          {loading ? (
-            <LoadingState label="Loading skills" />
-          ) : skills.length === 0 ? (
-            <EmptyState message="No workspace skills found." />
-          ) : (
-            <ul className="space-y-1">
-              {skills.map((skill) => (
-                <li key={skill.slug}>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedSlug(skill.slug)}
-                    className={cn(
-                      "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
-                      selectedSlug === skill.slug
-                        ? "bg-secondary text-foreground"
-                        : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
-                    )}
-                  >
-                    <span className="block truncate font-medium">
-                      {skill.name}
-                    </span>
-                    <span className="block truncate font-mono text-[10px]">
-                      {skill.slug}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </aside>
-        <section className="min-h-0 overflow-y-auto p-3">
-          {!selectedSlug ? (
-            <EmptyState message="Select a skill to inspect it." />
-          ) : skillLoading ? (
-            <LoadingState label="Loading skill" />
-          ) : selectedSkill ? (
-            <article>
-              <div className="mb-4">
-                <h3 className="text-xs font-semibold">{selectedSkill.name}</h3>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {selectedSkill.description || "No description."}
-                </p>
-                <p className="mt-2 font-mono text-[10px] text-muted-foreground">
-                  {selectedSkill.path}
-                </p>
-              </div>
-              <pre className="max-h-[440px] overflow-auto rounded-md bg-background/60 p-2.5 text-xs leading-normal whitespace-pre-wrap ring-1 ring-border">
-                {selectedSkill.body || "(empty)"}
-              </pre>
-            </article>
-          ) : null}
-        </section>
-      </div>
     </SettingsPageShell>
   );
 }
@@ -965,31 +539,6 @@ function SettingsCard({
       </div>
       {children}
     </section>
-  );
-}
-
-function LoadingState({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <Loader2 className="size-3.5 animate-spin" />
-      {label}
-    </div>
-  );
-}
-
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div className="rounded-md bg-background/35 px-2.5 py-3 text-xs text-muted-foreground ring-1 ring-border/70">
-      {message}
-    </div>
-  );
-}
-
-function ErrorBanner({ message }: { message: string }) {
-  return (
-    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive ring-1 ring-destructive/30">
-      {message}
-    </div>
   );
 }
 

--- a/components/chat/skills-browser.tsx
+++ b/components/chat/skills-browser.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { SkillDocument, SkillSummary } from "@/src/lib/api-types";
+import { errorMessage, getJson } from "@/src/lib/client-fetch";
+import { EmptyState, ErrorBanner, LoadingState } from "./feedback-states";
+
+type SkillsBrowserVariant = "settings" | "compact";
+
+export function useSkills(active: boolean) {
+  const [skills, setSkills] = useState<SkillSummary[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<SkillDocument | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [skillLoading, setSkillLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const loadSkills = async () => {
+      setLoading(true);
+      try {
+        const data = await getJson<{
+          skills: SkillSummary[];
+          warnings: string[];
+        }>("/api/skills");
+        setSkills(data.skills);
+        setWarnings(data.warnings);
+        setSelectedSlug((current) =>
+          current && data.skills.some((skill) => skill.slug === current)
+            ? current
+            : data.skills[0]?.slug ?? null,
+        );
+        setError(null);
+      } catch (err) {
+        setError(errorMessage(err, "Failed to load skills"));
+      } finally {
+        setLoading(false);
+      }
+    };
+    void loadSkills();
+  }, [active]);
+
+  useEffect(() => {
+    if (!selectedSlug) return;
+    const loadSkill = async () => {
+      setSkillLoading(true);
+      try {
+        const data = await getJson<{ skill: SkillDocument }>(
+          `/api/skills/${encodeURIComponent(selectedSlug)}`,
+        );
+        setSelectedSkill(data.skill);
+        setError(null);
+      } catch (err) {
+        setSelectedSkill(null);
+        setError(errorMessage(err, "Failed to load skill"));
+      } finally {
+        setSkillLoading(false);
+      }
+    };
+    void loadSkill();
+  }, [selectedSlug]);
+
+  return {
+    skills,
+    warnings,
+    selectedSlug,
+    selectedSkill,
+    loading,
+    skillLoading,
+    error,
+    setSelectedSlug,
+  };
+}
+
+export function SkillsBrowser({
+  active,
+  variant = "compact",
+}: {
+  active: boolean;
+  variant?: SkillsBrowserVariant;
+}) {
+  const {
+    skills,
+    warnings,
+    selectedSlug,
+    selectedSkill,
+    loading,
+    skillLoading,
+    error,
+    setSelectedSlug,
+  } = useSkills(active);
+
+  return (
+    <div className={browserClassName(variant)}>
+      <aside className={sidebarClassName(variant)}>
+        {loading ? (
+          <LoadingState label="Loading skills" />
+        ) : skills.length === 0 ? (
+          <EmptyState message="No workspace skills found." />
+        ) : (
+          <ul className="space-y-1">
+            {skills.map((skill) => (
+              <li key={skill.slug}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedSlug(skill.slug)}
+                  className={cn(
+                    "w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                    selectedSlug === skill.slug
+                      ? "bg-secondary text-foreground"
+                      : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
+                  )}
+                >
+                  <span className="block truncate font-medium">
+                    {skill.name}
+                  </span>
+                  <span className="block truncate font-mono text-[10px]">
+                    {skill.slug}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+      <section className="min-h-0 overflow-y-auto p-3">
+        {error && <ErrorBanner message={error} />}
+        {warnings.length > 0 && <SkillWarnings warnings={warnings} />}
+        {!selectedSlug ? (
+          <EmptyState message="Select a skill to inspect it." />
+        ) : skillLoading ? (
+          <LoadingState label="Loading skill" />
+        ) : selectedSkill ? (
+          <article className={variant === "settings" ? undefined : "space-y-3"}>
+            <div className={variant === "settings" ? "mb-4" : undefined}>
+              <h3 className="text-xs font-semibold">{selectedSkill.name}</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {selectedSkill.description || "No description."}
+              </p>
+              <p className="mt-2 font-mono text-[10px] text-muted-foreground">
+                {selectedSkill.path}
+              </p>
+            </div>
+            <pre className={preClassName(variant)}>
+              {selectedSkill.body || "(empty)"}
+            </pre>
+          </article>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function SkillWarnings({ warnings }: { warnings: string[] }) {
+  return (
+    <div className="mb-2.5 space-y-1 rounded-md bg-amber-500/10 p-2.5 text-xs text-amber-700 ring-1 ring-amber-500/30 dark:text-amber-300">
+      <div className="flex items-center gap-2 font-medium">
+        <AlertTriangle className="size-3.5" />
+        Skill warnings
+      </div>
+      <ul className="list-disc space-y-1 pl-5">
+        {warnings.map((warning) => (
+          <li key={warning}>{warning}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function browserClassName(variant: SkillsBrowserVariant): string {
+  if (variant === "settings") {
+    return "grid min-h-[440px] overflow-hidden rounded-md bg-card ring-1 ring-border lg:grid-cols-[240px_minmax(0,1fr)]";
+  }
+  return "grid h-full min-h-0 grid-cols-1 md:grid-cols-[210px_1fr]";
+}
+
+function sidebarClassName(variant: SkillsBrowserVariant): string {
+  if (variant === "settings") {
+    return "min-h-0 border-b border-border bg-background/25 p-2 lg:border-b-0 lg:border-r";
+  }
+  return "min-h-0 overflow-y-auto border-b border-border bg-background/20 p-2 md:border-b-0 md:border-r";
+}
+
+function preClassName(variant: SkillsBrowserVariant): string {
+  const maxHeight = variant === "settings" ? "max-h-[440px]" : "max-h-[420px]";
+  return `${maxHeight} overflow-auto rounded-md bg-background/60 p-2.5 text-xs leading-normal whitespace-pre-wrap ring-1 ring-border`;
+}

--- a/components/chat/tool-card.tsx
+++ b/components/chat/tool-card.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import type { ChatAddToolApproveResponseFunction } from "ai";
+import type { ToolState } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { DiffView } from "./diff-view";
-
-type ToolState =
-  | "input-streaming"
-  | "input-available"
-  | "approval-requested"
-  | "approval-responded"
-  | "output-available"
-  | "output-error"
-  | "output-denied";
+import {
+  isOkWriteFileOutput,
+  pickString,
+  safeStringify,
+  toolStateBadge,
+} from "./tool-display";
 
 interface ToolCardProps {
   name: string;
@@ -33,7 +31,7 @@ export function ToolCard({
   approvalId,
   onApproval,
 }: ToolCardProps) {
-  const { label, tone } = stateBadge(state);
+  const { label, tone } = toolStateBadge(state);
 
   return (
     <details
@@ -42,9 +40,9 @@ export function ToolCard({
         "bg-card/50 text-foreground ring-1 ring-border",
       )}
     >
-      <summary className="flex items-center justify-between gap-2 cursor-pointer select-none px-3 py-2">
-        <span className="flex items-center gap-2 min-w-0">
-          <span className="font-mono text-[11px] font-semibold truncate">
+      <summary className="flex cursor-pointer select-none items-center justify-between gap-2 px-3 py-2">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-[11px] font-semibold">
             {name}
           </span>
           <span
@@ -58,7 +56,7 @@ export function ToolCard({
         </span>
       </summary>
 
-      <div className="px-3 pb-3 pt-1 space-y-2">
+      <div className="space-y-2 px-3 pb-3 pt-1">
         {name === "write_file" ? (
           <WriteFileBody input={input} output={output} state={state} />
         ) : (
@@ -130,33 +128,35 @@ function WriteFileBody({
 }) {
   const nextContent = pickString(input, "content");
   const relPath = pickString(input, "path");
-
   const showDiff =
-    state === "output-available" && isOkWriteFileOutput(output) && nextContent !== undefined;
+    state === "output-available" &&
+    isOkWriteFileOutput(output) &&
+    nextContent !== undefined;
 
   if (showDiff) {
-    const out = output as WriteFileOkOutput;
     return (
       <div className="space-y-2">
         <Section title="file">
-          <span className="font-mono text-[11px]">{out.path ?? relPath ?? "?"}</span>
+          <span className="font-mono text-[11px]">
+            {output.path ?? relPath ?? "?"}
+          </span>
         </Section>
-        {out.previousTruncated ? (
+        {output.previousTruncated ? (
           <div className="rounded bg-background/60 px-3 py-2 text-[11px] text-muted-foreground ring-1 ring-border">
-            Existing file was too large to diff inline ({out.bytesWritten} bytes written).
+            Existing file was too large to diff inline ({output.bytesWritten}{" "}
+            bytes written).
           </div>
         ) : (
           <DiffView
-            previous={out.previousContent ?? ""}
-            next={nextContent ?? ""}
-            newFile={out.existed === false}
+            previous={output.previousContent ?? ""}
+            next={nextContent}
+            newFile={output.existed === false}
           />
         )}
       </div>
     );
   }
 
-  // Fallback for pre-output states: just show the file path + content preview.
   return (
     <div className="space-y-2">
       {relPath && (
@@ -173,30 +173,6 @@ function WriteFileBody({
       )}
     </div>
   );
-}
-
-type WriteFileOkOutput = {
-  ok: true;
-  path?: string;
-  bytesWritten?: number;
-  existed?: boolean;
-  previousContent?: string;
-  previousTruncated?: boolean;
-};
-
-function isOkWriteFileOutput(value: unknown): value is WriteFileOkOutput {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "ok" in value &&
-    (value as { ok: unknown }).ok === true
-  );
-}
-
-function pickString(value: unknown, key: string): string | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const v = (value as Record<string, unknown>)[key];
-  return typeof v === "string" ? v : undefined;
 }
 
 function Section({
@@ -221,52 +197,4 @@ function Section({
       <div className="font-mono text-[11px] leading-snug">{children}</div>
     </div>
   );
-}
-
-function stateBadge(state: ToolState): { label: string; tone: string } {
-  switch (state) {
-    case "input-streaming":
-      return {
-        label: "calling…",
-        tone: "bg-secondary text-muted-foreground",
-      };
-    case "input-available":
-      return {
-        label: "running…",
-        tone: "bg-secondary text-muted-foreground",
-      };
-    case "approval-requested":
-      return {
-        label: "needs approval",
-        tone: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
-      };
-    case "approval-responded":
-      return {
-        label: "approved",
-        tone: "bg-secondary text-muted-foreground",
-      };
-    case "output-available":
-      return {
-        label: "done",
-        tone: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
-      };
-    case "output-error":
-      return {
-        label: "error",
-        tone: "bg-destructive/15 text-destructive",
-      };
-    case "output-denied":
-      return {
-        label: "denied",
-        tone: "bg-destructive/15 text-destructive",
-      };
-  }
-}
-
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 }

--- a/components/chat/tool-display.tsx
+++ b/components/chat/tool-display.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  TerminalSquare,
+  XCircle,
+} from "lucide-react";
+
+import type { ToolTraceEntry, ToolState } from "@/src/lib/trace";
+
+export type WriteFileOkOutput = {
+  ok: true;
+  path?: string;
+  bytesWritten?: number;
+  existed?: boolean;
+  previousContent?: string;
+  previousTruncated?: boolean;
+};
+
+export function isOkWriteFileOutput(
+  value: unknown,
+): value is WriteFileOkOutput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    (value as { ok: unknown }).ok === true
+  );
+}
+
+export function pickString(
+  value: unknown,
+  key: string,
+): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  return typeof record[key] === "string" ? record[key] : undefined;
+}
+
+export function previewToolInput(input: unknown): string {
+  if (typeof input === "object" && input !== null) {
+    return (
+      pickString(input, "command") ??
+      pickString(input, "path") ??
+      pickString(input, "pattern") ??
+      pickString(input, "slug") ??
+      pickString(input, "task") ??
+      safeStringify(input)
+    );
+  }
+  return safeStringify(input);
+}
+
+export function safeStringify(value: unknown): string {
+  if (value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function toolStateMeta(state: ToolState) {
+  switch (state) {
+    case "input-streaming":
+      return {
+        label: "streaming",
+        Icon: Loader2,
+        iconClass: "animate-spin text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "input-available":
+      return {
+        label: "running",
+        Icon: Clock3,
+        iconClass: "text-sky-400",
+        textClass: "text-sky-400",
+      };
+    case "approval-requested":
+      return {
+        label: "approval",
+        Icon: AlertCircle,
+        iconClass: "text-amber-400",
+        textClass: "text-amber-400",
+      };
+    case "approval-responded":
+      return {
+        label: "approved",
+        Icon: CheckCircle2,
+        iconClass: "text-muted-foreground",
+        textClass: "text-muted-foreground",
+      };
+    case "output-available":
+      return {
+        label: "done",
+        Icon: CheckCircle2,
+        iconClass: "text-emerald-400",
+        textClass: "text-emerald-400",
+      };
+    case "output-error":
+      return {
+        label: "error",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+    case "output-denied":
+      return {
+        label: "denied",
+        Icon: XCircle,
+        iconClass: "text-destructive",
+        textClass: "text-destructive",
+      };
+  }
+}
+
+export function toolStateBadge(state: ToolState): {
+  label: string;
+  tone: string;
+} {
+  switch (state) {
+    case "input-streaming":
+      return {
+        label: "calling...",
+        tone: "bg-secondary text-muted-foreground",
+      };
+    case "input-available":
+      return {
+        label: "running...",
+        tone: "bg-secondary text-muted-foreground",
+      };
+    case "approval-requested":
+      return {
+        label: "needs approval",
+        tone: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+      };
+    case "approval-responded":
+      return {
+        label: "approved",
+        tone: "bg-secondary text-muted-foreground",
+      };
+    case "output-available":
+      return {
+        label: "done",
+        tone: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+      };
+    case "output-error":
+      return {
+        label: "error",
+        tone: "bg-destructive/15 text-destructive",
+      };
+    case "output-denied":
+      return {
+        label: "denied",
+        tone: "bg-destructive/15 text-destructive",
+      };
+  }
+}
+
+export function traceToolStateMeta(state: ToolTraceEntry["state"]) {
+  const meta = toolStateMeta(state);
+  if (state !== "output-available") return meta;
+  return {
+    ...meta,
+    Icon: iconForTool,
+  };
+}
+
+function iconForTool({ className }: { className?: string }) {
+  return <TerminalSquare className={className} />;
+}

--- a/components/chat/worklog.tsx
+++ b/components/chat/worklog.tsx
@@ -3,10 +3,7 @@
 import { useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
-  AlertCircle,
   CheckCircle2,
-  Clock3,
-  Loader2,
   TerminalSquare,
   X,
   XCircle,
@@ -16,11 +13,18 @@ import {
   getToolTraceEntries,
   type AntonUIMessage,
   type ToolTraceEntry,
-  type ToolState,
 } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { DiffView } from "./diff-view";
+import {
+  isOkWriteFileOutput,
+  pickString,
+  previewToolInput,
+  safeStringify,
+  toolStateMeta,
+  type WriteFileOkOutput,
+} from "./tool-display";
 
 export type WorklogEntry = ToolTraceEntry;
 
@@ -100,7 +104,6 @@ export function Worklog({
     </aside>
   );
 }
-
 export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
   return getToolTraceEntries(messages);
 }
@@ -114,7 +117,7 @@ function WorklogRow({
   active: boolean;
   onSelect: () => void;
 }) {
-  const state = stateMeta(entry.state);
+  const state = toolStateMeta(entry.state);
   return (
     <button
       type="button"
@@ -139,13 +142,12 @@ function WorklogRow({
           </span>
         </div>
         <p className="truncate font-mono text-[10px] text-muted-foreground">
-          {previewInput(entry.input)}
+          {previewToolInput(entry.input)}
         </p>
       </div>
     </button>
   );
 }
-
 function WorklogDetail({
   entry,
   onApproval,
@@ -153,7 +155,7 @@ function WorklogDetail({
   entry: WorklogEntry;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
-  const state = stateMeta(entry.state);
+  const state = toolStateMeta(entry.state);
   const showWriteDiff =
     entry.name === "write_file" &&
     entry.state === "output-available" &&
@@ -241,102 +243,4 @@ function LogBlock({
       </pre>
     </div>
   );
-}
-
-function stateMeta(state: ToolState) {
-  switch (state) {
-    case "input-streaming":
-      return {
-        label: "streaming",
-        Icon: Loader2,
-        iconClass: "animate-spin text-sky-400",
-        textClass: "text-sky-400",
-      };
-    case "input-available":
-      return {
-        label: "running",
-        Icon: Clock3,
-        iconClass: "text-sky-400",
-        textClass: "text-sky-400",
-      };
-    case "approval-requested":
-      return {
-        label: "approval",
-        Icon: AlertCircle,
-        iconClass: "text-amber-400",
-        textClass: "text-amber-400",
-      };
-    case "approval-responded":
-      return {
-        label: "approved",
-        Icon: CheckCircle2,
-        iconClass: "text-muted-foreground",
-        textClass: "text-muted-foreground",
-      };
-    case "output-available":
-      return {
-        label: "done",
-        Icon: CheckCircle2,
-        iconClass: "text-emerald-400",
-        textClass: "text-emerald-400",
-      };
-    case "output-error":
-      return {
-        label: "error",
-        Icon: XCircle,
-        iconClass: "text-destructive",
-        textClass: "text-destructive",
-      };
-    case "output-denied":
-      return {
-        label: "denied",
-        Icon: XCircle,
-        iconClass: "text-destructive",
-        textClass: "text-destructive",
-      };
-  }
-}
-
-function previewInput(input: unknown): string {
-  if (typeof input === "object" && input !== null) {
-    const path = pickString(input, "path");
-    const command = pickString(input, "command");
-    const pattern = pickString(input, "pattern");
-    return command ?? path ?? pattern ?? safeStringify(input);
-  }
-  return safeStringify(input);
-}
-
-type WriteFileOkOutput = {
-  ok: true;
-  path?: string;
-  bytesWritten?: number;
-  existed?: boolean;
-  previousContent?: string;
-  previousTruncated?: boolean;
-};
-
-function isOkWriteFileOutput(value: unknown): value is WriteFileOkOutput {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "ok" in value &&
-    (value as { ok: unknown }).ok === true
-  );
-}
-
-function pickString(value: unknown, key: string): string | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const v = (value as Record<string, unknown>)[key];
-  return typeof v === "string" ? v : undefined;
-}
-
-function safeStringify(value: unknown): string {
-  if (value === undefined) return "";
-  if (typeof value === "string") return value;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 }

--- a/components/chat/workspace-dialog.tsx
+++ b/components/chat/workspace-dialog.tsx
@@ -11,45 +11,18 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-
-const ACTIVE_PROJECT_KEY = "anton.activeProjectId";
-
-type WorkspaceSettings = {
-  localWorkspacesRoot: string | null;
-  resolvedLocalWorkspacesRoot: string | null;
-  source: "database" | "env" | "default";
-  exists: boolean;
-};
-
-type GitHubRepository = {
-  id: number;
-  installationId: number;
-  name: string;
-  fullName: string;
-  owner: string;
-  private: boolean;
-  defaultBranch: string;
-  htmlUrl: string;
-  clonedProjectId: string | null;
-  cloneStatus: "cloning" | "ready" | "error" | null;
-};
-
-export type ProjectSummary = {
-  id: string;
-  provider: "github";
-  githubRepoId: number;
-  githubInstallationId: number;
-  owner: string;
-  name: string;
-  fullName: string;
-  defaultBranch: string;
-  cloneUrl: string;
-  localPath: string;
-  status: "cloning" | "ready" | "error";
-  lastError: string | null;
-  createdAt: number;
-  updatedAt: number;
-};
+import type {
+  GitHubRepositorySummary,
+  ProjectSummary,
+  WorkspaceSettingsSummary,
+} from "@/src/lib/api-types";
+import {
+  errorMessage,
+  getJson,
+  jsonHeaders,
+  requestJson,
+} from "@/src/lib/client-fetch";
+import { readActiveProjectId, writeActiveProjectId } from "./active-project";
 
 interface WorkspaceDialogProps {
   open: boolean;
@@ -64,9 +37,9 @@ export function WorkspaceDialog({
   activeProjectId,
   onActiveProjectChange,
 }: WorkspaceDialogProps) {
-  const [settings, setSettings] = useState<WorkspaceSettings | null>(null);
+  const [settings, setSettings] = useState<WorkspaceSettingsSummary | null>(null);
   const [rootDraft, setRootDraft] = useState("");
-  const [repositories, setRepositories] = useState<GitHubRepository[]>([]);
+  const [repositories, setRepositories] = useState<GitHubRepositorySummary[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -76,21 +49,16 @@ export function WorkspaceDialog({
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const [settingsRes, projectsRes, reposRes] = await Promise.all([
-        fetch("/api/workspace-settings", { cache: "no-store" }),
-        fetch("/api/projects", { cache: "no-store" }),
-        fetch("/api/github/repositories", { cache: "no-store" }),
+      const [settingsData, projectsData, reposData] = await Promise.all([
+        getJson<{ settings: WorkspaceSettingsSummary }>(
+          "/api/workspace-settings",
+        ),
+        getJson<{ projects: ProjectSummary[] }>("/api/projects"),
+        getJson<{ repositories: GitHubRepositorySummary[] }>(
+          "/api/github/repositories",
+        ).catch(() => null),
       ]);
 
-      if (!settingsRes.ok) throw new Error(`Settings HTTP ${settingsRes.status}`);
-      if (!projectsRes.ok) throw new Error(`Projects HTTP ${projectsRes.status}`);
-
-      const settingsData = (await settingsRes.json()) as {
-        settings: WorkspaceSettings;
-      };
-      const projectsData = (await projectsRes.json()) as {
-        projects: ProjectSummary[];
-      };
       setSettings(settingsData.settings);
       setRootDraft(
         settingsData.settings.localWorkspacesRoot ??
@@ -98,18 +66,10 @@ export function WorkspaceDialog({
           "",
       );
       setProjects(projectsData.projects);
-
-      if (reposRes.ok) {
-        const reposData = (await reposRes.json()) as {
-          repositories: GitHubRepository[];
-        };
-        setRepositories(reposData.repositories);
-      } else {
-        setRepositories([]);
-      }
+      setRepositories(reposData?.repositories ?? []);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load workspaces");
+      setError(errorMessage(err, "Failed to load workspaces"));
     } finally {
       setLoading(false);
     }
@@ -133,54 +93,45 @@ export function WorkspaceDialog({
   const saveRoot = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/workspace-settings", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ localWorkspacesRoot: rootDraft.trim() || null }),
-      });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(data?.error ?? `HTTP ${res.status}`);
-      }
+      await requestJson<{ settings: WorkspaceSettingsSummary }>(
+        "/api/workspace-settings",
+        {
+          method: "PATCH",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ localWorkspacesRoot: rootDraft.trim() || null }),
+        },
+      );
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save root");
+      setError(errorMessage(err, "Failed to save root"));
     } finally {
       setSaving(false);
     }
   };
 
-  const cloneRepo = async (repo: GitHubRepository) => {
+  const cloneRepo = async (repo: GitHubRepositorySummary) => {
     setCloningRepoId(repo.id);
     try {
-      const res = await fetch("/api/projects", {
+      const data = await requestJson<{ project: ProjectSummary }>("/api/projects", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: jsonHeaders(),
         body: JSON.stringify({
           repositoryId: repo.id,
           installationId: repo.installationId,
         }),
       });
-      if (!res.ok) {
-        const data = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(data?.error ?? `HTTP ${res.status}`);
-      }
-      const data = (await res.json()) as { project: ProjectSummary };
       selectProject(data.project.id);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Clone failed");
+      setError(errorMessage(err, "Clone failed"));
     } finally {
       setCloningRepoId(null);
     }
   };
 
   const selectProject = (projectId: string) => {
-    localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+    writeActiveProjectId(projectId);
     onActiveProjectChange(projectId);
-    window.dispatchEvent(
-      new CustomEvent("anton-active-project-change", { detail: projectId }),
-    );
   };
 
   if (!open) return null;
@@ -334,7 +285,11 @@ export function WorkspaceDialog({
                           type="button"
                           size="sm"
                           variant="outline"
-                          onClick={() => selectProject(repo.clonedProjectId as string)}
+                          onClick={() => {
+                            if (repo.clonedProjectId) {
+                              selectProject(repo.clonedProjectId);
+                            }
+                          }}
                         >
                           Select
                         </Button>
@@ -365,10 +320,7 @@ export function WorkspaceDialog({
   );
 }
 
-export function readActiveProjectId(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(ACTIVE_PROJECT_KEY);
-}
+export { readActiveProjectId };
 
 function PanelTitle({
   icon,

--- a/src/lib/api-serializers.ts
+++ b/src/lib/api-serializers.ts
@@ -1,0 +1,30 @@
+import type { Memory, Project } from "@/src/db/schema";
+import type { ProjectMemory, ProjectSummary } from "./api-types";
+
+export function serializeProject(project: Project): ProjectSummary {
+  return {
+    id: project.id,
+    provider: project.provider,
+    githubRepoId: project.githubRepoId,
+    githubInstallationId: project.githubInstallationId,
+    owner: project.owner,
+    name: project.name,
+    fullName: project.fullName,
+    defaultBranch: project.defaultBranch,
+    cloneUrl: project.cloneUrl,
+    localPath: project.localPath,
+    status: project.status,
+    lastError: project.lastError,
+    createdAt: project.createdAt.getTime(),
+    updatedAt: project.updatedAt.getTime(),
+  };
+}
+
+export function serializeMemory(memory: Memory): ProjectMemory {
+  return {
+    id: memory.id,
+    content: memory.content,
+    createdAt: memory.createdAt.getTime(),
+    updatedAt: memory.updatedAt.getTime(),
+  };
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -1,0 +1,54 @@
+export type WorkspaceSettingsSummary = {
+  localWorkspacesRoot: string | null;
+  resolvedLocalWorkspacesRoot: string | null;
+  source: "database" | "env" | "default";
+  exists: boolean;
+};
+
+export type GitHubRepositorySummary = {
+  id: number;
+  installationId: number;
+  name?: string;
+  fullName: string;
+  owner?: string;
+  private: boolean;
+  defaultBranch: string;
+  htmlUrl?: string;
+  clonedProjectId: string | null;
+  cloneStatus?: "cloning" | "ready" | "error" | null;
+};
+
+export type ProjectSummary = {
+  id: string;
+  provider: "github";
+  githubRepoId: number;
+  githubInstallationId: number;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  cloneUrl: string;
+  localPath: string;
+  status: "cloning" | "ready" | "error";
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ProjectMemory = {
+  id: string;
+  content: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SkillSummary = {
+  slug: string;
+  name: string;
+  description: string;
+  path: string;
+};
+
+export type SkillDocument = SkillSummary & {
+  body: string;
+};

--- a/src/lib/client-fetch.ts
+++ b/src/lib/client-fetch.ts
@@ -1,0 +1,45 @@
+type JsonRequestInit = RequestInit & {
+  headers?: HeadersInit;
+};
+
+export async function getJson<T>(url: string): Promise<T> {
+  return requestJson<T>(url, { cache: "no-store" });
+}
+
+export async function requestJson<T>(
+  url: string,
+  init?: JsonRequestInit,
+): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(await responseError(res));
+  }
+  return (await res.json()) as T;
+}
+
+export async function requestOk(
+  url: string,
+  init?: JsonRequestInit,
+): Promise<void> {
+  const res = await fetch(url, init);
+  if (!res.ok && res.status !== 204) {
+    throw new Error(await responseError(res));
+  }
+}
+
+export function jsonHeaders(
+  headers?: HeadersInit,
+): HeadersInit {
+  return { ...headers, "content-type": "application/json" };
+}
+
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+async function responseError(res: Response): Promise<string> {
+  const data = (await res.json().catch(() => null)) as
+    | { error?: unknown }
+    | null;
+  return typeof data?.error === "string" ? data.error : `HTTP ${res.status}`;
+}


### PR DESCRIPTION
## Summary
- Adds shared client-safe API types, fetch helpers, and server serializers for repeated response shapes.
- Extracts reusable memory/skills UI used by Settings and Project Context.
- Extracts shared tool display helpers for tool cards, worklog, and run traces.
- Moves active-project localStorage/event helpers out of `workspace-dialog`.

Refs #25

## Verification
- `pnpm typecheck` passed.
- `pnpm lint` passed.
- `git diff --check` passed.
- `pnpm build` passed.
- Local dev server was already running at `http://localhost:3000`; root page returned HTTP 200.

## Notes
- `pnpm build` still reports a Turbopack NFT tracing warning through `app/api/projects/route.ts -> src/workspace/local.ts -> next.config.ts`. Build completed successfully; this appears related to existing filesystem/path use in project workspace handling, not this modularization behavior.
