### PR TITLE
[codex] Stabilize trace approvals and response metrics

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -13,7 +13,12 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import { runAgent } from "@/src/agent/loop";
-import type { PermissionMode } from "@/src/agent/permissions";
+import {
+  getNativeToolPermissionMetadata,
+  isMcpTool,
+  preClassifyBashInput,
+  type PermissionMode,
+} from "@/src/agent/permissions";
 import { bashProgress } from "@/src/lib/bash-stream";
 import {
   addSessionTokens,
@@ -419,6 +424,28 @@ function createTraceWriter({
       if (event.toolName === "bash") {
         details.streamToken = bashProgress.prepareStream(event.toolCallId);
       }
+
+      const permissionMeta = getNativeToolPermissionMetadata(event.toolName);
+      if (permissionMeta) {
+        details.riskCategories = [...permissionMeta.categories];
+        details.riskSummary = permissionMeta.summary;
+      } else if (isMcpTool(event.toolName)) {
+        const parts = event.toolName.split("__");
+        details.riskCategories = ["external-integration"];
+        details.riskSummary = `Calls external MCP tool "${parts[2] ?? event.toolName}" from "${parts[1] ?? "unknown"}" server.`;
+      }
+
+      if (event.toolName === "bash") {
+        const classification = preClassifyBashInput(event.input);
+        if (classification) {
+          details.bashClassification = {
+            categories: [...classification.categories],
+            forbidden: classification.forbidden,
+            reason: classification.reason,
+          };
+        }
+      }
+
       startEvent({
         id: `${runId}:tool:${event.toolCallId}`,
         kind: "tool",
@@ -438,11 +465,13 @@ function createTraceWriter({
       output?: unknown;
       error?: unknown;
     }) {
+      const current = events.get(`${runId}:tool:${event.toolCallId}`);
       finishEvent(`${runId}:tool:${event.toolCallId}`, {
         status: event.success ? "completed" : "error",
         label: toolLabel(event.toolName, event.input),
         summary: summarizeInput(event.input),
         details: {
+          ...current?.details,
           toolName: event.toolName,
           stepNumber: event.stepNumber,
           success: event.success,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { Chat } from "@/components/features/chat/chat";
 
 export default function Home() {
-  return <Chat />;
+  return <Chat key="new-chat" />;
 }

--- a/app/s/[sessionId]/page.tsx
+++ b/app/s/[sessionId]/page.tsx
@@ -20,6 +20,7 @@ export default async function SessionPage({
 
   return (
     <Chat
+      key={session.id}
       sessionId={session.id}
       initialMessages={messages}
       initialModel={session.model as ModelId}

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -10,7 +11,7 @@ import { PanelLeftOpen, PanelRightClose, PanelRightOpen } from "lucide-react";
 
 import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
 import type { PermissionMode } from "@/src/agent/permissions";
-import type { AntonUIMessage } from "@/src/lib/trace";
+import { getRunDataList, type AntonUIMessage } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MessageList } from "./message-list";
@@ -33,7 +34,11 @@ interface ChatProps {
   initialProjectId?: string | null;
 }
 
-export function Chat({
+export function Chat(props: ChatProps) {
+  return <ChatSession key={props.sessionId ?? "new-chat"} {...props} />;
+}
+
+function ChatSession({
   sessionId: sessionIdProp,
   initialMessages,
   initialModel,
@@ -41,6 +46,7 @@ export function Chat({
   initialTokensTotal = 0,
   initialProjectId = null,
 }: ChatProps) {
+  const router = useRouter();
   const { sessions, refresh } = useSessionStore();
   const sidebar = useSidebar();
   const persistedRef = useRef(sessionIdProp !== undefined);
@@ -85,9 +91,7 @@ export function Chat({
     onFinish: () => {
       if (!persistedRef.current) {
         persistedRef.current = true;
-        if (typeof window !== "undefined") {
-          window.history.replaceState(null, "", `/s/${sessionId}`);
-        }
+        router.replace(`/s/${sessionId}`);
       }
       void refresh();
     },
@@ -95,8 +99,16 @@ export function Chat({
 
   const streaming = status === "streaming" || status === "submitted";
   const headerTitle = initialTitle ?? (sessionIdProp ? "Session" : "New chat");
-  const tokensTotal =
+  const persistedTokensTotal =
     sessions.find((s) => s.id === sessionId)?.tokensTotal ?? initialTokensTotal;
+  const messageTokensTotal = messages.reduce((sum, message) => {
+    return sum + getRunDataList(message).reduce((runSum, run) => {
+      return typeof run.totalTokens === "number" && Number.isFinite(run.totalTokens)
+        ? runSum + run.totalTokens
+        : runSum;
+    }, 0);
+  }, 0);
+  const tokensTotal = Math.max(persistedTokensTotal, messageTokensTotal);
 
   const toggleWorklog = () => {
     if (

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -232,6 +232,7 @@ function TokenCounter({
       title="Total tokens used in this session"
     >
       <span className="size-1.5 rounded-full bg-muted-foreground/50" aria-hidden />
+      <span className="text-muted-foreground/70">session</span>
       {formatTokens(tokens)}
       <span className="text-muted-foreground/70">tok</span>
     </span>

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -14,9 +14,14 @@ import {
 } from "lucide-react";
 
 import {
+  getAssistantTextDisplay,
+  getMessageRunDurationMs,
   getRunData,
+  getRunDataList,
   getToolTraceEntries,
+  hasPendingToolApproval,
   type AntonUIMessage,
+  type AntonRunData,
 } from "@/src/lib/trace";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
@@ -81,17 +86,30 @@ function MessageEvent({
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
   const isUser = message.role === "user";
-  const plainText = message.parts
+  const userText = message.parts
     .filter((p) => p.type === "text")
     .map((p) => (p as { text: string }).text)
     .join("\n\n")
     .trim();
-  const fallbackText = !isUser && plainText.length === 0
+  const assistantText = !isUser
+    ? getAssistantTextDisplay(message).finalText
+    : "";
+  const pendingApproval = !isUser && hasPendingToolApproval(message);
+  const assistantFinal = !isUser && isAssistantMessageFinal(message);
+  const fallbackText = !isUser &&
+    assistantText.length === 0 &&
+    !pendingApproval &&
+    assistantFinal
     ? toolResultFallbackText(message)
     : "";
-  const finalText = plainText || fallbackText;
+  const responseText = isUser ? userText : assistantText || fallbackText;
   const responseTime = !isUser ? messageDisplayTime(message) : undefined;
   const metrics = !isUser ? messageMetrics(message) : undefined;
+  const showActions =
+    !isUser &&
+    responseText.length > 0 &&
+    !pendingApproval &&
+    assistantFinal;
 
   return (
     <div
@@ -115,30 +133,33 @@ function MessageEvent({
             onApproval={onApproval}
           />
         )}
-        {message.parts.map((part, i) => {
-          if (part.type !== "text") return null;
-          if (isUser) {
+        {isUser ? (
+          message.parts.map((part, i) => {
+            if (part.type !== "text") return null;
             return (
               <div key={i} className="whitespace-pre-wrap leading-normal">
                 {part.text}
               </div>
             );
-          }
-          return <Markdown key={i} className="text-xs">{part.text}</Markdown>;
-        })}
-        {!isUser && plainText.length === 0 && fallbackText.length > 0 && (
-          <Markdown className="text-xs">{fallbackText}</Markdown>
-        )}
+          })
+        ) : responseText.length > 0 ? (
+          <Markdown className="text-xs">{responseText}</Markdown>
+        ) : null}
       </div>
-      {!isUser && finalText.length > 0 && (
+      {showActions && (
         <MessageActions
-          text={finalText}
+          text={responseText}
           responseTime={responseTime}
           metrics={metrics}
         />
       )}
     </div>
   );
+}
+
+function isAssistantMessageFinal(message: AntonUIMessage): boolean {
+  const runStatus = getRunData(message)?.status ?? message.metadata?.status;
+  return runStatus === undefined || runStatus !== "running";
 }
 
 function toolResultFallbackText(message: AntonUIMessage): string {
@@ -172,7 +193,7 @@ function bashOutputFallback(output: unknown): string {
 function messageDisplayTime(message: AntonUIMessage): string | undefined {
   const metadata = message.metadata;
   const run = getRunData(message);
-  const timestamp = metadata?.finishedAt ?? metadata?.startedAt ?? run?.finishedAt ?? run?.startedAt;
+  const timestamp = run?.finishedAt ?? metadata?.finishedAt ?? run?.startedAt ?? metadata?.startedAt;
   if (typeof timestamp !== "number") return undefined;
   return new Intl.DateTimeFormat(undefined, {
     hour: "2-digit",
@@ -192,19 +213,42 @@ type ResponseMetrics = {
 
 function messageMetrics(message: AntonUIMessage): ResponseMetrics {
   const metadata = message.metadata;
-  const run = getRunData(message);
+  const runs = getRunDataList(message);
+  const run = runs.at(-1);
+  const aggregate = aggregateRunMetrics(runs);
   return {
-    model: metadata?.model ?? run?.model,
-    durationMs: metadata?.durationMs ?? run?.durationMs,
-    inputTokens: metadata?.inputTokens ?? run?.inputTokens,
-    outputTokens: metadata?.outputTokens ?? run?.outputTokens,
-    totalTokens: metadata?.totalTokens ?? run?.totalTokens,
+    model: run?.model ?? metadata?.model,
+    durationMs: getMessageRunDurationMs(message) ?? aggregate.durationMs,
+    inputTokens: aggregate.inputTokens ?? metadata?.inputTokens ?? run?.inputTokens,
+    outputTokens: aggregate.outputTokens ?? metadata?.outputTokens ?? run?.outputTokens,
+    totalTokens: aggregate.totalTokens ?? metadata?.totalTokens ?? run?.totalTokens,
     costUsd:
+      aggregate.costUsd ??
       readNumber(metadata, "costUsd") ??
       readNumber(metadata, "cost") ??
       readNumber(run, "costUsd") ??
       readNumber(run, "cost"),
   };
+}
+
+function aggregateRunMetrics(runs: AntonRunData[]): ResponseMetrics {
+  return {
+    inputTokens: sumDefined(runs.map((run) => run.inputTokens)),
+    outputTokens: sumDefined(runs.map((run) => run.outputTokens)),
+    totalTokens: sumDefined(runs.map((run) => run.totalTokens)),
+    costUsd: sumDefined(runs.map((run) => run.costUsd)),
+  };
+}
+
+function sumDefined(values: Array<number | undefined>): number | undefined {
+  let total = 0;
+  let hasValue = false;
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    total += value;
+    hasValue = true;
+  }
+  return hasValue ? total : undefined;
 }
 
 function readNumber(value: unknown, key: string): number | undefined {
@@ -248,7 +292,7 @@ function StatsHoverCard({ metrics }: { metrics: ResponseMetrics }) {
           <Cpu className="size-3" />
         </button>
       </HoverCardTrigger>
-      <HoverCardContent className="w-56 px-2.5 py-2">
+      <HoverCardContent className="w-64 px-2.5 py-2">
         <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
           <Cpu className="size-3" />
           {modelName}
@@ -257,30 +301,30 @@ function StatsHoverCard({ metrics }: { metrics: ResponseMetrics }) {
           <div className="flex items-center gap-1.5 text-muted-foreground">
             <Hash className="size-3" />
             <span>Total</span>
-            <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.totalTokens)}</span>
+            <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatNumber(metrics.totalTokens)}</span>
           </div>
           <div className="grid grid-cols-2 gap-x-3 gap-y-1">
             <div className="flex items-center gap-1.5">
               <ArrowDownToLine className="size-3 text-muted-foreground" />
               <span className="text-muted-foreground">In</span>
-              <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.inputTokens)}</span>
+              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatNumber(metrics.inputTokens)}</span>
             </div>
             <div className="flex items-center gap-1.5">
               <ArrowUpFromLine className="size-3 text-muted-foreground" />
               <span className="text-muted-foreground">Out</span>
-              <span className="ml-auto font-mono text-foreground">{formatNumber(metrics.outputTokens)}</span>
+              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatNumber(metrics.outputTokens)}</span>
             </div>
           </div>
           <div className="grid grid-cols-2 gap-x-3 gap-y-1">
             <div className="flex items-center gap-1.5">
               <DollarSign className="size-3 text-muted-foreground" />
               <span className="text-muted-foreground">Cost</span>
-              <span className="ml-auto font-mono text-foreground">{formatCost(metrics.costUsd)}</span>
+              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatCost(metrics.costUsd)}</span>
             </div>
             <div className="flex items-center gap-1.5">
               <Clock className="size-3 text-muted-foreground" />
               <span className="text-muted-foreground">Duration</span>
-              <span className="ml-auto font-mono text-foreground">{formatDuration(metrics.durationMs)}</span>
+              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatDuration(metrics.durationMs)}</span>
             </div>
           </div>
         </div>
@@ -307,8 +351,11 @@ function formatCost(value: number | undefined): string {
 
 function formatDuration(value: number | undefined): string {
   if (value === undefined) return "—";
-  if (value < 1000) return `${value}ms`;
-  return `${(value / 1000).toFixed(value < 10000 ? 1 : 0)}s`;
+  const seconds = Math.max(0, Math.round(value / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
 }
 
 function formatModelName(value: string | undefined): string {

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -10,7 +10,13 @@ import {
   Loader2,
 } from "lucide-react";
 
-import { getRunData, type AntonUIMessage } from "@/src/lib/trace";
+import {
+  getAssistantTextDisplay,
+  getMessageRunDurationMs,
+  getRunData,
+  hasPendingToolApproval,
+  type AntonUIMessage,
+} from "@/src/lib/trace";
 import { Disclosure } from "@/components/shared/disclosure";
 
 import {
@@ -20,7 +26,7 @@ import {
   getTraceRows,
   groupTraceRowsByStep,
 } from "./trace-data";
-import { InlineReasoningRow, StepGroupView, TraceRowView } from "./trace-rows";
+import { StepGroupView, TraceRowView } from "./trace-rows";
 
 function buildInterleaved(
   rows: ReturnType<typeof getTraceRows>,
@@ -55,12 +61,19 @@ export function RunTraceAccordion({
     (run?.status ?? metadata?.status) === "running" &&
     (status === "submitted" || status === "streaming");
 
-  const hasResponseText = useMemo(
-    () => message.parts.some((p) => p.type === "text" && (p as { text: string }).text.trim().length > 0),
-    [message.parts],
+  const pendingApproval = useMemo(
+    () => hasPendingToolApproval(message),
+    [message],
+  );
+  const hasFinalResponseText = useMemo(
+    () => getAssistantTextDisplay(message).finalText.length > 0,
+    [message],
   );
 
-  const showInline = isRunning && !hasResponseText;
+  const forceOpen =
+    isRunning ||
+    pendingApproval ||
+    (!hasFinalResponseText && (status === "submitted" || status === "streaming"));
 
   const now = useTick(isRunning);
   const rows = useMemo(() => getTraceRows(message), [message]);
@@ -71,62 +84,29 @@ export function RunTraceAccordion({
 
   const startedAt = run?.startedAt ?? metadata?.startedAt;
   const durationMs =
-    run?.durationMs ??
-    metadata?.durationMs ??
+    getMessageRunDurationMs(message, now) ??
     getTraceDurationMs(rows) ??
     (startedAt === undefined ? 0 : Math.max(0, now - startedAt));
   const runStatus = run?.status ?? metadata?.status ?? "completed";
   const header =
-    runStatus === "running"
+    pendingApproval
+      ? "Waiting for approval"
+      : runStatus === "running"
       ? `Working for ${formatDuration(durationMs)}`
       : runStatus === "completed"
         ? `Worked for ${formatDuration(durationMs)}`
         : `Stopped after ${formatDuration(durationMs)}`;
 
-  if (showInline) {
-    return (
-      <div className="mb-2 w-full space-y-0 text-xs text-muted-foreground">
-        <div className="flex items-center gap-1.5 px-1 py-0.5 text-[11px]">
-          <Loader2 className="size-3.5 animate-spin text-sky-400" />
-          <span className="font-medium text-foreground/90">{header}</span>
-        </div>
-        <div className="ml-1 space-y-0.5 pl-1">
-          {buildInterleaved(rows, stepGroups).map((item) =>
-            item.kind === "group" ? (
-              <StepGroupView
-                key={`step-${item.group.stepNumber}`}
-                group={item.group}
-                onApproval={onApproval}
-              />
-            ) : item.row.kind === "reasoning" ? (
-              <InlineReasoningRow
-                key={item.row.id}
-                event={item.row.event}
-                runStatus={runStatus}
-                text={item.row.text}
-              />
-            ) : (
-              <TraceRowView
-                key={item.row.id}
-                row={item.row}
-                runStatus={runStatus}
-                onApproval={onApproval}
-              />
-            ),
-          )}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <Disclosure
       className="mb-2 w-full text-xs text-muted-foreground"
-      defaultOpen={false}
-      forceOpen={isRunning}
+      defaultOpen={!hasFinalResponseText}
+      forceOpen={forceOpen}
       trigger={({ open }) => (
         <span className="inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-[11px]">
-          {runStatus === "running" ? (
+          {pendingApproval ? (
+            <AlertCircle className="size-3.5 text-amber-400" />
+          ) : runStatus === "running" ? (
             <Loader2 className="size-3.5 animate-spin text-sky-400" />
           ) : runStatus === "completed" ? (
             <CheckCircle2 className="size-3.5 text-emerald-400" />

--- a/components/features/run-trace/tool-display.tsx
+++ b/components/features/run-trace/tool-display.tsx
@@ -173,3 +173,28 @@ export function traceToolStateMeta(state: ToolTraceEntry["state"]) {
 function iconForTool({ className }: { className?: string }) {
   return <TerminalSquare className={className} />;
 }
+
+export function riskCategoryBadge(
+  category: string,
+): { label: string; baseClass: string } {
+  switch (category) {
+    case "read-only":
+      return { label: "read", baseClass: "bg-secondary text-muted-foreground ring-1 ring-border" };
+    case "write":
+      return { label: "write", baseClass: "bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/40" };
+    case "delete":
+      return { label: "delete", baseClass: "bg-red-500/15 text-red-300 ring-1 ring-red-500/40" };
+    case "network":
+      return { label: "network", baseClass: "bg-sky-500/15 text-sky-300 ring-1 ring-sky-500/40" };
+    case "package-install":
+      return { label: "install", baseClass: "bg-purple-500/15 text-purple-300 ring-1 ring-purple-500/40" };
+    case "git":
+      return { label: "git", baseClass: "bg-teal-500/15 text-teal-300 ring-1 ring-teal-500/40" };
+    case "long-running-process":
+      return { label: "long-run", baseClass: "bg-orange-500/15 text-orange-300 ring-1 ring-orange-500/40" };
+    case "external-integration":
+      return { label: "external", baseClass: "bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/40" };
+    default:
+      return { label: category, baseClass: "bg-secondary text-muted-foreground ring-1 ring-border" };
+  }
+}

--- a/components/features/run-trace/tool-trace-row.tsx
+++ b/components/features/run-trace/tool-trace-row.tsx
@@ -10,12 +10,16 @@ import {
 
 import { cn } from "@/lib/utils";
 import { Disclosure } from "@/components/shared/disclosure";
-import type { ToolTraceEntry } from "@/src/lib/trace";
+import {
+  getApprovalMetadata,
+  type ToolTraceEntry,
+} from "@/src/lib/trace";
 
 import { formatDuration, toolTitle } from "./trace-data";
 import {
   pickString,
   previewToolInput,
+  riskCategoryBadge,
   safeStringify,
   traceToolStateMeta,
 } from "./tool-display";
@@ -36,6 +40,7 @@ export function ToolTraceRow({
       ? entry.approvalId
       : undefined;
   const needsApproval = approvalId !== undefined;
+  const approvalMeta = needsApproval ? getApprovalMetadata(entry) : undefined;
   const showDetails = entry.name === "bash";
   const forceOpen = showDetails && entry.activity?.status === "running";
   const streamToken = pickString(entry.activity?.details, "streamToken");
@@ -66,7 +71,27 @@ export function ToolTraceRow({
                 </span>
               )}
               {approvalId && (
-                <ApprovalControls approvalId={approvalId} onApproval={onApproval} />
+                <>
+                  <ApprovalControls approvalId={approvalId} onApproval={onApproval} />
+                </>
+              )}
+              {approvalMeta && (
+                <span className="inline-flex items-center gap-0.5">
+                  {approvalMeta.riskCategories.map((cat) => {
+                    const badge = riskCategoryBadge(cat);
+                    return (
+                      <span
+                        key={cat}
+                        className={cn(
+                          "rounded px-1 py-px text-[9px] uppercase tracking-wide",
+                          badge.baseClass,
+                        )}
+                      >
+                        {badge.label}
+                      </span>
+                    );
+                  })}
+                </span>
               )}
               {entry.activity?.durationMs !== undefined && (
                 <span className="shrink-0 text-[10px]">
@@ -77,6 +102,15 @@ export function ToolTraceRow({
             {showPreview && (
               <span className="block truncate font-mono text-[10px]">
                 {preview}
+              </span>
+            )}
+            {approvalMeta && (
+              <span className="block text-[10px] text-muted-foreground">
+                {approvalMeta.riskSummary}
+                {approvalMeta.bashClassification &&
+                  !approvalMeta.bashClassification.forbidden && (
+                    <> &mdash; {approvalMeta.bashClassification.reason}</>
+                  )}
               </span>
             )}
           </span>

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -1,7 +1,7 @@
 import {
   getActivityEvents,
-  getReasoningTexts,
   getToolTraceEntries,
+  isReasoningPart,
   type AntonActivityEvent,
   type AntonUIMessage,
   type ToolTraceEntry,
@@ -33,63 +33,90 @@ export type TraceRow =
   | {
       id: string;
       order: number;
+      kind: "progress";
+      text: string;
+    }
+  | {
+      id: string;
+      order: number;
       kind: "tool";
       tool: ToolTraceEntry;
     };
 
 export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   const activities = getActivityEvents(message);
-  const reasoningTexts = getReasoningTexts(message);
   const reasoningActivities = activities.filter(
     (event) => event.kind === "reasoning",
   );
   const toolEntries = getToolTraceEntries([message]);
   const rows: TraceRow[] = [];
+  let reasoningIndex = 0;
+  const lastToolIndex = message.parts.findLastIndex((part) =>
+    toolCallIdForPart(part)
+      ? toolEntries.some((entry) => entry.id === toolCallIdForPart(part))
+      : false,
+  );
+
+  message.parts.forEach((part, index) => {
+    if (isReasoningPart(part)) {
+      const text = part.text.trim();
+      if (!text) return;
+      const event = reasoningActivities[reasoningIndex];
+      reasoningIndex += 1;
+      rows.push({
+        id: event?.id ?? `${message.id}:reasoning:${index}`,
+        order: index,
+        kind: "reasoning",
+        event,
+        text,
+      });
+      return;
+    }
+
+    if (part.type === "text" && index < lastToolIndex) {
+      const text = part.text.trim();
+      if (!text) return;
+      rows.push({
+        id: `${message.id}:progress:${index}`,
+        order: index,
+        kind: "progress",
+        text,
+      });
+      return;
+    }
+
+    const toolCallId = toolCallIdForPart(part);
+    if (!toolCallId) return;
+    const tool = toolEntries.find((entry) => entry.id === toolCallId);
+    if (!tool) return;
+    rows.push({
+      id: tool.id,
+      order: index,
+      kind: "tool",
+      tool,
+    });
+  });
 
   for (const event of activities) {
     if (event.kind === "tool" || event.kind === "reasoning") continue;
     if (event.kind === "step") continue;
     rows.push({
       id: event.id,
-      order: event.sequence,
+      order: 10_000 + event.sequence,
       kind: "activity",
       event,
     });
   }
 
-  if (reasoningActivities.length > 0) {
-    reasoningActivities.forEach((event, index) => {
-      const text = reasoningTexts[index] ?? reasoningTexts.join("\n\n");
-      if (!text) return;
-      rows.push({
-        id: event.id,
-        order: event.sequence,
-        kind: "reasoning",
-        event,
-        text,
-      });
-    });
-  } else {
-    reasoningTexts.forEach((text, index) => {
-      rows.push({
-        id: `${message.id}:reasoning:${index}`,
-        order: 200 + index,
-        kind: "reasoning",
-        text,
-      });
-    });
-  }
-
-  toolEntries.forEach((tool, index) => {
-    rows.push({
-      id: tool.id,
-      order: tool.activity?.sequence ?? 500 + index,
-      kind: "tool",
-      tool,
-    });
-  });
-
   return rows.sort((a, b) => a.order - b.order);
+}
+
+function toolCallIdForPart(
+  part: AntonUIMessage["parts"][number],
+): string | undefined {
+  return "toolCallId" in part && typeof part.toolCallId === "string"
+    ? part.toolCallId
+    : undefined;
 }
 
 export function groupTraceRowsByStep(
@@ -97,7 +124,9 @@ export function groupTraceRowsByStep(
   rows: TraceRow[],
 ): StepGroup[] {
   const orderedRows = rows.toSorted((a, b) => a.order - b.order);
-  const reasoningRows = orderedRows.filter((row) => row.kind === "reasoning");
+  const boundaryRows = orderedRows.filter(
+    (row) => row.kind === "reasoning" || row.kind === "progress",
+  );
   const groups: StepGroup[] = [];
 
   const addGroup = (toolRows: TraceRow[]) => {
@@ -110,26 +139,26 @@ export function groupTraceRowsByStep(
     });
   };
 
-  if (reasoningRows.length === 0) {
+  if (boundaryRows.length === 0) {
     addGroup(orderedRows.filter((row) => row.kind === "tool"));
     return groups;
   }
 
   addGroup(
     orderedRows.filter(
-      (row) => row.kind === "tool" && row.order < reasoningRows[0].order,
+      (row) => row.kind === "tool" && row.order < boundaryRows[0].order,
     ),
   );
 
-  reasoningRows.forEach((reasoningRow, index) => {
-    const nextReasoningRow = reasoningRows[index + 1];
+  boundaryRows.forEach((boundaryRow, index) => {
+    const nextBoundaryRow = boundaryRows[index + 1];
     addGroup(
       orderedRows.filter(
         (row) =>
           row.kind === "tool" &&
-          row.order > reasoningRow.order &&
-          (nextReasoningRow === undefined ||
-            row.order < nextReasoningRow.order),
+          row.order > boundaryRow.order &&
+          (nextBoundaryRow === undefined ||
+            row.order < nextBoundaryRow.order),
       ),
     );
   });
@@ -189,6 +218,7 @@ export function getTraceDurationMs(rows: TraceRow[]): number | undefined {
     .map((row) => {
       if (row.kind === "activity") return row.event.durationMs;
       if (row.kind === "reasoning") return row.event?.durationMs;
+      if (row.kind === "progress") return undefined;
       return row.tool.activity?.durationMs;
     })
     .filter((duration): duration is number => duration !== undefined);

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -8,6 +8,7 @@ import {
   ChevronDown,
   ChevronRight,
   Loader2,
+  MessageCircleMore,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -36,6 +37,9 @@ export function TraceRowView({
     return (
       <ReasoningRow event={row.event} runStatus={runStatus} text={row.text} />
     );
+  }
+  if (row.kind === "progress") {
+    return <ProgressRow text={row.text} />;
   }
   return <ActivityRow event={row.event} runStatus={runStatus} />;
 }
@@ -143,6 +147,17 @@ function ReasoningRow({
   );
 }
 
+function ProgressRow({ text }: { text: string }) {
+  return (
+    <div className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2 py-0.5">
+      <MessageCircleMore className="mt-0.5 size-3.5 text-muted-foreground" />
+      <p className="min-w-0 whitespace-pre-wrap font-mono text-[10px] leading-relaxed text-foreground/75">
+        {text}
+      </p>
+    </div>
+  );
+}
+
 export function StepGroupView({
   group,
   onApproval,
@@ -153,10 +168,13 @@ export function StepGroupView({
   const hasRunningTool = group.toolRows.some(
     (row) => row.kind === "tool" && row.tool.activity?.status === "running",
   );
+  const hasPendingApproval = group.toolRows.some(
+    (row) => row.kind === "tool" && row.tool.state === "approval-requested",
+  );
   return (
     <Disclosure
       className="py-0.5"
-      forceOpen={hasRunningTool}
+      forceOpen={hasRunningTool || hasPendingApproval}
       trigger={({ open }) => (
         <span className="inline-flex max-w-full items-center gap-1.5 rounded px-0 py-0 text-[11px] text-muted-foreground/80 hover:text-foreground/80">
           <span className="truncate">{group.summary}</span>

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -11,6 +11,7 @@ import {
 
 import {
   getToolTraceEntries,
+  getApprovalMetadata,
   type AntonUIMessage,
   type ToolTraceEntry,
 } from "@/src/lib/trace";
@@ -21,6 +22,7 @@ import {
   isOkWriteFileOutput,
   pickString,
   previewToolInput,
+  riskCategoryBadge,
   safeStringify,
   toolStateMeta,
   type WriteFileOkOutput,
@@ -166,6 +168,10 @@ function WorklogDetail({
     isOkWriteFileOutput(entry.output) &&
     pickString(entry.input, "content") !== undefined;
   const streamToken = pickString(entry.activity?.details, "streamToken");
+  const approvalMeta =
+    entry.state === "approval-requested"
+      ? getApprovalMetadata(entry)
+      : undefined;
 
   return (
     <section className="space-y-2.5 px-3 py-3">
@@ -203,7 +209,35 @@ function WorklogDetail({
             </button>
           </div>
         )}
+        {approvalMeta && (
+          <div className="flex flex-wrap items-center gap-1">
+            {approvalMeta.riskCategories.map((cat) => {
+              const badge = riskCategoryBadge(cat);
+              return (
+                <span
+                  key={cat}
+                  className={cn(
+                    "rounded px-1.5 py-px font-mono text-[10px] uppercase",
+                    badge.baseClass,
+                  )}
+                >
+                  {badge.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
       </div>
+
+      {approvalMeta && (
+        <p className="text-[10px] text-muted-foreground">
+          {approvalMeta.riskSummary}
+          {approvalMeta.bashClassification &&
+            !approvalMeta.bashClassification.forbidden && (
+              <> &mdash; {approvalMeta.bashClassification.reason}</>
+            )}
+        </p>
+      )}
 
       {entry.name !== "bash" && (
         <LogBlock title="Input">{safeStringify(entry.input)}</LogBlock>

--- a/components/features/sessions/session-row.tsx
+++ b/components/features/sessions/session-row.tsx
@@ -49,8 +49,12 @@ export function SessionRow({
   };
 
   const onDelete = async () => {
-    await remove(session.id);
-    if (isActive) router.push("/");
+    const deleted = await remove(session.id);
+    if (!deleted) return;
+    if (isActive) {
+      router.replace("/");
+      router.refresh();
+    }
   };
 
   if (editing) {

--- a/components/features/sessions/session-sidebar.tsx
+++ b/components/features/sessions/session-sidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useState, type ReactNode } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   MessageSquare,
   PanelLeftClose,
@@ -22,12 +22,19 @@ import { SidebarProvider, useSidebar } from "./sidebar-state";
 export { SidebarProvider, useSidebar };
 
 export function SessionSidebar() {
-  const { sessions, loading, error } = useSessionStore();
+  const { sessions, loading, error, removedSessionIds } = useSessionStore();
   const params = useParams<{ sessionId?: string }>();
+  const router = useRouter();
   const activeId = params?.sessionId;
   const [settingsOpen, setSettingsOpen] = useState(false);
   const { open, setOpen } = useSidebar();
   const [activeProjectId, setActiveProjectId] = useActiveProjectIdState();
+
+  useEffect(() => {
+    if (!activeId || loading || !removedSessionIds.has(activeId)) return;
+    router.replace("/");
+    router.refresh();
+  }, [activeId, loading, removedSessionIds, router]);
 
   return (
     <aside

--- a/components/features/sessions/session-store.tsx
+++ b/components/features/sessions/session-store.tsx
@@ -24,9 +24,10 @@ interface SessionStoreValue {
   sessions: SessionSummary[];
   loading: boolean;
   error: string | null;
+  removedSessionIds: ReadonlySet<string>;
   refresh: () => Promise<void>;
   rename: (id: string, title: string) => Promise<void>;
-  remove: (id: string) => Promise<void>;
+  remove: (id: string) => Promise<boolean>;
 }
 
 const SessionStoreContext = createContext<SessionStoreValue | null>(null);
@@ -35,6 +36,9 @@ export function SessionStoreProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [removedSessionIds, setRemovedSessionIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -83,22 +87,38 @@ export function SessionStoreProvider({ children }: { children: ReactNode }) {
     async (id: string) => {
       const snapshot = sessions;
       setSessions((prev) => prev.filter((s) => s.id !== id));
+      setRemovedSessionIds((prev) => new Set(prev).add(id));
       try {
         const res = await fetch(`/api/sessions/${id}`, { method: "DELETE" });
         if (!res.ok && res.status !== 204) {
           throw new Error(`HTTP ${res.status}`);
         }
+        return true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Delete failed");
         setSessions(snapshot);
+        setRemovedSessionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        return false;
       }
     },
     [sessions],
   );
 
   const value = useMemo<SessionStoreValue>(
-    () => ({ sessions, loading, error, refresh, rename, remove }),
-    [sessions, loading, error, refresh, rename, remove],
+    () => ({
+      sessions,
+      loading,
+      error,
+      removedSessionIds,
+      refresh,
+      rename,
+      remove,
+    }),
+    [sessions, loading, error, removedSessionIds, refresh, rename, remove],
   );
 
   return (

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -144,6 +144,19 @@ export function stripApprovalFlags<TTools extends ToolSet>(
   ) as TTools;
 }
 
+export function preClassifyBashInput(
+  input: unknown,
+): BashCommandClassification | undefined {
+  if (typeof input !== "object" || input === null) return undefined;
+  const command = (input as Record<string, unknown>)["command"];
+  if (typeof command !== "string") return undefined;
+  return classifyBashCommand(command);
+}
+
+export function isMcpTool(name: string): boolean {
+  return name.startsWith("mcp__");
+}
+
 export function classifyBashCommand(command: string): BashCommandClassification {
   const normalized = command.trim();
   if (!normalized) {

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -97,12 +97,167 @@ export type ToolTraceEntry = {
   activity?: AntonActivityEvent;
 };
 
+export type ApprovalMetadata = {
+  riskCategories: string[];
+  riskSummary: string;
+  bashClassification?: {
+    categories: string[];
+    forbidden: boolean;
+    reason: string;
+  };
+};
+
+export function getApprovalMetadata(
+  entry: ToolTraceEntry,
+): ApprovalMetadata | undefined {
+  const details = entry.activity?.details;
+  if (!details) return undefined;
+  const riskCategories = stringArray(details.riskCategories);
+  const riskSummary = details.riskSummary;
+  if (
+    riskCategories.length === 0 ||
+    typeof riskSummary !== "string"
+  ) {
+    return undefined;
+  }
+  const bashDetails = details.bashClassification;
+  let bashClassification: ApprovalMetadata["bashClassification"] | undefined;
+  if (
+    typeof bashDetails === "object" &&
+    bashDetails !== null &&
+    typeof (bashDetails as Record<string, unknown>).reason === "string"
+  ) {
+    const categories = stringArray(
+      (bashDetails as Record<string, unknown>).categories,
+    );
+    bashClassification = {
+      categories,
+      forbidden: Boolean((bashDetails as Record<string, unknown>).forbidden),
+      reason: (bashDetails as Record<string, unknown>).reason as string,
+    };
+  }
+  return {
+    riskCategories:
+      entry.name === "bash" && bashClassification?.categories.length
+        ? bashClassification.categories
+        : riskCategories,
+    riskSummary,
+    bashClassification,
+  };
+}
+
+export type AssistantTextDisplay = {
+  progressText: string;
+  finalText: string;
+};
+
+export function getAssistantTextDisplay(
+  message: AntonUIMessage,
+): AssistantTextDisplay {
+  const lastToolIndex = message.parts.findLastIndex(isToolUIPart);
+  const progressText: string[] = [];
+  const finalText: string[] = [];
+
+  for (const [index, part] of message.parts.entries()) {
+    if (part.type !== "text") continue;
+    const text = part.text.trim();
+    if (!text) continue;
+    if (lastToolIndex !== -1 && index < lastToolIndex) {
+      progressText.push(text);
+    } else {
+      finalText.push(text);
+    }
+  }
+
+  return {
+    progressText: progressText.join("\n\n"),
+    finalText: finalText.join("\n\n"),
+  };
+}
+
+export function hasPendingToolApproval(message: AntonUIMessage): boolean {
+  return getToolTraceEntries([message]).some(
+    (entry) => entry.state === "approval-requested",
+  );
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
 export function getRunData(message: AntonUIMessage): AntonRunData | undefined {
   let run: AntonRunData | undefined;
   for (const part of message.parts) {
     if (isRunDataPart(part)) run = part.data;
   }
   return run;
+}
+
+export function getRunDataList(message: AntonUIMessage): AntonRunData[] {
+  const byRunId = new Map<string, AntonRunData>();
+  for (const part of message.parts) {
+    if (isRunDataPart(part)) byRunId.set(part.data.runId, part.data);
+  }
+  return Array.from(byRunId.values());
+}
+
+export function getMessageRunDurationMs(
+  message: AntonUIMessage,
+  now = Date.now(),
+): number | undefined {
+  const runs = getRunDataList(message);
+  if (runs.length > 0) return sumRunDurations(runs, now);
+
+  const metadataDuration = finiteNumber(message.metadata?.durationMs);
+  if (metadataDuration !== undefined) return metadataDuration;
+
+  const startedAt = finiteNumber(message.metadata?.startedAt);
+  if (message.metadata?.status === "running" && startedAt !== undefined) {
+    return Math.max(0, now - startedAt);
+  }
+
+  const finishedAt = finiteNumber(message.metadata?.finishedAt);
+  if (startedAt !== undefined && finishedAt !== undefined) {
+    return Math.max(0, finishedAt - startedAt);
+  }
+
+  return undefined;
+}
+
+function sumRunDurations(runs: AntonRunData[], now: number): number | undefined {
+  let total = 0;
+  let hasDuration = false;
+
+  for (const run of runs) {
+    const duration = runDurationMs(run, now);
+    if (duration === undefined) continue;
+    total += duration;
+    hasDuration = true;
+  }
+
+  return hasDuration ? total : undefined;
+}
+
+function runDurationMs(run: AntonRunData, now: number): number | undefined {
+  const durationMs = finiteNumber(run.durationMs);
+  if (durationMs !== undefined) return durationMs;
+
+  const startedAt = finiteNumber(run.startedAt);
+  if (run.status === "running" && startedAt !== undefined) {
+    return Math.max(0, now - startedAt);
+  }
+
+  const finishedAt = finiteNumber(run.finishedAt);
+  if (startedAt !== undefined && finishedAt !== undefined) {
+    return Math.max(0, finishedAt - startedAt);
+  }
+
+  return undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 export function getActivityEvents(
@@ -160,6 +315,12 @@ export function getReasoningTexts(message: AntonUIMessage): string[] {
     .filter(isReasoningUIPart)
     .map((part) => part.text.trim())
     .filter((text) => text.length > 0);
+}
+
+export function isReasoningPart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "reasoning" }> {
+  return isReasoningUIPart(part);
 }
 
 export function isRunDataPart(


### PR DESCRIPTION
## Summary
- Fix approval metadata and risk badge handling for bash tool approvals.
- Split interim assistant narration into trace progress while rendering only final assistant response text.
- Keep pending/running traces visible and avoid trace remount flicker around approvals.
- Restore bash live output visibility and preserve stream context during tool completion.
- Align response stats, session token chips, and trace durations across approval continuations.
- Reset chat state correctly when navigating to a new/deleted session.

## Root Cause
Auto-review approval continuations can append multiple run records to one assistant message. The UI was reading only one run in some places, using stale metadata in others, and switching trace render paths as approval state changed. That caused mismatched token/duration values, frozen trace timers, response fallback output during active runs, and stale session rendering after deletes.

## Issues
Closes Ramgopalbhat10/anton#39
Closes Ramgopalbhat10/anton#40

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `Invoke-WebRequest -UseBasicParsing http://localhost:3000` returned `200`

## Visual Verification
Manually checked the trace/stat UI flows on the existing local dev server at `http://localhost:3000`, including pending approvals, running bash output, final response rendering, duration display, and the widened stats popover.