### PR TITLE
Harden live bash streaming and run metrics

### DIFF
--- a/app/api/bash-stream/route.ts
+++ b/app/api/bash-stream/route.ts
@@ -1,0 +1,110 @@
+import { bashProgress, type BashProgressEvent } from "@/src/lib/bash-stream";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const streamId = searchParams.get("streamId");
+  const token = searchParams.get("token");
+
+  if (!streamId) {
+    return new Response("Missing streamId", { status: 400 });
+  }
+  if (!token || !bashProgress.validateToken(streamId, token)) {
+    return new Response("Invalid stream token", { status: 403 });
+  }
+
+  const state = bashProgress.getState(streamId);
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      let closed = false;
+      let unsubscribeChunk = () => {};
+      let unsubscribeEnd = () => {};
+      const heartbeat = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(": keep-alive\n\n"));
+      }, HEARTBEAT_INTERVAL_MS);
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        unsubscribeChunk();
+        unsubscribeEnd();
+        controller.close();
+      };
+
+      if (state) {
+        if (state.stdout) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "stdout", chunk: state.stdout })}\n\n`,
+            ),
+          );
+        }
+        if (state.stderr) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "stderr", chunk: state.stderr })}\n\n`,
+            ),
+          );
+        }
+        if (state.finished) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                type: "exit",
+                exitCode: state.exitCode ?? null,
+                timedOut: state.timedOut ?? false,
+                killed: state.killed ?? false,
+                failedReason: state.failedReason,
+                finished: true,
+              })}\n\n`,
+            ),
+          );
+          close();
+          return;
+        }
+      }
+
+      unsubscribeChunk = bashProgress.onChunk(
+        streamId,
+        (event: BashProgressEvent) => {
+          if (closed) return;
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+          );
+
+          if (event.type === "exit") {
+            setTimeout(() => {
+              close();
+            }, 100);
+          }
+        },
+      );
+
+      unsubscribeEnd = bashProgress.onEnd(streamId, () => {
+        close();
+      });
+
+      req.signal.addEventListener("abort", () => {
+        unsubscribeChunk();
+        unsubscribeEnd();
+        close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import {
   createUIMessageStreamResponse,
   type FinishReason,
   type LanguageModelUsage,
+  type ProviderMetadata,
   type TextStreamPart,
   type ToolSet,
   type UIMessageStreamWriter,
@@ -13,6 +14,7 @@ import { z } from "zod";
 
 import { runAgent } from "@/src/agent/loop";
 import type { PermissionMode } from "@/src/agent/permissions";
+import { bashProgress } from "@/src/lib/bash-stream";
 import {
   addSessionTokens,
   createRun,
@@ -138,8 +140,8 @@ export async function POST(req: Request) {
           onStreamPart: (part) => trace.handleStreamPart(part),
           onAbort: () => trace.finalize("aborted"),
           onError: (error) => trace.fail(error),
-          onFinish: ({ totalUsage, finishReason }) => {
-            trace.finalize("completed", totalUsage, finishReason);
+          onFinish: ({ totalUsage, finishReason, providerMetadata }) => {
+            trace.finalize("completed", totalUsage, providerMetadata, finishReason);
             const delta = totalUsage.totalTokens;
             if (typeof delta === "number" && delta > 0) {
               addSessionTokens(sessionId, delta);
@@ -265,7 +267,7 @@ function createTraceWriter({
       finishedAt: event.finishedAt ? new Date(event.finishedAt) : null,
       durationMs: event.durationMs ?? null,
       toolCallId: event.toolCallId ?? null,
-      details: event.details ?? null,
+      details: persistableEventDetails(event.details),
     });
   };
 
@@ -357,6 +359,7 @@ function createTraceWriter({
   const finalize = (
     status: Exclude<AntonRunStatus, "running">,
     usage?: LanguageModelUsage,
+    providerMetadata?: ProviderMetadata,
     finishReason?: FinishReason,
   ) => {
     if (finalized) return;
@@ -364,13 +367,26 @@ function createTraceWriter({
     settleRunningEvents(status === "completed" ? "completed" : "error");
     const finishedAt = Date.now();
     const durationMs = Math.max(0, finishedAt - startedAt);
+    const inputTokens = usage?.inputTokens;
+    const outputTokens = usage?.outputTokens;
     const totalTokens = usage?.totalTokens;
-    writeRun(status, { finishedAt, durationMs, totalTokens });
+    const costUsd = openRouterCost(providerMetadata);
+    writeRun(status, {
+      finishedAt,
+      durationMs,
+      inputTokens,
+      outputTokens,
+      totalTokens,
+      costUsd,
+    });
     updateRun(runId, {
       status,
       finishedAt: new Date(finishedAt),
       durationMs,
+      inputTokens: inputTokens ?? null,
+      outputTokens: outputTokens ?? null,
       totalTokens: totalTokens ?? null,
+      costUsd: costUsd ?? null,
       finishReason: finishReason ?? null,
     });
   };
@@ -396,13 +412,20 @@ function createTraceWriter({
       toolName: string;
       input: unknown;
     }) {
+      const details: Record<string, unknown> = {
+        toolName: event.toolName,
+        stepNumber: event.stepNumber,
+      };
+      if (event.toolName === "bash") {
+        details.streamToken = bashProgress.prepareStream(event.toolCallId);
+      }
       startEvent({
         id: `${runId}:tool:${event.toolCallId}`,
         kind: "tool",
         label: toolLabel(event.toolName, event.input),
         summary: summarizeInput(event.input),
         toolCallId: event.toolCallId,
-        details: { toolName: event.toolName, stepNumber: event.stepNumber },
+        details,
       });
     },
     finishTool(event: {
@@ -467,4 +490,26 @@ function createTraceWriter({
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function openRouterCost(providerMetadata: ProviderMetadata | undefined): number | undefined {
+  const openrouter = providerMetadata?.openrouter;
+  if (!isRecord(openrouter)) return undefined;
+  const usage = openrouter.usage;
+  if (!isRecord(usage)) return undefined;
+  const cost = usage.cost;
+  return typeof cost === "number" && Number.isFinite(cost) ? cost : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function persistableEventDetails(
+  details: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (!details) return null;
+  const persistable = { ...details };
+  delete persistable.streamToken;
+  return persistable;
 }

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -2,15 +2,30 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
-import { Check, Copy } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Check,
+  Clock,
+  Copy,
+  Cpu,
+  DollarSign,
+  Hash,
+} from "lucide-react";
 
 import {
+  getRunData,
   getToolTraceEntries,
   type AntonUIMessage,
 } from "@/src/lib/trace";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
 import { RunTraceAccordion } from "@/components/features/run-trace/run-trace";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 
 interface MessageListProps {
   messages: AntonUIMessage[];
@@ -75,6 +90,8 @@ function MessageEvent({
     ? toolResultFallbackText(message)
     : "";
   const finalText = plainText || fallbackText;
+  const responseTime = !isUser ? messageDisplayTime(message) : undefined;
+  const metrics = !isUser ? messageMetrics(message) : undefined;
 
   return (
     <div
@@ -85,7 +102,7 @@ function MessageEvent({
     >
       <div
         className={cn(
-          "max-w-full text-xs break-words",
+          "max-w-full text-xs wrap-break-word",
           isUser
             ? "max-w-[88%] rounded-md bg-card px-2.5 py-1.5 text-foreground ring-1 ring-border"
             : "w-full text-foreground",
@@ -114,7 +131,11 @@ function MessageEvent({
         )}
       </div>
       {!isUser && finalText.length > 0 && (
-        <CopyMessageButton text={finalText} />
+        <MessageActions
+          text={finalText}
+          responseTime={responseTime}
+          metrics={metrics}
+        />
       )}
     </div>
   );
@@ -148,6 +169,153 @@ function bashOutputFallback(output: unknown): string {
   return "";
 }
 
+function messageDisplayTime(message: AntonUIMessage): string | undefined {
+  const metadata = message.metadata;
+  const run = getRunData(message);
+  const timestamp = metadata?.finishedAt ?? metadata?.startedAt ?? run?.finishedAt ?? run?.startedAt;
+  if (typeof timestamp !== "number") return undefined;
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(timestamp));
+}
+
+type ResponseMetrics = {
+  model?: string;
+  durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  costUsd?: number;
+};
+
+function messageMetrics(message: AntonUIMessage): ResponseMetrics {
+  const metadata = message.metadata;
+  const run = getRunData(message);
+  return {
+    model: metadata?.model ?? run?.model,
+    durationMs: metadata?.durationMs ?? run?.durationMs,
+    inputTokens: metadata?.inputTokens ?? run?.inputTokens,
+    outputTokens: metadata?.outputTokens ?? run?.outputTokens,
+    totalTokens: metadata?.totalTokens ?? run?.totalTokens,
+    costUsd:
+      readNumber(metadata, "costUsd") ??
+      readNumber(metadata, "cost") ??
+      readNumber(run, "costUsd") ??
+      readNumber(run, "cost"),
+  };
+}
+
+function readNumber(value: unknown, key: string): number | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const entry = (value as Record<string, unknown>)[key];
+  return typeof entry === "number" && Number.isFinite(entry) ? entry : undefined;
+}
+
+function MessageActions({
+  text,
+  responseTime,
+  metrics,
+}: {
+  text: string;
+  responseTime?: string;
+  metrics?: ResponseMetrics;
+}) {
+  return (
+    <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover/msg:opacity-100 focus-within:opacity-100">
+      <CopyMessageButton text={text} />
+      {metrics && <StatsHoverCard metrics={metrics} />}
+      {responseTime && (
+        <span className="px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+          {responseTime}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function StatsHoverCard({ metrics }: { metrics: ResponseMetrics }) {
+  const modelName = formatModelName(metrics.model);
+  return (
+    <HoverCard openDelay={150} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground focus:outline-none"
+          aria-label="Response metrics"
+        >
+          <Cpu className="size-3" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-56 px-2.5 py-2">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+          <Cpu className="size-3" />
+          {modelName}
+        </div>
+        <div className="space-y-1.5 text-[10px]">
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <Hash className="size-3" />
+            <span>Total</span>
+            <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.totalTokens)}</span>
+          </div>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+            <div className="flex items-center gap-1.5">
+              <ArrowDownToLine className="size-3 text-muted-foreground" />
+              <span className="text-muted-foreground">In</span>
+              <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.inputTokens)}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <ArrowUpFromLine className="size-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Out</span>
+              <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.outputTokens)}</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+            <div className="flex items-center gap-1.5">
+              <DollarSign className="size-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Cost</span>
+              <span className="ml-auto font-mono text-foreground">{formatCost(metrics.costUsd)}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Clock className="size-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Duration</span>
+              <span className="ml-auto font-mono text-foreground">{formatDuration(metrics.durationMs)}</span>
+            </div>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function formatNumber(value: number | undefined): string {
+  return value === undefined ? "—" : new Intl.NumberFormat().format(value);
+}
+
+function formatCost(value: number | undefined): string {
+  if (value === undefined) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    currencyDisplay: "symbol",
+    maximumFractionDigits: 4,
+  })
+    .format(value)
+    .replace("US$", "$");
+}
+
+function formatDuration(value: number | undefined): string {
+  if (value === undefined) return "—";
+  if (value < 1000) return `${value}ms`;
+  return `${(value / 1000).toFixed(value < 10000 ? 1 : 0)}s`;
+}
+
+function formatModelName(value: string | undefined): string {
+  if (!value) return "—";
+  return value.split("/").at(-1) ?? value;
+}
+
 function CopyMessageButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   const onClick = async () => {
@@ -163,7 +331,7 @@ function CopyMessageButton({ text }: { text: string }) {
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover/msg:opacity-100 focus:opacity-100"
+      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground"
       aria-label={copied ? "Copied" : "Copy message"}
     >
       {copied ? (

--- a/components/features/run-trace/live-terminal.tsx
+++ b/components/features/run-trace/live-terminal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo } from "react";
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useBashStream } from "./use-bash-stream";
+import {
+  renderAnsiToHtml,
+  terminalStatus,
+  type BashOutput,
+} from "./terminal-utils";
+
+interface LiveTerminalOutputProps {
+  command?: string;
+  streamId: string;
+  streamToken?: string;
+  initialOutput?: BashOutput;
+  className?: string;
+}
+
+export function LiveTerminalOutput({
+  command,
+  streamId,
+  streamToken,
+  initialOutput,
+  className,
+}: LiveTerminalOutputProps) {
+  const streamState = useBashStream(streamId, streamToken, true);
+
+  const stdout = streamState.stdout || initialOutput?.stdout || "";
+  const stderr = streamState.stderr || initialOutput?.stderr || "";
+  const exitCode = streamState.exitCode ?? initialOutput?.exitCode;
+  const timedOut = streamState.timedOut ?? initialOutput?.timedOut;
+  const killed = streamState.killed ?? initialOutput?.killed;
+  const failedReason = streamState.failedReason ?? initialOutput?.failedReason;
+  const isRunning = Boolean(streamToken) && !streamState.finished;
+  const status = terminalStatus({
+    exitCode,
+    timedOut,
+    killed,
+    failedReason,
+  });
+
+  const stdoutHtml = useMemo(
+    () => (stdout ? renderAnsiToHtml(stdout) : null),
+    [stdout],
+  );
+  const stderrHtml = useMemo(
+    () => (stderr ? renderAnsiToHtml(stderr) : null),
+    [stderr],
+  );
+
+  const hasOutput = stdoutHtml || stderrHtml;
+
+  return (
+    <div
+      className={cn(
+        "rounded-md bg-[#0d0d0d] ring-1 ring-white/8 font-mono text-[11px] leading-relaxed overflow-hidden",
+        className,
+      )}
+    >
+      {command && (
+        <div className="flex items-start gap-1.5 border-b border-white/8 px-2 py-1">
+          <span className="shrink-0 select-none text-emerald-400">$</span>
+          <span className="text-foreground/90 whitespace-pre-wrap break-all flex-1">{command}</span>
+          {isRunning && (
+            <Loader2 className="size-3.5 animate-spin text-sky-400 shrink-0 mt-0.5" />
+          )}
+        </div>
+      )}
+      {hasOutput ? (
+        <div className="max-h-64 overflow-y-auto px-3 py-2 space-y-1">
+          {stdoutHtml && (
+            <pre
+              className="whitespace-pre-wrap wrap-break-word text-foreground/80"
+              dangerouslySetInnerHTML={{ __html: stdoutHtml }}
+            />
+          )}
+          {stderrHtml && (
+            <pre
+              className="whitespace-pre-wrap wrap-break-word text-amber-300/90"
+              dangerouslySetInnerHTML={{ __html: stderrHtml }}
+            />
+          )}
+        </div>
+      ) : isRunning ? (
+        <div className="px-3 py-2 text-muted-foreground/50 italic flex items-center gap-2">
+          <Loader2 className="size-3 animate-spin" />
+          Running...
+        </div>
+      ) : (
+        <div className="px-3 py-2 text-muted-foreground/50 italic">
+          (no output)
+        </div>
+      )}
+      {status ? (
+        <div className="border-t border-white/8 px-2 py-1">
+          <span
+            className={cn(
+              "text-[10px] font-medium",
+              status.tone === "error"
+                ? "text-red-400"
+                : "text-muted-foreground/60",
+            )}
+          >
+            {status.label}
+          </span>
+        </div>
+      ) : isRunning ? (
+        <div className="border-t border-white/8 px-2 py-1">
+          <span className="text-[10px] font-medium text-sky-400 animate-pulse">
+            Running...
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -18,8 +18,25 @@ import {
   getModelTurnSummary,
   getTraceDurationMs,
   getTraceRows,
+  groupTraceRowsByStep,
 } from "./trace-data";
-import { TraceRowView } from "./trace-rows";
+import { InlineReasoningRow, StepGroupView, TraceRowView } from "./trace-rows";
+
+function buildInterleaved(
+  rows: ReturnType<typeof getTraceRows>,
+  stepGroups: ReturnType<typeof groupTraceRowsByStep>,
+): ({ kind: "row"; row: ReturnType<typeof getTraceRows>[number] } | { kind: "group"; group: ReturnType<typeof groupTraceRowsByStep>[number] })[] {
+  const items: ({ kind: "row"; row: ReturnType<typeof getTraceRows>[number]; order: number } | { kind: "group"; group: ReturnType<typeof groupTraceRowsByStep>[number]; order: number })[] = [];
+  for (const row of rows) {
+    if (row.kind === "tool") continue;
+    items.push({ kind: "row", row, order: row.order });
+  }
+  for (const group of stepGroups) {
+    items.push({ kind: "group", group, order: group.order });
+  }
+  items.sort((a, b) => a.order - b.order);
+  return items;
+}
 
 interface RunTraceAccordionProps {
   message: AntonUIMessage;
@@ -37,8 +54,17 @@ export function RunTraceAccordion({
   const isRunning =
     (run?.status ?? metadata?.status) === "running" &&
     (status === "submitted" || status === "streaming");
+
+  const hasResponseText = useMemo(
+    () => message.parts.some((p) => p.type === "text" && (p as { text: string }).text.trim().length > 0),
+    [message.parts],
+  );
+
+  const showInline = isRunning && !hasResponseText;
+
   const now = useTick(isRunning);
   const rows = useMemo(() => getTraceRows(message), [message]);
+  const stepGroups = useMemo(() => groupTraceRowsByStep(message, rows), [message, rows]);
   const modelTurnSummary = useMemo(() => getModelTurnSummary(message), [message]);
 
   if (!run && rows.length === 0) return null;
@@ -57,10 +83,46 @@ export function RunTraceAccordion({
         ? `Worked for ${formatDuration(durationMs)}`
         : `Stopped after ${formatDuration(durationMs)}`;
 
+  if (showInline) {
+    return (
+      <div className="mb-2 w-full space-y-0 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5 px-1 py-0.5 text-[11px]">
+          <Loader2 className="size-3.5 animate-spin text-sky-400" />
+          <span className="font-medium text-foreground/90">{header}</span>
+        </div>
+        <div className="ml-1 space-y-0.5 pl-1">
+          {buildInterleaved(rows, stepGroups).map((item) =>
+            item.kind === "group" ? (
+              <StepGroupView
+                key={`step-${item.group.stepNumber}`}
+                group={item.group}
+                onApproval={onApproval}
+              />
+            ) : item.row.kind === "reasoning" ? (
+              <InlineReasoningRow
+                key={item.row.id}
+                event={item.row.event}
+                runStatus={runStatus}
+                text={item.row.text}
+              />
+            ) : (
+              <TraceRowView
+                key={item.row.id}
+                row={item.row}
+                runStatus={runStatus}
+                onApproval={onApproval}
+              />
+            ),
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Disclosure
       className="mb-2 w-full text-xs text-muted-foreground"
-      defaultOpen={isRunning}
+      defaultOpen={false}
       forceOpen={isRunning}
       trigger={({ open }) => (
         <span className="inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-[11px]">
@@ -83,17 +145,25 @@ export function RunTraceAccordion({
       )}
     >
       <div className="min-h-0 overflow-hidden">
-        <ol className="ml-2 mt-1 space-y-0 border-l border-border/70 pl-3">
-          {rows.map((row) => (
-            <li key={row.id}>
-              <TraceRowView
-                row={row}
-                runStatus={runStatus}
+        <div className="ml-2 mt-1 space-y-0 border-l border-border/70 pl-3">
+          {buildInterleaved(rows, stepGroups).map((item) =>
+            item.kind === "group" ? (
+              <StepGroupView
+                key={`step-${item.group.stepNumber}`}
+                group={item.group}
                 onApproval={onApproval}
               />
-            </li>
-          ))}
-        </ol>
+            ) : (
+              <div key={item.row.id}>
+                <TraceRowView
+                  row={item.row}
+                  runStatus={runStatus}
+                  onApproval={onApproval}
+                />
+              </div>
+            ),
+          )}
+        </div>
       </div>
     </Disclosure>
   );

--- a/components/features/run-trace/terminal-output.tsx
+++ b/components/features/run-trace/terminal-output.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  parseBashOutput,
+  renderAnsiToHtml,
+  terminalStatus,
+  type BashOutput,
+} from "./terminal-utils";
+
+interface TerminalOutputProps {
+  command?: string;
+  output: BashOutput | string | unknown;
+  className?: string;
+}
+
+export function TerminalOutput({ command, output, className }: TerminalOutputProps) {
+  const parsed = useMemo(() => parseBashOutput(output), [output]);
+
+  const stdoutHtml = useMemo(
+    () => (parsed.stdout ? renderAnsiToHtml(parsed.stdout) : null),
+    [parsed.stdout],
+  );
+  const stderrHtml = useMemo(
+    () => (parsed.stderr ? renderAnsiToHtml(parsed.stderr) : null),
+    [parsed.stderr],
+  );
+
+  const hasOutput = stdoutHtml || stderrHtml;
+  const status = terminalStatus(parsed);
+
+  return (
+    <div
+      className={cn(
+        "rounded-md bg-[#0d0d0d] ring-1 ring-white/8 font-mono text-[11px] leading-relaxed overflow-hidden",
+        className,
+      )}
+    >
+      {command && (
+        <div className="flex items-start gap-1.5 border-b border-white/8 px-2 py-1">
+          <span className="shrink-0 select-none text-emerald-400">$</span>
+          <span className="text-foreground/90 whitespace-pre-wrap break-all">{command}</span>
+        </div>
+      )}
+      {hasOutput ? (
+        <div className="max-h-64 overflow-y-auto px-3 py-2 space-y-1">
+          {stdoutHtml && (
+            <pre
+              className="whitespace-pre-wrap wrap-break-word text-foreground/80"
+              dangerouslySetInnerHTML={{ __html: stdoutHtml }}
+            />
+          )}
+          {stderrHtml && (
+            <pre
+              className="whitespace-pre-wrap wrap-break-word text-amber-300/90"
+              dangerouslySetInnerHTML={{ __html: stderrHtml }}
+            />
+          )}
+        </div>
+      ) : (
+        <div className="px-3 py-2 text-muted-foreground/50 italic">
+          (no output)
+        </div>
+      )}
+      {status && (
+        <div className="border-t border-white/8 px-2 py-1">
+          <span
+            className={cn(
+              "text-[10px] font-medium",
+              status.tone === "error"
+                ? "text-red-400"
+                : "text-muted-foreground/60",
+            )}
+          >
+            {status.label}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/run-trace/terminal-utils.ts
+++ b/components/features/run-trace/terminal-utils.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import AnsiToHtml from "ansi-to-html";
+
+export type BashFailedReason = "timeout" | "killed" | "max_buffer" | "error";
+
+export interface BashOutput {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  killed?: boolean;
+  failedReason?: BashFailedReason;
+}
+
+const converter = new AnsiToHtml({
+  fg: "#d4d4d8",
+  bg: "transparent",
+  newline: true,
+  escapeXML: true,
+  stream: false,
+});
+
+export function parseBashOutput(output: unknown): BashOutput {
+  if (typeof output === "string") return { stdout: output };
+  if (typeof output !== "object" || output === null) return {};
+
+  const record = output as Record<string, unknown>;
+  return {
+    stdout: typeof record.stdout === "string" ? record.stdout : undefined,
+    stderr: typeof record.stderr === "string" ? record.stderr : undefined,
+    exitCode:
+      typeof record.exitCode === "number" || record.exitCode === null
+        ? record.exitCode
+        : undefined,
+    timedOut:
+      typeof record.timedOut === "boolean" ? record.timedOut : undefined,
+    killed: typeof record.killed === "boolean" ? record.killed : undefined,
+    failedReason: isFailedReason(record.failedReason)
+      ? record.failedReason
+      : undefined,
+  };
+}
+
+export function renderAnsiToHtml(text: string): string {
+  try {
+    // Terminal output is untrusted; only this escaped HTML reaches dangerouslySetInnerHTML.
+    return converter.toHtml(text);
+  } catch {
+    return escapeHtml(text);
+  }
+}
+
+export function terminalStatus(
+  output: BashOutput,
+): { label: string; tone: "error" | "muted" } | undefined {
+  if (output.timedOut || output.failedReason === "timeout") {
+    return { label: "Timed out", tone: "error" };
+  }
+  if (output.killed || output.failedReason === "killed") {
+    return { label: "Killed", tone: "error" };
+  }
+  if (output.failedReason === "max_buffer") {
+    return { label: "Output limit exceeded", tone: "error" };
+  }
+  if (output.failedReason === "error") {
+    return { label: "Command failed", tone: "error" };
+  }
+  if (typeof output.exitCode === "number") {
+    return output.exitCode === 0
+      ? { label: "Exited successfully", tone: "muted" }
+      : { label: `Exit code ${output.exitCode}`, tone: "error" };
+  }
+  if (output.exitCode === null) {
+    return { label: "No exit code", tone: "error" };
+  }
+  return undefined;
+}
+
+function isFailedReason(value: unknown): value is BashFailedReason {
+  return (
+    value === "timeout" ||
+    value === "killed" ||
+    value === "max_buffer" ||
+    value === "error"
+  );
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/components/features/run-trace/tool-card.tsx
+++ b/components/features/run-trace/tool-card.tsx
@@ -49,14 +49,16 @@ export function ToolCard({
             <span className="truncate font-mono text-[11px] font-semibold">
               {name}
             </span>
-            <span
-              className={cn(
-                "shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider",
-                tone,
-              )}
-            >
-              {label}
-            </span>
+            {label.length > 0 && (
+              <span
+                className={cn(
+                  "shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider",
+                  tone,
+                )}
+              >
+                {label}
+              </span>
+            )}
           </span>
           {open ? (
             <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
@@ -73,7 +75,7 @@ export function ToolCard({
           ) : (
             input !== undefined && (
               <Section title="input">
-                <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+                <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word">
                   {safeStringify(input)}
                 </pre>
               </Section>
@@ -104,7 +106,7 @@ export function ToolCard({
             output !== undefined &&
             name !== "write_file" && (
               <Section title="output">
-                <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+                <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word">
                   {safeStringify(output)}
                 </pre>
               </Section>
@@ -112,7 +114,7 @@ export function ToolCard({
 
           {state === "output-error" && errorText && (
             <Section title="error" tone="error">
-              <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+              <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word">
                 {errorText}
               </pre>
             </Section>
@@ -178,7 +180,7 @@ function WriteFileBody({
       )}
       {nextContent !== undefined && (
         <Section title="new content">
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+          <pre className="overflow-x-auto whitespace-pre-wrap wrap-break-word">
             {nextContent}
           </pre>
         </Section>

--- a/components/features/run-trace/tool-display.tsx
+++ b/components/features/run-trace/tool-display.tsx
@@ -96,7 +96,7 @@ export function toolStateMeta(state: ToolState) {
       };
     case "output-available":
       return {
-        label: "done",
+        label: "",
         Icon: CheckCircle2,
         iconClass: "text-emerald-400",
         textClass: "text-emerald-400",
@@ -145,7 +145,7 @@ export function toolStateBadge(state: ToolState): {
       };
     case "output-available":
       return {
-        label: "done",
+        label: "",
         tone: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
       };
     case "output-error":

--- a/components/features/run-trace/tool-trace-row.tsx
+++ b/components/features/run-trace/tool-trace-row.tsx
@@ -7,7 +7,6 @@ import {
   ChevronRight,
   XCircle,
 } from "lucide-react";
-import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import { Disclosure } from "@/components/shared/disclosure";
@@ -15,10 +14,13 @@ import type { ToolTraceEntry } from "@/src/lib/trace";
 
 import { formatDuration, toolTitle } from "./trace-data";
 import {
+  pickString,
   previewToolInput,
   safeStringify,
   traceToolStateMeta,
 } from "./tool-display";
+import { TerminalOutput } from "./terminal-output";
+import { LiveTerminalOutput } from "./live-terminal";
 
 export function ToolTraceRow({
   entry,
@@ -35,6 +37,8 @@ export function ToolTraceRow({
       : undefined;
   const needsApproval = approvalId !== undefined;
   const showDetails = entry.name === "bash";
+  const forceOpen = showDetails && entry.activity?.status === "running";
+  const streamToken = pickString(entry.activity?.details, "streamToken");
   const title = toolTitle(entry);
   const preview = previewToolInput(entry.input);
   const showPreview = preview.length > 0 && preview !== title.target;
@@ -42,6 +46,7 @@ export function ToolTraceRow({
     <Disclosure
       className="py-0.5"
       disabled={needsApproval || !showDetails}
+      forceOpen={forceOpen}
       trigger={({ open }) => (
         <span className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2 rounded px-0 py-0">
           <meta.Icon className={cn("mt-0.5 size-3.5", meta.iconClass)} />
@@ -55,7 +60,7 @@ export function ToolTraceRow({
                 ) : (
                   <ChevronRight className="size-3 shrink-0" />
                 ))}
-              {entry.name !== "bash" && (
+              {entry.name !== "bash" && meta.label.length > 0 && (
                 <span className={cn("shrink-0 text-[10px]", meta.textClass)}>
                   {meta.label}
                 </span>
@@ -80,22 +85,41 @@ export function ToolTraceRow({
     >
       {showDetails && (
         <div className="min-h-0 overflow-hidden">
-          <div className="ml-5 mt-1 rounded-md bg-card/50 px-2.5 py-2 ring-1 ring-border/70">
-            <LogLine title="Input">{safeStringify(entry.input)}</LogLine>
-            {entry.state === "output-error" && entry.errorText ? (
-              <LogLine title="Error" tone="error">
-                {entry.errorText}
-              </LogLine>
-            ) : entry.output !== undefined ? (
-              <LogLine title="Output">{safeStringify(entry.output)}</LogLine>
-            ) : null}
+          <div className="ml-5 mt-1">
+            {entry.name === "bash" && entry.activity?.status === "running" && entry.activity?.toolCallId ? (
+              <LiveTerminalOutput
+                command={pickString(entry.input, "command")}
+                streamId={entry.activity.toolCallId}
+                streamToken={streamToken}
+                initialOutput={
+                  typeof entry.output === "object" && entry.output !== null
+                    ? (entry.output as {
+                        stdout?: string;
+                        stderr?: string;
+                        exitCode?: number | null;
+                        timedOut?: boolean;
+                        killed?: boolean;
+                        failedReason?: "timeout" | "killed" | "max_buffer" | "error";
+                      })
+                    : undefined
+                }
+              />
+            ) : (
+              <TerminalOutput
+                command={pickString(entry.input, "command") ?? safeStringify(entry.input)}
+                output={
+                  entry.state === "output-error" && entry.errorText
+                    ? { stderr: entry.errorText, exitCode: 1 }
+                    : entry.output
+                }
+              />
+            )}
           </div>
         </div>
       )}
     </Disclosure>
   );
 }
-
 function ToolTitle({
   title,
 }: {
@@ -115,7 +139,6 @@ function ToolTitle({
     </span>
   );
 }
-
 function ApprovalControls({
   approvalId,
   onApproval,
@@ -150,31 +173,5 @@ function ApprovalControls({
         <XCircle className="size-3.5 text-destructive" />
       </button>
     </span>
-  );
-}
-
-function LogLine({
-  title,
-  tone,
-  children,
-}: {
-  title: string;
-  tone?: "error";
-  children: ReactNode;
-}) {
-  return (
-    <div className="space-y-1 py-1">
-      <div
-        className={cn(
-          "text-[10px] font-medium uppercase text-muted-foreground",
-          tone === "error" && "text-destructive",
-        )}
-      >
-        {title}
-      </div>
-      <pre className="max-h-32 overflow-auto font-mono text-[10px] leading-relaxed text-foreground/85 whitespace-pre-wrap">
-        {children}
-      </pre>
-    </div>
   );
 }

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -9,6 +9,13 @@ import {
 
 import { previewToolInput } from "./tool-display";
 
+export type StepGroup = {
+  stepNumber: number;
+  order: number;
+  toolRows: TraceRow[];
+  summary: string;
+};
+
 export type TraceRow =
   | {
       id: string;
@@ -83,6 +90,98 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   });
 
   return rows.sort((a, b) => a.order - b.order);
+}
+
+export function groupTraceRowsByStep(
+  _message: AntonUIMessage,
+  rows: TraceRow[],
+): StepGroup[] {
+  const orderedRows = rows.toSorted((a, b) => a.order - b.order);
+  const reasoningRows = orderedRows.filter((row) => row.kind === "reasoning");
+  const groups: StepGroup[] = [];
+
+  const addGroup = (toolRows: TraceRow[]) => {
+    if (toolRows.length === 0) return;
+    groups.push({
+      stepNumber: groups.length,
+      order: toolRows[0]?.order ?? 500,
+      toolRows,
+      summary: buildStepSummary(toolRows),
+    });
+  };
+
+  if (reasoningRows.length === 0) {
+    addGroup(orderedRows.filter((row) => row.kind === "tool"));
+    return groups;
+  }
+
+  addGroup(
+    orderedRows.filter(
+      (row) => row.kind === "tool" && row.order < reasoningRows[0].order,
+    ),
+  );
+
+  reasoningRows.forEach((reasoningRow, index) => {
+    const nextReasoningRow = reasoningRows[index + 1];
+    addGroup(
+      orderedRows.filter(
+        (row) =>
+          row.kind === "tool" &&
+          row.order > reasoningRow.order &&
+          (nextReasoningRow === undefined ||
+            row.order < nextReasoningRow.order),
+      ),
+    );
+  });
+
+  return groups;
+}
+
+function buildStepSummary(toolRows: TraceRow[]): string {
+  const counts: Record<string, number> = {};
+  for (const row of toolRows) {
+    if (row.kind !== "tool") continue;
+    const name = row.tool.name;
+    if (name === "bash") {
+      counts["command"] = (counts["command"] ?? 0) + 1;
+    } else if (name === "read_file") {
+      counts["file"] = (counts["file"] ?? 0) + 1;
+    } else if (name === "write_file") {
+      counts["edit"] = (counts["edit"] ?? 0) + 1;
+    } else if (name === "grep") {
+      counts["search"] = (counts["search"] ?? 0) + 1;
+    } else if (name === "glob") {
+      counts["list"] = (counts["list"] ?? 0) + 1;
+    } else {
+      counts["action"] = (counts["action"] ?? 0) + 1;
+    }
+  }
+
+  const parts: string[] = [];
+  if (counts["list"]) {
+    parts.push(`Listed ${counts["list"]} glob${counts["list"] > 1 ? "s" : ""}`);
+  }
+  if (counts["search"]) {
+    parts.push(`searched ${counts["search"]} time${counts["search"] > 1 ? "s" : ""}`);
+  }
+  if (counts["file"]) {
+    parts.push(`read ${counts["file"]} file${counts["file"] > 1 ? "s" : ""}`);
+  }
+  if (counts["command"]) {
+    parts.push(`ran ${counts["command"]} command${counts["command"] > 1 ? "s" : ""}`);
+  }
+  if (counts["edit"]) {
+    parts.push(`edited ${counts["edit"]} file${counts["edit"] > 1 ? "s" : ""}`);
+  }
+  if (counts["action"]) {
+    parts.push(`${counts["action"]} action${counts["action"] > 1 ? "s" : ""}`);
+  }
+
+  if (parts.length === 0) return `${toolRows.length} tool call${toolRows.length > 1 ? "s" : ""}`;
+  const [first, ...rest] = parts;
+  if (rest.length === 0) return first;
+  if (rest.length === 1) return `${first} and ${rest[0]}`;
+  return `${first}, ${rest.slice(0, -1).join(", ")} and ${rest.at(-1)}`;
 }
 
 export function getTraceDurationMs(rows: TraceRow[]): number | undefined {

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -17,7 +17,7 @@ import {
   type AntonRunStatus,
 } from "@/src/lib/trace";
 
-import { formatDuration, type TraceRow } from "./trace-data";
+import { formatDuration, type TraceRow, type StepGroup } from "./trace-data";
 import { ToolTraceRow } from "./tool-trace-row";
 
 export function TraceRowView({
@@ -73,6 +73,31 @@ function ActivityRow({
   );
 }
 
+export function InlineReasoningRow({
+  event,
+  runStatus,
+  text,
+}: {
+  event: AntonActivityEvent | undefined;
+  runStatus: AntonRunStatus;
+  text: string;
+}) {
+  const displayEvent = event ? displayEventForRun(event, runStatus) : undefined;
+  const running = displayEvent?.status === "running";
+  return (
+    <div className="flex gap-2 py-1 text-xs text-foreground/70">
+      {running ? (
+        <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-sky-400" />
+      ) : (
+        <Brain className="mt-0.5 size-3.5 shrink-0 text-muted-foreground/60" />
+      )}
+      <p className="whitespace-pre-wrap leading-relaxed text-foreground/70 italic font-mono text-[10px]">
+        {text}
+      </p>
+    </div>
+  );
+}
+
 function ReasoningRow({
   event,
   runStatus,
@@ -113,6 +138,46 @@ function ReasoningRow({
         <pre className="ml-5 mt-1 max-h-40 overflow-y-auto pr-2 font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
           {text}
         </pre>
+      </div>
+    </Disclosure>
+  );
+}
+
+export function StepGroupView({
+  group,
+  onApproval,
+}: {
+  group: StepGroup;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const hasRunningTool = group.toolRows.some(
+    (row) => row.kind === "tool" && row.tool.activity?.status === "running",
+  );
+  return (
+    <Disclosure
+      className="py-0.5"
+      forceOpen={hasRunningTool}
+      trigger={({ open }) => (
+        <span className="inline-flex max-w-full items-center gap-1.5 rounded px-0 py-0 text-[11px] text-muted-foreground/80 hover:text-foreground/80">
+          <span className="truncate">{group.summary}</span>
+          {open ? (
+            <ChevronDown className="size-3 shrink-0" />
+          ) : (
+            <ChevronRight className="size-3 shrink-0" />
+          )}
+        </span>
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+        <ol className="mt-1 space-y-0">
+          {group.toolRows.map((row) =>
+            row.kind === "tool" ? (
+              <li key={row.id}>
+                <ToolTraceRow entry={row.tool} onApproval={onApproval} />
+              </li>
+            ) : null,
+          )}
+        </ol>
       </div>
     </Disclosure>
   );

--- a/components/features/run-trace/use-bash-stream.ts
+++ b/components/features/run-trace/use-bash-stream.ts
@@ -1,0 +1,216 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export type BashStreamChunk =
+  | { type: "stdout"; chunk: string }
+  | { type: "stderr"; chunk: string }
+  | {
+      type: "exit";
+      exitCode: number | null;
+      timedOut: boolean;
+      killed: boolean;
+      failedReason?: BashFailedReason;
+      finished?: boolean;
+    };
+
+export type BashFailedReason = "timeout" | "killed" | "max_buffer" | "error";
+
+export interface BashStreamState {
+  stdout: string;
+  stderr: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  killed?: boolean;
+  failedReason?: BashFailedReason;
+  finished: boolean;
+  error?: string;
+}
+
+interface BashStreamStore {
+  state: BashStreamState;
+  listeners: Set<() => void>;
+  subscribers: number;
+  eventSource: EventSource | null;
+  reconnectTimeout: number | null;
+  closeTimeout: number | null;
+}
+
+const EMPTY_STATE: BashStreamState = {
+  stdout: "",
+  stderr: "",
+  finished: false,
+};
+
+const MAX_OUTPUT_CHARS = 64 * 1024;
+const RECONNECT_DELAY_MS = 1_000;
+const CLOSE_GRACE_MS = 500;
+
+const stores = new Map<string, BashStreamStore>();
+
+export function useBashStream(
+  streamId: string | undefined,
+  token: string | undefined,
+  enabled: boolean,
+): BashStreamState {
+  const activeStreamId = enabled && token ? streamId : undefined;
+  const activeToken = activeStreamId ? token : undefined;
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!activeStreamId || !activeToken) return () => {};
+      return subscribeToBashStream(activeStreamId, activeToken, onStoreChange);
+    },
+    [activeStreamId, activeToken],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!activeStreamId || !activeToken) return EMPTY_STATE;
+    return getStore(storeKey(activeStreamId, activeToken)).state;
+  }, [activeStreamId, activeToken]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_STATE);
+}
+
+function subscribeToBashStream(
+  streamId: string,
+  token: string,
+  listener: () => void,
+): () => void {
+  const key = storeKey(streamId, token);
+  const store = getStore(key);
+  store.subscribers += 1;
+  store.listeners.add(listener);
+
+  if (store.closeTimeout !== null) {
+    window.clearTimeout(store.closeTimeout);
+    store.closeTimeout = null;
+  }
+
+  if (!store.state.finished) {
+    connectStore(streamId, token, store);
+  }
+
+  return () => {
+    store.listeners.delete(listener);
+    store.subscribers = Math.max(0, store.subscribers - 1);
+    if (store.subscribers > 0 || store.closeTimeout !== null) return;
+
+    store.closeTimeout = window.setTimeout(() => {
+      store.closeTimeout = null;
+      if (store.subscribers > 0) return;
+      closeStore(key, store);
+    }, CLOSE_GRACE_MS);
+  };
+}
+
+function getStore(key: string): BashStreamStore {
+  const existing = stores.get(key);
+  if (existing) return existing;
+
+  const store: BashStreamStore = {
+    state: EMPTY_STATE,
+    listeners: new Set(),
+    subscribers: 0,
+    eventSource: null,
+    reconnectTimeout: null,
+    closeTimeout: null,
+  };
+  stores.set(key, store);
+  return store;
+}
+
+function connectStore(
+  streamId: string,
+  token: string,
+  store: BashStreamStore,
+): void {
+  if (store.eventSource || store.reconnectTimeout !== null) return;
+
+  const eventSource = new EventSource(
+    `/api/bash-stream?streamId=${encodeURIComponent(streamId)}&token=${encodeURIComponent(token)}`,
+  );
+  store.eventSource = eventSource;
+
+  eventSource.onmessage = (event) => {
+    let data: BashStreamChunk;
+    try {
+      data = JSON.parse(event.data) as BashStreamChunk;
+    } catch {
+      return;
+    }
+
+    if (data.type === "stdout") {
+      setStoreState(store, {
+        ...store.state,
+        stdout: capOutput(store.state.stdout + data.chunk),
+      });
+      return;
+    }
+
+    if (data.type === "stderr") {
+      setStoreState(store, {
+        ...store.state,
+        stderr: capOutput(store.state.stderr + data.chunk),
+      });
+      return;
+    }
+
+    setStoreState(store, {
+      ...store.state,
+      exitCode: data.exitCode,
+      timedOut: data.timedOut,
+      killed: data.killed,
+      failedReason: data.failedReason,
+      finished: true,
+    });
+    closeEventSource(store, eventSource);
+  };
+
+  eventSource.onerror = () => {
+    if (store.eventSource !== eventSource) return;
+    closeEventSource(store, eventSource);
+    if (store.state.finished || store.subscribers === 0) return;
+
+    store.reconnectTimeout = window.setTimeout(() => {
+      store.reconnectTimeout = null;
+      if (!store.state.finished && store.subscribers > 0) {
+        connectStore(streamId, token, store);
+      }
+    }, RECONNECT_DELAY_MS);
+  };
+}
+
+function setStoreState(store: BashStreamStore, state: BashStreamState): void {
+  store.state = state;
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function closeStore(key: string, store: BashStreamStore): void {
+  closeEventSource(store, store.eventSource);
+  if (store.reconnectTimeout !== null) {
+    window.clearTimeout(store.reconnectTimeout);
+    store.reconnectTimeout = null;
+  }
+  stores.delete(key);
+}
+
+function closeEventSource(
+  store: BashStreamStore,
+  eventSource: EventSource | null,
+): void {
+  if (!eventSource || store.eventSource !== eventSource) return;
+  store.eventSource = null;
+  eventSource.close();
+}
+
+function capOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) return output;
+  return output.slice(output.length - MAX_OUTPUT_CHARS);
+}
+
+function storeKey(streamId: string, token: string): string {
+  return `${streamId}:${token}`;
+}

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -25,6 +25,8 @@ import {
   toolStateMeta,
   type WriteFileOkOutput,
 } from "./tool-display";
+import { TerminalOutput } from "./terminal-output";
+import { LiveTerminalOutput } from "./live-terminal";
 
 export type WorklogEntry = ToolTraceEntry;
 
@@ -137,9 +139,11 @@ function WorklogRow({
           <span className="truncate font-mono text-[11px] text-foreground">
             {entry.name}
           </span>
-          <span className={cn("shrink-0 text-[10px]", state.textClass)}>
-            {state.label}
-          </span>
+          {state.label.length > 0 && (
+            <span className={cn("shrink-0 text-[10px]", state.textClass)}>
+              {state.label}
+            </span>
+          )}
         </div>
         <p className="truncate font-mono text-[10px] text-muted-foreground">
           {previewToolInput(entry.input)}
@@ -161,6 +165,7 @@ function WorklogDetail({
     entry.state === "output-available" &&
     isOkWriteFileOutput(entry.output) &&
     pickString(entry.input, "content") !== undefined;
+  const streamToken = pickString(entry.activity?.details, "streamToken");
 
   return (
     <section className="space-y-2.5 px-3 py-3">
@@ -168,7 +173,7 @@ function WorklogDetail({
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <state.Icon className={cn("size-3.5", state.iconClass)} />
-            <span>{state.label}</span>
+            {state.label.length > 0 && <span>{state.label}</span>}
           </div>
           <h2 className="mt-0.5 truncate font-mono text-xs font-semibold">
             {entry.name}
@@ -200,13 +205,42 @@ function WorklogDetail({
         )}
       </div>
 
-      <LogBlock title="Input">{safeStringify(entry.input)}</LogBlock>
+      {entry.name !== "bash" && (
+        <LogBlock title="Input">{safeStringify(entry.input)}</LogBlock>
+      )}
 
       {showWriteDiff ? (
         <DiffView
           previous={(entry.output as WriteFileOkOutput).previousContent ?? ""}
           next={pickString(entry.input, "content") ?? ""}
           newFile={(entry.output as WriteFileOkOutput).existed === false}
+        />
+      ) : entry.name === "bash" && entry.activity?.status === "running" && entry.activity?.toolCallId ? (
+        <LiveTerminalOutput
+          command={pickString(entry.input, "command")}
+          streamId={entry.activity.toolCallId}
+          streamToken={streamToken}
+          initialOutput={
+            typeof entry.output === "object" && entry.output !== null
+              ? (entry.output as {
+                  stdout?: string;
+                  stderr?: string;
+                  exitCode?: number | null;
+                  timedOut?: boolean;
+                  killed?: boolean;
+                  failedReason?: "timeout" | "killed" | "max_buffer" | "error";
+                })
+              : undefined
+          }
+        />
+      ) : entry.name === "bash" ? (
+        <TerminalOutput
+          command={pickString(entry.input, "command") ?? safeStringify(entry.input)}
+          output={
+            entry.state === "output-error" && entry.errorText
+              ? { stderr: entry.errorText, exitCode: 1 }
+              : entry.output
+          }
         />
       ) : entry.state === "output-error" && entry.errorText ? (
         <LogBlock title="Error" tone="error">

--- a/components/shared/disclosure.tsx
+++ b/components/shared/disclosure.tsx
@@ -5,7 +5,7 @@ import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 const DISCLOSURE_ANIMATION =
-  "overflow-hidden transition-[max-height,opacity] duration-300 ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
+  "overflow-hidden transition-[max-height,opacity] ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
 
 export function Disclosure({
   className,
@@ -68,7 +68,7 @@ export function Disclosure({
         id={id}
         className={cn(
           DISCLOSURE_ANIMATION,
-          effectiveOpen ? "opacity-100" : "opacity-0",
+          effectiveOpen ? "opacity-100 duration-100" : "opacity-0 duration-300",
         )}
         style={{
           maxHeight: effectiveOpen ? "var(--disclosure-height, 0px)" : "0px",

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { HoverCard as HoverCardPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-48 rounded-lg bg-popover px-3 py-2 text-popover-foreground shadow-md ring-1 ring-border outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "ansi-to-html": "^0.7.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       ai:
         specifier: ^6.0.168
         version: 6.0.168(zod@4.3.6)
+      ansi-to-html:
+        specifier: ^0.7.2
+        version: 0.7.2
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -2225,6 +2228,11 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-to-html@0.7.2:
+    resolution: {integrity: sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2741,6 +2749,9 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -6750,6 +6761,10 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-to-html@0.7.2:
+    dependencies:
+      entities: 2.2.0
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -7163,6 +7178,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@2.2.0: {}
 
   env-paths@2.2.1: {}
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -3,6 +3,7 @@ import {
   stepCountIs,
   type LanguageModelUsage,
   type ModelMessage,
+  type ProviderMetadata,
   type TextStreamPart,
   type ToolSet,
   type FinishReason,
@@ -38,6 +39,7 @@ function systemPrompt(mcpTools: LoadedMcpTools, workspaceRoot?: string): string 
     "- `read_file(path, startLine?, endLine?)` - read a text file. Prefer narrow ranges for large files.",
     "- `write_file(path, content)` - overwrite a file. Classified as write risk; the user must approve each call.",
     "- `bash(command, timeoutMs?)` - run a shell command in the workspace. Commands are conservatively classified by risk category before execution; shell execution requires approval. `sudo` is forbidden.",
+    "- `bash` output streams live to the UI. Do not pipe long-running commands through `tail`, `head`, or pagers just to limit output; the harness truncates output.",
     "- `grep(pattern, path?, glob?, caseInsensitive?)` - ripgrep-style search. Use this before reading large files.",
     "- `glob(pattern, path?)` - list files matching a glob like `**/*.ts`.",
     "- `list_memory(limit?)` - list project-wide memories that apply across sessions.",
@@ -166,6 +168,7 @@ export async function runAgent({
   onFinish?: (result: {
     totalUsage: LanguageModelUsage;
     finishReason: FinishReason;
+    providerMetadata?: ProviderMetadata;
   }) => void;
 }) {
   const mcpTools = await loadMcpTools(workspaceRoot);
@@ -193,6 +196,7 @@ export async function runAgent({
     providerOptions: {
       openrouter: {
         reasoning: { enabled: true, effort: "low", exclude: false },
+        usage: { include: true },
       },
     },
     experimental_transform: onStreamPart
@@ -230,8 +234,8 @@ export async function runAgent({
         error: event.success ? undefined : event.error,
       });
     },
-    onFinish: async ({ totalUsage, finishReason }) => {
-      onFinish?.({ totalUsage, finishReason });
+    onFinish: async ({ totalUsage, finishReason, providerMetadata }) => {
+      onFinish?.({ totalUsage, finishReason, providerMetadata });
       await closeMcpTools();
     },
     onAbort: async () => {

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -3,6 +3,10 @@ import { execa } from "execa";
 import { tool } from "ai";
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt } from "../sandbox";
 import { classifyBashCommand } from "../permissions";
+import {
+  bashProgress,
+  type BashFailedReason,
+} from "@/src/lib/bash-stream";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -10,64 +14,38 @@ const MAX_TIMEOUT_MS = 120_000;
 
 export function createBashTool(workspaceRoot?: string) {
   return tool({
-  description:
-    "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. `sudo` is forbidden. Requires user approval.",
-  inputSchema: z.object({
-    command: z.string().describe("Shell command to execute via `bash -lc`."),
-    timeoutMs: z
-      .number()
-      .int()
-      .min(100)
-      .max(MAX_TIMEOUT_MS)
-      .optional()
-      .describe(
-        `Maximum time to wait before the command is killed. Defaults to ${DEFAULT_TIMEOUT_MS}ms, capped at ${MAX_TIMEOUT_MS}ms.`,
-      ),
-  }),
-  execute: async ({ command, timeoutMs }) => {
-    const classification = classifyBashCommand(command);
-    if (classification.forbidden) {
-      return {
-        ok: false as const,
-        classification,
-        riskCategories: classification.categories,
-        error: classification.reason,
-      };
-    }
+    description:
+      "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. `sudo` is forbidden. Requires user approval.",
+    inputSchema: z.object({
+      command: z.string().describe("Shell command to execute via `bash -lc`."),
+      timeoutMs: z
+        .number()
+        .int()
+        .min(100)
+        .max(MAX_TIMEOUT_MS)
+        .optional()
+        .describe(
+          `Maximum time to wait before the command is killed. Defaults to ${DEFAULT_TIMEOUT_MS}ms, capped at ${MAX_TIMEOUT_MS}ms.`,
+        ),
+    }),
+    execute: async ({ command, timeoutMs }, { toolCallId }) => {
+      const classification = classifyBashCommand(command);
+      if (classification.forbidden) {
+        return {
+          ok: false as const,
+          classification,
+          riskCategories: classification.categories as string[],
+          error: classification.reason,
+        };
+      }
 
-    const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    try {
+      const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
       const root = workspaceRoot
         ? ensureWorkspaceRootAt(workspaceRoot)
         : ensureWorkspaceRoot();
-      const result = await execa("bash", ["-lc", command], {
-        cwd: root,
-        timeout,
-        reject: false,
-        all: true,
-        stripFinalNewline: false,
-        maxBuffer: MAX_OUTPUT_BYTES * 4,
-      });
 
-      return {
-        ok: true as const,
-        classification,
-        riskCategories: classification.categories,
-        exitCode: result.exitCode ?? null,
-        timedOut: result.timedOut ?? false,
-        killed: result.isCanceled ?? false,
-        stdout: truncate(result.stdout ?? ""),
-        stderr: truncate(result.stderr ?? ""),
-      };
-    } catch (err) {
-      return {
-        ok: false as const,
-        classification,
-        riskCategories: classification.categories,
-        error: errorMessage(err),
-      };
-    }
-  },
+      return executeWithStreaming(command, root, timeout, toolCallId, classification);
+    },
   });
 }
 
@@ -78,6 +56,153 @@ function truncate(output: string): string {
   if (buf.byteLength <= MAX_OUTPUT_BYTES) return output;
   const head = buf.subarray(0, MAX_OUTPUT_BYTES).toString("utf8");
   return `${head}\n…[truncated ${buf.byteLength - MAX_OUTPUT_BYTES} bytes]`;
+}
+
+async function executeWithStreaming(
+  command: string,
+  root: string,
+  timeout: number,
+  streamId: string,
+  classification: ReturnType<typeof classifyBashCommand>,
+): Promise<BashToolOkOutput | BashToolErrorOutput> {
+  bashProgress.startStream(streamId);
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  let sentExit = false;
+
+  try {
+    const subprocess = execa("bash", ["-lc", command], {
+      cwd: root,
+      timeout,
+      reject: false,
+      stripFinalNewline: false,
+      maxBuffer: MAX_OUTPUT_BYTES * 4,
+    });
+
+    subprocess.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stdoutChunks.push(text);
+      bashProgress.emitChunk(streamId, { type: "stdout", chunk: text });
+    });
+
+    subprocess.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stderrChunks.push(text);
+      bashProgress.emitChunk(streamId, { type: "stderr", chunk: text });
+    });
+
+    const result = await subprocess;
+    const exitCode = result.exitCode ?? null;
+    const timedOut = result.timedOut ?? false;
+    const killed = result.isCanceled ?? false;
+    const failedReason = failedReasonForResult({
+      timedOut,
+      killed,
+      isMaxBuffer: result.isMaxBuffer ?? false,
+    });
+
+    bashProgress.emitChunk(streamId, {
+      type: "exit",
+      exitCode,
+      timedOut,
+      killed,
+      failedReason,
+    });
+    sentExit = true;
+
+    return {
+      ok: true as const,
+      classification,
+      riskCategories: classification.categories as string[],
+      exitCode,
+      timedOut,
+      killed,
+      failedReason,
+      stdout: truncate(stdoutChunks.join("")),
+      stderr: truncate(stderrChunks.join("")),
+      streamId,
+    };
+  } catch (err) {
+    const error = errorMessage(err);
+    const stderr = truncate([...stderrChunks, error].filter(Boolean).join("\n"));
+    bashProgress.emitChunk(streamId, { type: "stderr", chunk: `${error}\n` });
+    bashProgress.emitChunk(streamId, {
+      type: "exit",
+      exitCode: null,
+      timedOut: false,
+      killed: false,
+      failedReason: "error",
+    });
+    sentExit = true;
+
+    return {
+      ok: false as const,
+      classification,
+      riskCategories: classification.categories as string[],
+      error,
+      exitCode: null,
+      timedOut: false,
+      killed: false,
+      failedReason: "error",
+      stdout: truncate(stdoutChunks.join("")),
+      stderr,
+      streamId,
+    };
+  } finally {
+    if (!sentExit) {
+      bashProgress.emitChunk(streamId, {
+        type: "exit",
+        exitCode: null,
+        timedOut: false,
+        killed: false,
+        failedReason: "error",
+      });
+    }
+    bashProgress.endStream(streamId);
+  }
+}
+
+type BashToolOkOutput = {
+  ok: true;
+  classification: ReturnType<typeof classifyBashCommand>;
+  riskCategories: string[];
+  exitCode: number | null;
+  timedOut: boolean;
+  killed: boolean;
+  failedReason?: BashFailedReason;
+  stdout: string;
+  stderr: string;
+  streamId: string;
+};
+
+type BashToolErrorOutput = {
+  ok: false;
+  classification: ReturnType<typeof classifyBashCommand>;
+  riskCategories: string[];
+  error: string;
+  exitCode: null;
+  timedOut: false;
+  killed: false;
+  failedReason: "error";
+  stdout: string;
+  stderr: string;
+  streamId: string;
+};
+
+function failedReasonForResult({
+  timedOut,
+  killed,
+  isMaxBuffer,
+}: {
+  timedOut: boolean;
+  killed: boolean;
+  isMaxBuffer: boolean;
+}): BashFailedReason | undefined {
+  if (timedOut) return "timeout";
+  if (killed) return "killed";
+  if (isMaxBuffer) return "max_buffer";
+  return undefined;
 }
 
 function errorMessage(err: unknown): string {

--- a/src/db/migrations/0005_bright_blue_shield.sql
+++ b/src/db/migrations/0005_bright_blue_shield.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `runs` ADD `input_tokens` integer;--> statement-breakpoint
+ALTER TABLE `runs` ADD `output_tokens` integer;--> statement-breakpoint
+ALTER TABLE `runs` ADD `cost_usd` real;

--- a/src/db/migrations/meta/0005_snapshot.json
+++ b/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,675 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "50f27ef3-42d4-4f2f-a62a-b6dc982bf823",
+  "prevId": "8dfc70d2-2300-4320-9f7a-619a135e6e9f",
+  "tables": {
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777742922807,
       "tag": "0004_public_umar",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1777909003397,
+      "tag": "0005_bright_blue_shield",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,12 @@
 import { sql } from "drizzle-orm";
-import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import {
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 export const workspaceSettings = sqliteTable("workspace_settings", {
   id: text("id").primaryKey(),
@@ -98,7 +105,10 @@ export const runs = sqliteTable(
     startedAt: integer("started_at", { mode: "timestamp_ms" }).notNull(),
     finishedAt: integer("finished_at", { mode: "timestamp_ms" }),
     durationMs: integer("duration_ms"),
+    inputTokens: integer("input_tokens"),
+    outputTokens: integer("output_tokens"),
     totalTokens: integer("total_tokens"),
+    costUsd: real("cost_usd"),
     finishReason: text("finish_reason"),
   },
   (table) => [

--- a/src/lib/bash-stream.ts
+++ b/src/lib/bash-stream.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+
+export type BashFailedReason = "timeout" | "killed" | "max_buffer" | "error";
+
+const MAX_STREAM_OUTPUT_CHARS = 64 * 1024;
+const STREAM_RECONNECT_TTL_MS = 60_000;
+
+export type BashProgressEvent =
+  | {
+      type: "stdout";
+      chunk: string;
+    }
+  | {
+      type: "stderr";
+      chunk: string;
+    }
+  | {
+      type: "exit";
+      exitCode: number | null;
+      timedOut: boolean;
+      killed: boolean;
+      failedReason?: BashFailedReason;
+    };
+
+export interface BashStreamState {
+  token: string;
+  stdout: string;
+  stderr: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  killed?: boolean;
+  failedReason?: BashFailedReason;
+  finished: boolean;
+}
+
+class BashProgressEmitter extends EventEmitter {
+  private streams = new Map<string, BashStreamState>();
+
+  prepareStream(toolCallId: string): string {
+    const existing = this.streams.get(toolCallId);
+    if (existing) return existing.token;
+
+    const token = randomUUID();
+    this.streams.set(toolCallId, {
+      token,
+      stdout: "",
+      stderr: "",
+      finished: false,
+    });
+    return token;
+  }
+
+  startStream(toolCallId: string): void {
+    const token = this.streams.get(toolCallId)?.token ?? randomUUID();
+    this.streams.set(toolCallId, {
+      token,
+      stdout: "",
+      stderr: "",
+      finished: false,
+    });
+    this.emit("start", toolCallId);
+  }
+
+  emitChunk(
+    toolCallId: string,
+    event: BashProgressEvent,
+  ): void {
+    const state = this.streams.get(toolCallId);
+    if (!state) return;
+
+    if (event.type === "stdout") {
+      state.stdout = capOutput(state.stdout + event.chunk);
+    } else if (event.type === "stderr") {
+      state.stderr = capOutput(state.stderr + event.chunk);
+    } else if (event.type === "exit") {
+      state.exitCode = event.exitCode;
+      state.timedOut = event.timedOut;
+      state.killed = event.killed;
+      state.failedReason = event.failedReason;
+      state.finished = true;
+    }
+
+    this.emit(`chunk:${toolCallId}`, event, state);
+  }
+
+  validateToken(toolCallId: string, token: string): boolean {
+    return this.streams.get(toolCallId)?.token === token;
+  }
+
+  getState(toolCallId: string): BashStreamState | undefined {
+    return this.streams.get(toolCallId);
+  }
+
+  endStream(toolCallId: string): void {
+    this.emit(`end:${toolCallId}`);
+    setTimeout(() => {
+      this.streams.delete(toolCallId);
+    }, STREAM_RECONNECT_TTL_MS);
+  }
+
+  onChunk(
+    toolCallId: string,
+    callback: (event: BashProgressEvent, state: BashStreamState) => void,
+  ): () => void {
+    const listener = (event: BashProgressEvent, state: BashStreamState) =>
+      callback(event, state);
+    this.on(`chunk:${toolCallId}`, listener);
+    return () => {
+      this.off(`chunk:${toolCallId}`, listener);
+    };
+  }
+
+  onEnd(toolCallId: string, callback: () => void): () => void {
+    const listener = () => callback();
+    this.on(`end:${toolCallId}`, listener);
+    return () => {
+      this.off(`end:${toolCallId}`, listener);
+    };
+  }
+}
+
+function capOutput(output: string): string {
+  if (output.length <= MAX_STREAM_OUTPUT_CHARS) return output;
+  return output.slice(output.length - MAX_STREAM_OUTPUT_CHARS);
+}
+
+const globalForBashProgress = globalThis as typeof globalThis & {
+  __antonBashProgress?: BashProgressEmitter;
+};
+
+export const bashProgress =
+  globalForBashProgress.__antonBashProgress ?? new BashProgressEmitter();
+
+globalForBashProgress.__antonBashProgress = bashProgress;

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -31,7 +31,10 @@ export type AntonMessageMetadata = {
   startedAt?: number;
   finishedAt?: number;
   durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
   totalTokens?: number;
+  costUsd?: number;
 };
 
 export type AntonRunData = {
@@ -41,7 +44,10 @@ export type AntonRunData = {
   startedAt: number;
   finishedAt?: number;
   durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
   totalTokens?: number;
+  costUsd?: number;
 };
 
 export type AntonActivityEvent = {
@@ -129,7 +135,7 @@ export function getToolTraceEntries(
           ? part.toolCallId
           : undefined;
       entries.push({
-        id: `${message.id}:${index}`,
+        id: toolCallId ?? `${message.id}:${index}`,
         sourceMessageId: message.id,
         name: String(getToolName(part)),
         state,


### PR DESCRIPTION
## Summary
Closes #37

Harden live bash terminal streaming and persist the run metrics that power the response-metrics UI.

## Changes
- Added `/api/bash-stream` SSE streaming with a per-tool-call capability token.
- Updated bash execution results to preserve `exitCode: null` and distinguish timeout, killed, max-buffer, and generic error states.
- Added shared terminal ANSI rendering utilities with escaped HTML before terminal output is rendered.
- Persisted input tokens, output tokens, and USD cost on `runs` via Drizzle migration `0005_bright_blue_shield`.
- Added inline/worklog terminal output views and response metric hover details.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `pnpm db:migrate`
- Manual: `/api/bash-stream?streamId=manual-check` returns `403` without a valid token.

## Notes
- No automated test framework was added in this pass, per scope.