### PR TITLE
Complete Phase 1 trust boundary hardening

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,12 +55,12 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add per-tool and per-command approval metadata that explains exactly what will happen before execution.
 - [✔️] Require explicit approval before starting stdio MCP servers, not only before invoking MCP tools.
 - [✔️] Add a trust store for approved MCP server configs, commands, environment variables, and workspace roots.
-- [] Scrub shell environment by default and pass only an allowlist of required variables.
-- [] Add command policy checks for absolute paths, shell redirection outside workspace, destructive filesystem operations, network access, and secret-printing commands.
-- [] Replace the current `sudo`/`su` denylist with a parser-backed or policy-backed command classifier.
-- [] Add secret redaction for tool inputs, tool outputs, logs, and UI rendering.
-- [] Add workspace-root validation that prevents using Anton source, `.git`, dependency folders, build output, system directories, and user home as agent workspaces.
-- [] Add tests for sandbox traversal, symlink escapes, workspace root validation, and command policy behavior.
+- [✔️] Scrub shell environment by default and pass only an allowlist of required variables.
+- [✔️] Add command policy checks for absolute paths, shell redirection outside workspace, destructive filesystem operations, network access, and secret-printing commands.
+- [✔️] Replace the current `sudo`/`su` denylist with a parser-backed or policy-backed command classifier.
+- [✔️] Add secret redaction for tool inputs, tool outputs, logs, and UI rendering.
+- [✔️] Add workspace-root validation that prevents using Anton source, `.git`, dependency folders, build output, system directories, and user home as agent workspaces.
+- [✔️] Add tests for sandbox traversal, symlink escapes, workspace root validation, and command policy behavior.
 
 ## Phase 2: Real Coding-Agent Editing
 
@@ -158,12 +158,12 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 ## Known Implementation Risks
 
 - [] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
-- [] Shell tool still runs through `bash -lc` with broad process capability and no environment allowlist.
+- [] Shell tool still runs through `bash -lc`; command policy is heuristic rather than a full shell parser.
 - [] MCP stdio server startup can execute configured commands before user approval.
 - [] Full-file `write_file` remains the main write primitive.
 - [] Message persistence still deletes and reinserts the full session transcript.
 - [] There is no durable tool-call audit table yet.
 - [] There is no automated test suite yet.
 - [] GitHub clone/fetch runs synchronously inside request handling and may exceed request duration for large repositories.
-- [] Installation tokens are injected into git through extra headers; logs and errors need explicit secret redaction guarantees.
+- [] Installation tokens are injected into git through extra headers; keep redaction coverage current as clone/fetch behavior evolves.
 - [] Active project selection is client-local and not yet a durable user/workspace preference.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -35,6 +35,7 @@ import {
   upsertRunEvent,
 } from "@/src/db/queries";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
+import { redactText, redactValue } from "@/src/lib/redaction";
 import type {
   AntonActivityEvent,
   AntonActivityKind,
@@ -173,7 +174,10 @@ export async function POST(req: Request) {
     onFinish: ({ messages }) => {
       const persistedMessages = messages.filter(hasSubstantiveHistoryParts);
       if (persistedMessages.length === 0) return;
-      replaceMessages<AntonUIMessage>(sessionId, persistedMessages);
+      replaceMessages<AntonUIMessage>(
+        sessionId,
+        redactValue(persistedMessages) as AntonUIMessage[],
+      );
     },
   });
 
@@ -292,7 +296,7 @@ function createTraceWriter({
       kind: event.kind,
       status: event.status,
       label: event.label,
-      summary: event.summary ?? null,
+      summary: event.summary ? redactText(event.summary) : null,
       startedAt: new Date(event.startedAt),
       finishedAt: event.finishedAt ? new Date(event.finishedAt) : null,
       durationMs: event.durationMs ?? null,
@@ -302,9 +306,10 @@ function createTraceWriter({
   };
 
   const writeEvent = (event: AntonActivityEvent) => {
-    events.set(event.id, event);
-    persistEvent(event);
-    writer.write({ type: "data-activity", id: event.id, data: event });
+    const safeEvent = redactActivityEvent(event);
+    events.set(safeEvent.id, safeEvent);
+    persistEvent(safeEvent);
+    writer.write({ type: "data-activity", id: safeEvent.id, data: safeEvent });
   };
 
   const startEvent = ({
@@ -371,7 +376,7 @@ function createTraceWriter({
     if (typeof input !== "object" || input === null) return undefined;
     const record = input as Record<string, unknown>;
     for (const key of ["command", "path", "pattern", "slug", "task"]) {
-      if (typeof record[key] === "string") return record[key];
+      if (typeof record[key] === "string") return redactText(record[key]);
     }
     return undefined;
   };
@@ -466,7 +471,7 @@ function createTraceWriter({
         workspaceRoot,
       });
       if (approval) {
-        details.approval = approval;
+        details.approval = redactValue(approval);
         details.riskCategories = [...approval.riskCategories];
         details.riskSummary = approval.summary;
       }
@@ -534,7 +539,7 @@ function createTraceWriter({
           kind: "error",
           status: "error",
           label: "Stream error",
-          summary: errorMessage(part.error),
+          summary: redactText(errorMessage(part.error)),
         });
       }
     },
@@ -544,7 +549,7 @@ function createTraceWriter({
         kind: "error",
         status: "error",
         label: "Run failed",
-        summary: errorMessage(error),
+        summary: redactText(errorMessage(error)),
       });
       finalize("error");
     },
@@ -576,5 +581,20 @@ function persistableEventDetails(
   if (!details) return null;
   const persistable = { ...details };
   delete persistable.streamToken;
-  return persistable;
+  return redactValue(persistable) as Record<string, unknown>;
+}
+
+function redactActivityEvent(event: AntonActivityEvent): AntonActivityEvent {
+  const details = event.details
+    ? (redactValue(event.details) as Record<string, unknown>)
+    : undefined;
+  if (details && event.details && "streamToken" in event.details) {
+    details.streamToken = event.details.streamToken;
+  }
+  return {
+    ...event,
+    label: redactText(event.label),
+    summary: event.summary ? redactText(event.summary) : event.summary,
+    details,
+  };
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "node --import tsx --test \"tests/**/*.test.ts\"",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",

--- a/src/agent/command-policy.ts
+++ b/src/agent/command-policy.ts
@@ -1,0 +1,415 @@
+import path from "node:path";
+
+import type { ToolRiskCategory } from "./permissions";
+
+export type BashCommandClassification = {
+  categories: readonly ToolRiskCategory[];
+  forbidden: boolean;
+  reason: string;
+};
+
+export type BashCommandPolicyDecision =
+  | {
+      allowed: true;
+      classification: BashCommandClassification;
+    }
+  | {
+      allowed: false;
+      classification: BashCommandClassification;
+      reason: string;
+    };
+
+const RISK_CATEGORY_ORDER: readonly ToolRiskCategory[] = [
+  "read-only",
+  "write",
+  "delete",
+  "network",
+  "package-install",
+  "git",
+  "long-running-process",
+  "external-integration",
+];
+
+const READ_ONLY_COMMANDS = new Set([
+  "awk",
+  "basename",
+  "cat",
+  "dirname",
+  "du",
+  "echo",
+  "file",
+  "find",
+  "grep",
+  "head",
+  "jq",
+  "ls",
+  "pwd",
+  "realpath",
+  "rg",
+  "sed",
+  "sort",
+  "stat",
+  "tail",
+  "test",
+  "tree",
+  "tr",
+  "type",
+  "wc",
+  "which",
+]);
+
+const BASH_ENV_ALLOWLIST = new Set([
+  "CI",
+  "COLORTERM",
+  "ComSpec",
+  "COMSPEC",
+  "FORCE_COLOR",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "NO_COLOR",
+  "Path",
+  "PATH",
+  "PATHEXT",
+  "SHELL",
+  "SystemRoot",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "USERPROFILE",
+  "WINDIR",
+  "windir",
+]);
+
+const FORBIDDEN_COMMAND_PATTERNS: readonly RegExp[] = [
+  /(^|\s|;|&&|\|\|)\s*sudo(\s|$)/,
+  /(^|\s|;|&&|\|\|)\s*su(\s|$)/,
+];
+
+const SECRET_FILE_RE =
+  /(^|[\s/\\])(?:\.env(?:\.[^/\\\s]+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|[^/\\\s]*(?:token|secret|credential|private[-_]?key)[^/\\\s]*)(?:$|\s)/i;
+const SECRET_NAME_RE =
+  /\b(?:api[_-]?key|authorization|bearer|client[_-]?secret|credential|github[_-]?app[_-]?private[_-]?key|openrouter[_-]?api[_-]?key|password|private[_-]?key|secret|token)\b/i;
+
+export function classifyBashCommand(command: string): BashCommandClassification {
+  const normalized = command.trim();
+  if (!normalized) {
+    return {
+      categories: ["read-only"],
+      forbidden: false,
+      reason: "empty command",
+    };
+  }
+
+  const forbidden = forbiddenPattern(normalized);
+  if (forbidden) {
+    return {
+      categories: ["external-integration"],
+      forbidden: true,
+      reason: `forbidden command pattern: ${forbidden}`,
+    };
+  }
+
+  const categories = new Set<ToolRiskCategory>();
+  if (isGitCommand(normalized)) categories.add("git");
+  if (hasNetworkPattern(normalized)) categories.add("network");
+  if (hasPackageInstallPattern(normalized)) categories.add("package-install");
+  if (hasLongRunningPattern(normalized)) categories.add("long-running-process");
+  if (hasDeletePattern(normalized)) categories.add("delete");
+  if (hasWritePattern(normalized)) categories.add("write");
+  if (hasExternalIntegrationPattern(normalized)) categories.add("external-integration");
+
+  if (
+    isReadOnlyShellCommand(normalized) &&
+    (categories.size === 0 || (categories.size === 1 && categories.has("git")))
+  ) {
+    categories.add("read-only");
+  } else if (categories.size === 0) {
+    categories.add("write");
+  }
+
+  const orderedCategories = orderedRiskCategories(categories);
+  return {
+    categories: orderedCategories,
+    forbidden: false,
+    reason: reasonForCategories(orderedCategories),
+  };
+}
+
+export function evaluateBashCommandPolicy(
+  command: string,
+  options: { workspaceRoot?: string } = {},
+): BashCommandPolicyDecision {
+  const classification = classifyBashCommand(command);
+  if (classification.forbidden) {
+    return { allowed: false, classification, reason: classification.reason };
+  }
+
+  const violation = firstPolicyViolation(command, options.workspaceRoot);
+  if (violation) {
+    return {
+      allowed: false,
+      classification: { ...classification, forbidden: true, reason: violation },
+      reason: violation,
+    };
+  }
+
+  return { allowed: true, classification };
+}
+
+export function buildBashEnvironment(
+  source: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (!isAllowedEnvironmentKey(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function firstPolicyViolation(
+  command: string,
+  workspaceRoot: string | undefined,
+): string | null {
+  const normalized = command.trim();
+  if (!normalized) return null;
+  if (printsEnvironment(normalized)) {
+    return "refuses commands that print the shell environment";
+  }
+  if (readsSecretTarget(normalized)) {
+    return "refuses commands that read or search likely secret files or values";
+  }
+  return (
+    destructiveTargetViolation(normalized) ??
+    absolutePathViolation(normalized) ??
+    redirectionViolation(normalized, workspaceRoot)
+  );
+}
+
+function forbiddenPattern(command: string): RegExp | null {
+  for (const re of FORBIDDEN_COMMAND_PATTERNS) {
+    if (re.test(command)) return re;
+  }
+  return null;
+}
+
+function printsEnvironment(command: string): boolean {
+  return splitCommandSegments(command).some((segment) =>
+    /^(?:env|printenv|set)(?:\s|$)/.test(segment),
+  );
+}
+
+function readsSecretTarget(command: string): boolean {
+  return splitCommandSegments(command).some((segment) => {
+    if (!/^(?:cat|grep|head|tail|less|more|rg|sed|awk|type)\b/.test(segment)) {
+      return false;
+    }
+    return SECRET_FILE_RE.test(`${segment} `) || SECRET_NAME_RE.test(segment);
+  });
+}
+
+function destructiveTargetViolation(command: string): string | null {
+  for (const segment of splitCommandSegments(command)) {
+    if (!/^(?:rm|unlink|rmdir)\b/.test(segment)) continue;
+    const targets = shellWords(segment).slice(1).filter((token) => !token.startsWith("-"));
+    if (
+      targets.some((token) =>
+        ["/", "\\", "~", ".", "..", "*", "./*", ".\\*"].includes(token),
+      )
+    ) {
+      return "refuses destructive filesystem commands aimed at root, home, parent, current directory, or workspace-wide wildcards";
+    }
+    if (targets.some((token) => token.startsWith("../") || token.startsWith("..\\"))) {
+      return "refuses destructive filesystem commands targeting parent directories";
+    }
+  }
+  if (/\bgit\s+(?:clean|reset\s+--hard)\b/.test(command)) {
+    return "refuses destructive git cleanup/reset commands";
+  }
+  return null;
+}
+
+function absolutePathViolation(command: string): string | null {
+  for (const token of shellWords(command)) {
+    if (isUrl(token) || token.startsWith("-")) continue;
+    if (isAbsoluteFilesystemPath(token)) {
+      return "refuses absolute filesystem paths in shell commands";
+    }
+  }
+  return null;
+}
+
+function redirectionViolation(
+  command: string,
+  workspaceRoot: string | undefined,
+): string | null {
+  const redirections = command.matchAll(/(?:^|[^<>])>{1,2}(?![>&])\s*([^;&|)\s]+)/g);
+  for (const match of redirections) {
+    const target = stripQuotes(match[1] ?? "");
+    if (!target || target === "/dev/null") continue;
+    if (target.startsWith("../") || target.startsWith("..\\")) {
+      return "refuses shell redirection outside the workspace";
+    }
+    if (isAbsoluteFilesystemPath(target)) {
+      if (!workspaceRoot) return "refuses absolute shell redirection targets";
+      if (!isInside(path.resolve(target), path.resolve(workspaceRoot))) {
+        return "refuses shell redirection outside the workspace";
+      }
+    }
+  }
+  return null;
+}
+
+function shellWords(command: string): string[] {
+  const words = command.match(/"[^"]*"|'[^']*'|[^\s;&|()]+/g) ?? [];
+  return words.map(stripQuotes);
+}
+
+function splitCommandSegments(command: string): string[] {
+  return command
+    .split(/&&|\|\||[;|]/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/g, "");
+}
+
+function isAbsoluteFilesystemPath(value: string): boolean {
+  return (
+    path.isAbsolute(value) ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.startsWith("/") ||
+    value.startsWith("\\")
+  );
+}
+
+function isUrl(value: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(value);
+}
+
+function isInside(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function isAllowedEnvironmentKey(key: string): boolean {
+  return BASH_ENV_ALLOWLIST.has(key) || key.startsWith("LC_");
+}
+
+function orderedRiskCategories(
+  categories: ReadonlySet<ToolRiskCategory>,
+): ToolRiskCategory[] {
+  return RISK_CATEGORY_ORDER.filter((category) => categories.has(category));
+}
+
+function reasonForCategories(categories: readonly ToolRiskCategory[]): string {
+  if (categories.length === 1 && categories[0] === "read-only") {
+    return "matched read-only command patterns";
+  }
+  return `matched ${categories.join(", ")} command risk patterns`;
+}
+
+function isGitCommand(command: string): boolean {
+  return /(^|[\s;&|()])git(\s|$)/.test(command);
+}
+
+function hasNetworkPattern(command: string): boolean {
+  return (
+    /\b(?:curl|wget|ssh|scp|sftp|rsync|nc|netcat|telnet|ftp)\b/.test(command) ||
+    /\b(?:https?|ssh|git):\/\/\S+/.test(command) ||
+    /\bgit@[A-Za-z0-9_.-]+:[^\s]+/.test(command) ||
+    /\bgit\s+(?:clone|fetch|pull|push|ls-remote|submodule\s+update)\b/.test(
+      command,
+    ) ||
+    /\bgh\s+(?:api|auth|browse|codespace|gist|issue|pr|release|repo|run|workflow)\b/.test(
+      command,
+    )
+  );
+}
+
+function hasPackageInstallPattern(command: string): boolean {
+  return (
+    /\b(?:npm|pnpm|yarn|bun)\s+(?:install|i|add|remove|rm|update|upgrade|dlx|create|init)\b/.test(
+      command,
+    ) ||
+    /\bnpx\b/.test(command) ||
+    /\bpip3?\s+install\b/.test(command) ||
+    /\buv\s+(?:add|remove|sync|pip\s+install)\b/.test(command) ||
+    /\bpoetry\s+(?:add|install|remove|update)\b/.test(command) ||
+    /\bcargo\s+install\b/.test(command) ||
+    /\bgo\s+(?:get|install)\b/.test(command) ||
+    /\bgem\s+install\b/.test(command) ||
+    /\bbundle\s+(?:add|install|update)\b/.test(command) ||
+    /\bcomposer\s+(?:install|require|remove|update)\b/.test(command)
+  );
+}
+
+function hasLongRunningPattern(command: string): boolean {
+  return (
+    /(^|[\s;&|()])(?:watch|top|htop|less|more)\b/.test(command) ||
+    /\b(?:tail)\s+[^;&|]*\s-f\b/.test(command) ||
+    /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|preview|watch)\b/.test(
+      command,
+    ) ||
+    /\b(?:next|vite|webpack|turbo)\s+(?:dev|start|serve|preview|watch)\b/.test(
+      command,
+    ) ||
+    /\b(?:nodemon|tsx\s+watch|ts-node-dev)\b/.test(command) ||
+    /\bpython3?\s+-m\s+http\.server\b/.test(command) ||
+    /(^|[\s;&|()])sleep\s+(?:[3-9]\d|\d{3,})\b/.test(command) ||
+    /(^|[^&])&\s*(?:$|[#;])/.test(command)
+  );
+}
+
+function hasDeletePattern(command: string): boolean {
+  return (
+    /(^|[\s;&|()])(?:rm|unlink|rmdir)\b/.test(command) ||
+    /\bfind\b[^;&|]*\s-delete\b/.test(command) ||
+    /\bgit\s+(?:clean|reset\s+--hard)\b/.test(command)
+  );
+}
+
+function hasWritePattern(command: string): boolean {
+  return (
+    /(^|[^<>])>{1,2}(?![>&])/.test(command) ||
+    /(^|[\s;&|()])(?:tee|touch|mkdir|mv|cp|install|chmod|chown|truncate)\b/.test(
+      command,
+    ) ||
+    /\b(?:sed|perl)\s+[^;&|]*\s-i(?:\s|$)/.test(command) ||
+    /\bgit\s+(?:add|am|apply|checkout|cherry-pick|commit|merge|mv|rebase|restore|revert|switch|tag)\b/.test(
+      command,
+    ) ||
+    hasPackageInstallPattern(command)
+  );
+}
+
+function hasExternalIntegrationPattern(command: string): boolean {
+  return (
+    /\b(?:gh|aws|gcloud|az|vercel|netlify|flyctl|railway|supabase|stripe|kubectl|docker|docker-compose)\b/.test(
+      command,
+    ) || hasNetworkPattern(command)
+  );
+}
+
+function isReadOnlyShellCommand(command: string): boolean {
+  const segments = splitCommandSegments(command);
+  if (segments.length === 0) return true;
+
+  return segments.every((segment) => {
+    const executable = segment.match(/^([A-Za-z0-9_.-]+)/)?.[1];
+    if (!executable) return false;
+    if (executable === "git") {
+      return /\bgit\s+(?:status|diff|show|log|branch|rev-parse|ls-files)\b/.test(
+        segment,
+      );
+    }
+    if (executable === "find" && /\s-delete\b/.test(segment)) return false;
+    return READ_ONLY_COMMANDS.has(executable);
+  });
+}

--- a/src/agent/mcp-config.ts
+++ b/src/agent/mcp-config.ts
@@ -2,6 +2,12 @@ import { createHash } from "node:crypto";
 
 import { z } from "zod";
 
+import {
+  preserveRedactedRecordValues,
+  redactRecordSecrets,
+  redactText,
+} from "@/src/lib/redaction";
+
 export const mcpTransportSchema = z.enum(["stdio", "http", "sse"]);
 export type McpTransport = z.infer<typeof mcpTransportSchema>;
 
@@ -62,6 +68,42 @@ export function normalizeMcpConfig(config: McpServerConfig): McpServerConfig {
   };
 }
 
+export function redactMcpConfig(config: McpServerConfig): McpServerConfig {
+  if (config.type === "stdio") {
+    return {
+      ...config,
+      args: config.args.map(redactText),
+      env: redactRecordSecrets(config.env),
+      ...(config.cwd ? { cwd: redactText(config.cwd) } : {}),
+    };
+  }
+
+  return {
+    ...config,
+    url: redactText(config.url),
+    headers: redactRecordSecrets(config.headers),
+  };
+}
+
+export function preserveRedactedMcpConfigValues(
+  next: McpServerConfig,
+  current: McpServerConfig,
+): McpServerConfig {
+  if (next.type === "stdio" && current.type === "stdio") {
+    return {
+      ...next,
+      env: preserveRedactedRecordValues(next.env, current.env),
+    };
+  }
+  if (next.type !== "stdio" && current.type !== "stdio") {
+    return {
+      ...next,
+      headers: preserveRedactedRecordValues(next.headers, current.headers),
+    };
+  }
+  return next;
+}
+
 export function fingerprintMcpConfig(config: McpServerConfig): string {
   const stable = stableJson(normalizeMcpConfig(config));
   return createHash("sha256").update(stable).digest("hex");
@@ -84,9 +126,9 @@ export function makeMcpApprovalDetails({
       riskCategories: ["external-integration", "long-running-process"],
       target: normalized.command,
       details: [
-        `Command: ${normalized.command}`,
-        `Args: ${normalized.args.length > 0 ? normalized.args.join(" ") : "none"}`,
-        `Working directory: ${normalized.cwd ?? "workspace root"}`,
+        `Command: ${redactText(normalized.command)}`,
+        `Args: ${normalized.args.length > 0 ? redactText(normalized.args.join(" ")) : "none"}`,
+        `Working directory: ${normalized.cwd ? redactText(normalized.cwd) : "workspace root"}`,
         `Environment keys: ${envKeys.length > 0 ? envKeys.join(", ") : "none"}`,
         "Trust only allows server startup; individual MCP tool calls still require approval.",
       ],
@@ -102,7 +144,7 @@ export function makeMcpApprovalDetails({
     target: normalized.url,
     details: [
       `Transport: ${normalized.type.toUpperCase()}`,
-      `URL: ${normalized.url}`,
+      `URL: ${redactText(normalized.url)}`,
       `Headers: ${headerKeys.length > 0 ? headerKeys.join(", ") : "none"}`,
       `Redirect mode: ${normalized.redirect}`,
       "Trust only allows server connection; individual MCP tool calls still require approval.",
@@ -121,9 +163,9 @@ export function namespaceFromDisplayName(displayName: string): string {
 
 export function summarizeMcpConfig(config: McpServerConfig): string {
   if (config.type === "stdio") {
-    return [config.command, ...(config.args ?? [])].join(" ");
+    return redactText([config.command, ...(config.args ?? [])].join(" "));
   }
-  return config.url;
+  return redactText(config.url);
 }
 
 function sortedRecord(record: Record<string, string>): Record<string, string> {

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -6,6 +6,10 @@ import {
   ensureWorkspaceRootAt,
   resolveInWorkspace,
 } from "./sandbox";
+import {
+  classifyBashCommand as classifyBashCommandByPolicy,
+  type BashCommandClassification,
+} from "./command-policy";
 
 // Permission gate helpers for tool execution.
 //
@@ -37,12 +41,6 @@ export type ToolPermissionMetadata = {
   categories: readonly ToolRiskCategory[];
   requiresApproval: boolean;
   summary: string;
-};
-
-export type BashCommandClassification = {
-  categories: readonly ToolRiskCategory[];
-  forbidden: boolean;
-  reason: string;
 };
 
 export type ToolApprovalMetadata = {
@@ -431,65 +429,7 @@ function buildMcpToolApprovalMetadata(toolName: string): ToolApprovalMetadata {
 }
 
 export function classifyBashCommand(command: string): BashCommandClassification {
-  const normalized = command.trim();
-  if (!normalized) {
-    return {
-      categories: ["read-only"],
-      forbidden: false,
-      reason: "empty command",
-    };
-  }
-
-  const forbidden = isForbiddenBashCommand(normalized);
-  if (forbidden) {
-    return {
-      categories: ["external-integration"],
-      forbidden: true,
-      reason: `forbidden command pattern: ${forbidden}`,
-    };
-  }
-
-  const categories = new Set<ToolRiskCategory>();
-
-  if (isGitCommand(normalized)) categories.add("git");
-  if (hasNetworkPattern(normalized)) categories.add("network");
-  if (hasPackageInstallPattern(normalized)) categories.add("package-install");
-  if (hasLongRunningPattern(normalized)) categories.add("long-running-process");
-  if (hasDeletePattern(normalized)) categories.add("delete");
-  if (hasWritePattern(normalized)) categories.add("write");
-  if (hasExternalIntegrationPattern(normalized)) {
-    categories.add("external-integration");
-  }
-
-  if (
-    isReadOnlyShellCommand(normalized) &&
-    (categories.size === 0 || (categories.size === 1 && categories.has("git")))
-  ) {
-    categories.add("read-only");
-  } else if (categories.size === 0) {
-    categories.add("write");
-  }
-
-  const orderedCategories = orderedRiskCategories(categories);
-  return {
-    categories: orderedCategories,
-    forbidden: false,
-    reason: reasonForCategories(orderedCategories),
-  };
-}
-
-// Commands we refuse to execute in `bash` even after approval — the user
-// should never be able to approve these by accident.
-export const FORBIDDEN_BASH_PATTERNS: readonly RegExp[] = [
-  /(^|\s|;|&&|\|\|)\s*sudo(\s|$)/,
-  /(^|\s|;|&&|\|\|)\s*su(\s|$)/,
-];
-
-export function isForbiddenBashCommand(command: string): RegExp | null {
-  for (const re of FORBIDDEN_BASH_PATTERNS) {
-    if (re.test(command)) return re;
-  }
-  return null;
+  return classifyBashCommandByPolicy(command);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -579,148 +519,3 @@ function toolMetadata(
 ): ToolPermissionMetadata {
   return { categories, requiresApproval, summary };
 }
-
-function orderedRiskCategories(
-  categories: ReadonlySet<ToolRiskCategory>,
-): ToolRiskCategory[] {
-  return TOOL_RISK_CATEGORIES.filter((category) => categories.has(category));
-}
-
-function reasonForCategories(categories: readonly ToolRiskCategory[]): string {
-  if (categories.length === 1 && categories[0] === "read-only") {
-    return "matched read-only command patterns";
-  }
-
-  return `matched ${categories.join(", ")} command risk patterns`;
-}
-
-function isGitCommand(command: string): boolean {
-  return /(^|[\s;&|()])git(\s|$)/.test(command);
-}
-
-function hasNetworkPattern(command: string): boolean {
-  return (
-    /\b(?:curl|wget|ssh|scp|sftp|rsync|nc|netcat|telnet|ftp)\b/.test(command) ||
-    /\b(?:https?|ssh|git):\/\/\S+/.test(command) ||
-    /\bgit@[A-Za-z0-9_.-]+:[^\s]+/.test(command) ||
-    /\bgit\s+(?:clone|fetch|pull|push|ls-remote|submodule\s+update)\b/.test(
-      command,
-    ) ||
-    /\bgh\s+(?:api|auth|browse|codespace|gist|issue|pr|release|repo|run|workflow)\b/.test(
-      command,
-    )
-  );
-}
-
-function hasPackageInstallPattern(command: string): boolean {
-  return (
-    /\b(?:npm|pnpm|yarn|bun)\s+(?:install|i|add|remove|rm|update|upgrade|dlx|create|init)\b/.test(
-      command,
-    ) ||
-    /\bnpx\b/.test(command) ||
-    /\bpip3?\s+install\b/.test(command) ||
-    /\buv\s+(?:add|remove|sync|pip\s+install)\b/.test(command) ||
-    /\bpoetry\s+(?:add|install|remove|update)\b/.test(command) ||
-    /\bcargo\s+install\b/.test(command) ||
-    /\bgo\s+(?:get|install)\b/.test(command) ||
-    /\bgem\s+install\b/.test(command) ||
-    /\bbundle\s+(?:add|install|update)\b/.test(command) ||
-    /\bcomposer\s+(?:install|require|remove|update)\b/.test(command)
-  );
-}
-
-function hasLongRunningPattern(command: string): boolean {
-  return (
-    /(^|[\s;&|()])(?:watch|top|htop|less|more)\b/.test(command) ||
-    /\b(?:tail)\s+[^;&|]*\s-f\b/.test(command) ||
-    /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|preview|watch)\b/.test(
-      command,
-    ) ||
-    /\b(?:next|vite|webpack|turbo)\s+(?:dev|start|serve|preview|watch)\b/.test(
-      command,
-    ) ||
-    /\b(?:nodemon|tsx\s+watch|ts-node-dev)\b/.test(command) ||
-    /\bpython3?\s+-m\s+http\.server\b/.test(command) ||
-    /(^|[\s;&|()])sleep\s+(?:[3-9]\d|\d{3,})\b/.test(command) ||
-    /(^|[^&])&\s*(?:$|[#;])/.test(command)
-  );
-}
-
-function hasDeletePattern(command: string): boolean {
-  return (
-    /(^|[\s;&|()])(?:rm|unlink|rmdir)\b/.test(command) ||
-    /\bfind\b[^;&|]*\s-delete\b/.test(command) ||
-    /\bgit\s+(?:clean|reset\s+--hard)\b/.test(command)
-  );
-}
-
-function hasWritePattern(command: string): boolean {
-  return (
-    /(^|[^<>])>{1,2}(?![>&])/.test(command) ||
-    /(^|[\s;&|()])(?:tee|touch|mkdir|mv|cp|install|chmod|chown|truncate)\b/.test(
-      command,
-    ) ||
-    /\b(?:sed|perl)\s+[^;&|]*\s-i(?:\s|$)/.test(command) ||
-    /\bgit\s+(?:add|am|apply|checkout|cherry-pick|commit|merge|mv|rebase|restore|revert|switch|tag)\b/.test(
-      command,
-    ) ||
-    hasPackageInstallPattern(command)
-  );
-}
-
-function hasExternalIntegrationPattern(command: string): boolean {
-  return (
-    /\b(?:gh|aws|gcloud|az|vercel|netlify|flyctl|railway|supabase|stripe|kubectl|docker|docker-compose)\b/.test(
-      command,
-    ) || hasNetworkPattern(command)
-  );
-}
-
-function isReadOnlyShellCommand(command: string): boolean {
-  const segments = command
-    .split(/&&|\|\||[;|]/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-  if (segments.length === 0) return true;
-
-  return segments.every((segment) => {
-    const executable = segment.match(/^(?:env\s+)?([A-Za-z0-9_.-]+)/)?.[1];
-    if (!executable) return false;
-    if (executable === "git") {
-      return /\bgit\s+(?:status|diff|show|log|branch|rev-parse|ls-files)\b/.test(
-        segment,
-      );
-    }
-    if (executable === "find" && /\s-delete\b/.test(segment)) return false;
-    return READ_ONLY_COMMANDS.has(executable);
-  });
-}
-
-const READ_ONLY_COMMANDS = new Set([
-  "awk",
-  "basename",
-  "cat",
-  "dirname",
-  "du",
-  "echo",
-  "env",
-  "file",
-  "find",
-  "grep",
-  "head",
-  "jq",
-  "ls",
-  "pwd",
-  "realpath",
-  "rg",
-  "sed",
-  "sort",
-  "stat",
-  "tail",
-  "test",
-  "tree",
-  "tr",
-  "type",
-  "wc",
-  "which",
-]);

--- a/src/agent/sandbox.ts
+++ b/src/agent/sandbox.ts
@@ -24,6 +24,7 @@ export function ensureWorkspaceRoot(): string {
 
 export function ensureWorkspaceRootAt(rootPath: string): string {
   const root = path.resolve(rootPath);
+  validateSandboxWorkspaceRoot(root);
   if (!fs.existsSync(root)) {
     fs.mkdirSync(root, { recursive: true });
   }
@@ -84,6 +85,40 @@ export function workspaceRelativeTo(rootPath: string, absPath: string): string {
 function isInside(child: string, parent: string): boolean {
   const rel = path.relative(parent, child);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function validateSandboxWorkspaceRoot(root: string): void {
+  const resolved = path.resolve(root);
+  const appRoot = path.resolve(process.cwd());
+  if (samePath(resolved, appRoot)) {
+    throw new SandboxError("workspace root cannot be the Anton source directory");
+  }
+  if (samePath(resolved, path.parse(resolved).root)) {
+    throw new SandboxError("workspace root cannot be a filesystem root");
+  }
+  if (samePath(resolved, homeDir())) {
+    throw new SandboxError("workspace root cannot be the user home directory");
+  }
+  if (hasUnsafeSegment(resolved)) {
+    throw new SandboxError(
+      "workspace root cannot be inside .git, dependencies, or build output",
+    );
+  }
+}
+
+function hasUnsafeSegment(target: string): boolean {
+  const parts = path.resolve(target).split(path.sep).map((part) => part.toLowerCase());
+  return parts.some((part) =>
+    [".git", "node_modules", ".next", "dist", "build"].includes(part),
+  );
+}
+
+function homeDir(): string {
+  return process.env.USERPROFILE || process.env.HOME || "";
+}
+
+function samePath(a: string, b: string): boolean {
+  return b.length > 0 && path.resolve(a).toLowerCase() === path.resolve(b).toLowerCase();
 }
 
 function realpathOfExistingAncestor(target: string): string {

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -2,11 +2,16 @@ import { z } from "zod";
 import { execa } from "execa";
 import { tool } from "ai";
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt } from "../sandbox";
-import { classifyBashCommand } from "../permissions";
+import {
+  buildBashEnvironment,
+  classifyBashCommand,
+  evaluateBashCommandPolicy,
+} from "../command-policy";
 import {
   bashProgress,
   type BashFailedReason,
 } from "@/src/lib/bash-stream";
+import { redactText } from "@/src/lib/redaction";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -29,20 +34,21 @@ export function createBashTool(workspaceRoot?: string) {
         ),
     }),
     execute: async ({ command, timeoutMs }, { toolCallId }) => {
-      const classification = classifyBashCommand(command);
-      if (classification.forbidden) {
+      const root = workspaceRoot
+        ? ensureWorkspaceRootAt(workspaceRoot)
+        : ensureWorkspaceRoot();
+      const policy = evaluateBashCommandPolicy(command, { workspaceRoot: root });
+      if (!policy.allowed) {
         return {
           ok: false as const,
-          classification,
-          riskCategories: classification.categories as string[],
-          error: classification.reason,
+          classification: policy.classification,
+          riskCategories: policy.classification.categories as string[],
+          error: policy.reason,
         };
       }
 
       const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
-      const root = workspaceRoot
-        ? ensureWorkspaceRootAt(workspaceRoot)
-        : ensureWorkspaceRoot();
+      const classification = policy.classification;
 
       return executeWithStreaming(command, root, timeout, toolCallId, classification);
     },
@@ -52,8 +58,9 @@ export function createBashTool(workspaceRoot?: string) {
 export const bashTool = createBashTool();
 
 function truncate(output: string): string {
-  const buf = Buffer.from(output, "utf8");
-  if (buf.byteLength <= MAX_OUTPUT_BYTES) return output;
+  const redacted = redactText(output);
+  const buf = Buffer.from(redacted, "utf8");
+  if (buf.byteLength <= MAX_OUTPUT_BYTES) return redacted;
   const head = buf.subarray(0, MAX_OUTPUT_BYTES).toString("utf8");
   return `${head}\n…[truncated ${buf.byteLength - MAX_OUTPUT_BYTES} bytes]`;
 }
@@ -74,6 +81,8 @@ async function executeWithStreaming(
   try {
     const subprocess = execa("bash", ["-lc", command], {
       cwd: root,
+      env: buildBashEnvironment(),
+      extendEnv: false,
       timeout,
       reject: false,
       stripFinalNewline: false,
@@ -81,13 +90,13 @@ async function executeWithStreaming(
     });
 
     subprocess.stdout?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString("utf8");
+      const text = redactText(chunk.toString("utf8"));
       stdoutChunks.push(text);
       bashProgress.emitChunk(streamId, { type: "stdout", chunk: text });
     });
 
     subprocess.stderr?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString("utf8");
+      const text = redactText(chunk.toString("utf8"));
       stderrChunks.push(text);
       bashProgress.emitChunk(streamId, { type: "stderr", chunk: text });
     });
@@ -124,7 +133,7 @@ async function executeWithStreaming(
       streamId,
     };
   } catch (err) {
-    const error = errorMessage(err);
+    const error = redactText(errorMessage(err));
     const stderr = truncate([...stderrChunks, error].filter(Boolean).join("\n"));
     bashProgress.emitChunk(streamId, { type: "stderr", chunk: `${error}\n` });
     bashProgress.emitChunk(streamId, {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -31,6 +31,7 @@ import {
   fingerprintMcpConfig,
   namespaceFromDisplayName,
   normalizeMcpConfig,
+  preserveRedactedMcpConfigValues,
   type McpServerConfig,
 } from "@/src/agent/mcp-config";
 
@@ -495,7 +496,12 @@ export function updateMcpServer(
   }
   if (input.transport) update.transport = input.transport;
   if (input.config) {
-    update.config = normalizeMcpConfig(input.config) as unknown;
+    update.config = normalizeMcpConfig(
+      preserveRedactedMcpConfigValues(
+        input.config,
+        current.config as McpServerConfig,
+      ),
+    ) as unknown;
     update.lastStatus = "untested";
     update.lastError = null;
     update.lastCheckedAt = null;

--- a/src/lib/api-serializers.ts
+++ b/src/lib/api-serializers.ts
@@ -1,6 +1,7 @@
 import {
   fingerprintMcpConfig,
   makeMcpApprovalDetails,
+  redactMcpConfig,
   summarizeMcpConfig,
   type McpServerConfig,
 } from "@/src/agent/mcp-config";
@@ -45,7 +46,7 @@ export function serializeMcpServer(server: McpServer): McpServerSummary {
     displayName: server.displayName,
     namespace: server.namespace,
     transport: server.transport,
-    config,
+    config: redactMcpConfig(config),
     enabled: server.enabled,
     summary: summarizeMcpConfig(config),
     trust: {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -55,6 +55,8 @@ export type SkillDocument = SkillSummary & {
 
 export type McpTransport = "stdio" | "http" | "sse";
 
+// UI-facing MCP configs redact secret-looking env/header values as "[redacted]".
+// PATCH requests may submit that sentinel to preserve the stored value.
 export type StdioMcpConfig = {
   type: "stdio";
   command: string;

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -1,0 +1,71 @@
+export const REDACTED = "[redacted]";
+
+const SECRET_KEY_RE =
+  /(?:api[_-]?key|authorization|bearer|client[_-]?secret|credential|password|private[_-]?key|secret|token)/i;
+
+const SECRET_TEXT_PATTERNS: readonly [RegExp, string][] = [
+  [
+    /\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY|AUTHORIZATION|CREDENTIAL)[A-Z0-9_]*)=([^\s]+)/gi,
+    `$1=${REDACTED}`,
+  ],
+  [/\b(Authorization:\s*Bearer\s+)([A-Za-z0-9._~+/=-]+)/gi, `$1${REDACTED}`],
+  [/\b(Authorization:\s*basic\s+)([A-Za-z0-9+/=-]+)/gi, `$1${REDACTED}`],
+  [/\b(AUTHORIZATION:\s*basic\s+)([A-Za-z0-9+/=-]+)/gi, `$1${REDACTED}`],
+  [/\bsk-or-v1-[A-Za-z0-9._-]+/g, REDACTED],
+  [/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, REDACTED],
+];
+
+export function isRedactedSentinel(value: unknown): boolean {
+  return value === REDACTED;
+}
+
+export function isSecretKey(key: string): boolean {
+  return SECRET_KEY_RE.test(key);
+}
+
+export function redactText(value: string): string {
+  return SECRET_TEXT_PATTERNS.reduce(
+    (current, [pattern, replacement]) => current.replace(pattern, replacement),
+    value,
+  );
+}
+
+export function redactValue(value: unknown, keyHint?: string): unknown {
+  if (typeof keyHint === "string" && isSecretKey(keyHint)) {
+    return REDACTED;
+  }
+  if (typeof value === "string") return redactText(value);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+        key,
+        redactValue(item, key),
+      ]),
+    );
+  }
+  return value;
+}
+
+export function redactRecordSecrets(
+  record: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      isSecretKey(key) ? REDACTED : redactText(value),
+    ]),
+  );
+}
+
+export function preserveRedactedRecordValues(
+  next: Record<string, string>,
+  current: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(next).map(([key, value]) => [
+      key,
+      isRedactedSentinel(value) && key in current ? current[key] : value,
+    ]),
+  );
+}

--- a/src/workspace/clone.ts
+++ b/src/workspace/clone.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execa } from "execa";
 
 import { createInstallationToken, type GitHubRepository } from "@/src/github/app";
+import { redactText } from "@/src/lib/redaction";
 import {
   getProjectByGithubRepoId,
   upsertProject,
@@ -51,7 +52,7 @@ export async function cloneGitHubRepository(input: {
     });
     return updateProjectStatus(project.id, "ready", null) ?? project;
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = redactText(err instanceof Error ? err.message : String(err));
     updateProjectStatus(project.id, "error", message);
     throw new CloneError(message);
   }

--- a/src/workspace/local.ts
+++ b/src/workspace/local.ts
@@ -51,6 +51,15 @@ export async function validateAndPrepareLocalWorkspacesRoot(
   if (!path.isAbsolute(inputPath)) {
     throw new WorkspaceRootError("Workspace root must be an absolute path.");
   }
+  if (isFilesystemRoot(resolved)) {
+    throw new WorkspaceRootError("Workspace root cannot be a filesystem root.");
+  }
+  if (isSamePath(resolved, os.homedir())) {
+    throw new WorkspaceRootError("Workspace root cannot be the user home directory.");
+  }
+  if (isSystemDirectory(resolved)) {
+    throw new WorkspaceRootError("Workspace root cannot be a system directory.");
+  }
   if (hasUnsafeSegment(resolved)) {
     throw new WorkspaceRootError(
       "Workspace root cannot be inside .git, node_modules, or build output.",
@@ -110,9 +119,49 @@ function hasUnsafeSegment(target: string): boolean {
   );
 }
 
+function isFilesystemRoot(target: string): boolean {
+  const resolved = path.resolve(target);
+  return isSamePath(resolved, path.parse(resolved).root);
+}
+
+function isSystemDirectory(target: string): boolean {
+  const resolved = path.resolve(target);
+  return systemDirectories().some(
+    (dir) => isSamePath(resolved, dir) || isInside(resolved, dir),
+  );
+}
+
+function systemDirectories(): string[] {
+  const dirs = [
+    process.env.SystemRoot,
+    process.env.WINDIR,
+    process.env.ProgramFiles,
+    process.env["ProgramFiles(x86)"],
+    process.env.ProgramData,
+    "/bin",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/lib",
+    "/lib64",
+    "/proc",
+    "/sbin",
+    "/sys",
+    "/usr",
+    "/var",
+  ];
+  return dirs
+    .filter((dir): dir is string => typeof dir === "string" && dir.trim().length > 0)
+    .map((dir) => path.resolve(dir));
+}
+
 function isInside(child: string, parent: string): boolean {
   const rel = path.relative(parent, child);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function isSamePath(a: string, b: string): boolean {
+  return path.resolve(a).toLowerCase() === path.resolve(b).toLowerCase();
 }
 
 function safePathSegment(segment: string): string {

--- a/tests/command-policy.test.ts
+++ b/tests/command-policy.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildBashEnvironment,
+  classifyBashCommand,
+  evaluateBashCommandPolicy,
+} from "../src/agent/command-policy";
+
+test("classifies read-only and risky command categories", () => {
+  assert.deepEqual(classifyBashCommand("ls && git status").categories, [
+    "read-only",
+    "git",
+  ]);
+  assert.deepEqual(classifyBashCommand("curl https://example.com").categories, [
+    "network",
+    "external-integration",
+  ]);
+  assert.ok(
+    classifyBashCommand("pnpm install").categories.includes("package-install"),
+  );
+  assert.ok(classifyBashCommand("pnpm dev").categories.includes("long-running-process"));
+  assert.ok(classifyBashCommand("rm -rf dist").categories.includes("delete"));
+  assert.ok(classifyBashCommand("echo hi > out.txt").categories.includes("write"));
+});
+
+test("refuses forbidden and secret-printing commands before execution", () => {
+  for (const command of [
+    "sudo whoami",
+    "su root",
+    "env",
+    "printenv",
+    "cat .env.local",
+    "rg OPENROUTER_API_KEY .env",
+    "cat id_rsa",
+  ]) {
+    const policy = evaluateBashCommandPolicy(command, {
+      workspaceRoot: process.cwd(),
+    });
+    assert.equal(policy.allowed, false, command);
+  }
+});
+
+test("refuses destructive and out-of-workspace path usage", () => {
+  const root = process.cwd();
+  for (const command of [
+    "rm -rf /",
+    "rm -rf ~",
+    "rm -rf ..",
+    "rm -rf *",
+    "cat /etc/passwd",
+    "echo hi > ../outside.txt",
+  ]) {
+    const policy = evaluateBashCommandPolicy(command, { workspaceRoot: root });
+    assert.equal(policy.allowed, false, command);
+  }
+});
+
+test("allows common safe commands inside the workspace", () => {
+  for (const command of ["pwd", "ls src", "git diff -- src/agent/permissions.ts"]) {
+    const policy = evaluateBashCommandPolicy(command, {
+      workspaceRoot: process.cwd(),
+    });
+    assert.equal(policy.allowed, true, command);
+  }
+});
+
+test("bash environment allowlist excludes Anton and arbitrary secrets", () => {
+  const env = buildBashEnvironment({
+    PATH: "bin",
+    OPENROUTER_API_KEY: "not-a-real-openrouter-key",
+    GITHUB_APP_PRIVATE_KEY: "private-key",
+    CUSTOM_SECRET: "secret",
+    ComSpec: "cmd.exe",
+    SystemRoot: "C:\\Windows",
+  });
+  assert.equal(env.PATH, "bin");
+  assert.equal(env.ComSpec, "cmd.exe");
+  assert.equal(env.SystemRoot, "C:\\Windows");
+  assert.equal("OPENROUTER_API_KEY" in env, false);
+  assert.equal("GITHUB_APP_PRIVATE_KEY" in env, false);
+  assert.equal("CUSTOM_SECRET" in env, false);
+});

--- a/tests/mcp-redaction.test.ts
+++ b/tests/mcp-redaction.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  preserveRedactedMcpConfigValues,
+  redactMcpConfig,
+  type McpServerConfig,
+} from "../src/agent/mcp-config";
+import { REDACTED } from "../src/lib/redaction";
+
+test("redacts MCP env and header secrets for UI-facing configs", () => {
+  const stdio: McpServerConfig = {
+    type: "stdio",
+    command: "node",
+    args: ["server.js"],
+    env: {
+      NODE_ENV: "development",
+      API_KEY: "secret",
+    },
+  };
+  const remote: McpServerConfig = {
+    type: "http",
+    url: "https://example.test/mcp",
+    headers: {
+      Authorization: "Bearer secret",
+      Accept: "application/json",
+    },
+    redirect: "error",
+  };
+
+  assert.deepEqual(redactMcpConfig(stdio), {
+    ...stdio,
+    env: { NODE_ENV: "development", API_KEY: REDACTED },
+  });
+  assert.deepEqual(redactMcpConfig(remote), {
+    ...remote,
+    headers: { Authorization: REDACTED, Accept: "application/json" },
+  });
+});
+
+test("preserves existing MCP secret values when UI submits redacted sentinel", () => {
+  const current: McpServerConfig = {
+    type: "http",
+    url: "https://example.test/mcp",
+    headers: {
+      Authorization: "Bearer existing",
+      Accept: "application/json",
+    },
+    redirect: "error",
+  };
+  const next: McpServerConfig = {
+    ...current,
+    headers: {
+      Authorization: REDACTED,
+      Accept: "application/json",
+    },
+  };
+
+  assert.deepEqual(preserveRedactedMcpConfigValues(next, current), current);
+});

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  REDACTED,
+  redactRecordSecrets,
+  redactText,
+  redactValue,
+} from "../src/lib/redaction";
+
+test("redacts key-value secrets and auth headers in text", () => {
+  const openRouterKey = `sk-or-v1-${"a".repeat(32)}`;
+  const githubToken = `ghp_${"b".repeat(36)}`;
+  const basicAuth = "dXNlcjpzdXBlcnNlY3JldA==";
+  const input = [
+    `OPENROUTER_API_KEY=${openRouterKey}`,
+    `Authorization: Bearer ${githubToken}`,
+    `GIT_CONFIG_VALUE_0=AUTHORIZATION: basic ${basicAuth}`,
+  ].join("\n");
+
+  const output = redactText(input);
+  assert.equal(output.includes(openRouterKey), false);
+  assert.equal(output.includes(githubToken), false);
+  assert.equal(output.includes(basicAuth), false);
+  assert.match(output, /\[redacted\]/);
+});
+
+test("redacts nested structured secret values", () => {
+  const output = redactValue({
+    ok: true,
+    token: `ghs_${"c".repeat(36)}`,
+    nested: {
+      headers: {
+        Authorization: `Bearer sk-or-v1-${"d".repeat(32)}`,
+      },
+      visible: "hello",
+    },
+  });
+
+  assert.deepEqual(output, {
+    ok: true,
+    token: REDACTED,
+    nested: {
+      headers: {
+        Authorization: REDACTED,
+      },
+      visible: "hello",
+    },
+  });
+});
+
+test("redacts only secret-looking record values", () => {
+  assert.deepEqual(
+    redactRecordSecrets({
+      NODE_ENV: "development",
+      API_KEY: "super-secret",
+      Authorization: "Bearer token-value",
+    }),
+    {
+      NODE_ENV: "development",
+      API_KEY: REDACTED,
+      Authorization: REDACTED,
+    },
+  );
+});

--- a/tests/sandbox-workspace.test.ts
+++ b/tests/sandbox-workspace.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { resolveInWorkspace, SandboxError } from "../src/agent/sandbox";
+import {
+  validateAndPrepareLocalWorkspacesRoot,
+  WorkspaceRootError,
+} from "../src/workspace/local";
+
+test("resolveInWorkspace rejects traversal and absolute paths", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "anton-sandbox-"));
+  assert.throws(() => resolveInWorkspace("../outside.txt", root), SandboxError);
+  assert.throws(() => resolveInWorkspace(path.join(root, "file.txt"), root), SandboxError);
+});
+
+test("resolveInWorkspace rejects symlink escapes", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "anton-sandbox-"));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "anton-outside-"));
+  const link = path.join(root, "linked");
+  fs.symlinkSync(outside, link, "junction");
+
+  assert.throws(() => resolveInWorkspace("linked/secret.txt", root), SandboxError);
+});
+
+test("workspace root validation rejects unsafe roots", async () => {
+  const cwd = process.cwd();
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "anton-workspaces-"));
+  const unsafeDirs = [
+    cwd,
+    os.homedir(),
+    path.parse(cwd).root,
+    path.join(temp, "repo", ".git", "workspaces"),
+    path.join(temp, "repo", "node_modules", "workspaces"),
+    path.join(temp, "repo", ".next", "workspaces"),
+    path.join(temp, "repo", "dist", "workspaces"),
+    path.join(temp, "repo", "build", "workspaces"),
+  ];
+
+  for (const dir of unsafeDirs) {
+    await assert.rejects(
+      validateAndPrepareLocalWorkspacesRoot(dir),
+      WorkspaceRootError,
+      dir,
+    );
+  }
+});
+
+test("workspace root validation accepts a dedicated absolute directory", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "anton-workspaces-"));
+  const root = path.join(temp, "dedicated");
+  const validated = await validateAndPrepareLocalWorkspacesRoot(root);
+  assert.equal(validated, fs.realpathSync(root));
+});


### PR DESCRIPTION
Closes #48.

## Summary
- Add a policy-backed bash command classifier and enforce it before shell execution.
- Scrub bash child-process environments to an allowlist and redact shell output/errors before streaming or returning them.
- Add shared redaction helpers for text/structured data, redact MCP UI-facing secrets, and preserve stored MCP secret values when `[redacted]` is submitted.
- Harden workspace-root validation and add focused safety tests.
- Mark completed Phase 1 roadmap items and refine remaining risk notes.

## Verification
- `pnpm test` - 14 tests passed
- `pnpm typecheck` - passed
- `pnpm lint` - passed

## Notes
- This PR is stacked on `codex/46-global-mcp-config` because the implementation branch was created from the current workspace branch as requested.
- Command policy remains heuristic rather than a full shell parser; the roadmap risk note now reflects that residual limitation.
