### PR TITLE
[codex] Persist worklog state incrementally

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,9 +82,9 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add durable `run_events` for ordered reasoning, tool, approval, progress, and error trace rows.
 - [✔️] Add `tool_calls` table with tool name, input summary, approval decision, output summary, timestamps, exit code, and error state.
 - [✔️] Add `approvals` table or structured approval fields tied to tool calls.
-- [] Persist Worklog from database state instead of reconstructing from message parts and trace data.
-- [] Stop replacing entire message transcripts on every finish; append messages or use optimistic concurrency.
-- [] Add concurrency protection for two browser tabs writing the same session.
+- [✔️] Persist Worklog from database state instead of reconstructing from message parts and trace data.
+- [✔️] Stop replacing entire message transcripts on every finish; append messages or use optimistic concurrency.
+- [✔️] Add concurrency protection for two browser tabs writing the same session.
 - [✔️] Add indexes for `messages.session_id`, `sessions.updated_at`, `sessions.project_id`, `projects.github_repo_id`, and `memories.updated_at`.
 - [✔️] Track model, usage, finish reason, and abort/error status for each run.
 - [✔️] Add database migrations for run and run-event persistence changes.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -28,10 +28,13 @@ import {
   createRun,
   createSession,
   deriveTitleFromMessages,
+  getActiveRunForSession,
+  getMessagePersistenceConflict,
   getProject,
   getSession,
   getToolCall,
-  replaceMessages,
+  MessagePersistenceConflictError,
+  saveMessagesIncrementally,
   setSessionProject,
   touchSession,
   updateRun,
@@ -42,7 +45,11 @@ import {
 } from "@/src/db/queries";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
 import { redactText, redactValue } from "@/src/lib/redaction";
-import { getApprovalMetadata, getToolTraceEntries } from "@/src/lib/trace";
+import {
+  getApprovalMetadata,
+  getToolTraceEntries,
+  isRunDataPart,
+} from "@/src/lib/trace";
 import type {
   AntonActivityEvent,
   AntonActivityKind,
@@ -55,6 +62,7 @@ import type {
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
+const ACTIVE_RUN_STALE_AFTER_MS = 5 * 60 * 1000;
 
 const bodySchema = z.object({
   sessionId: z.string().min(1),
@@ -104,6 +112,33 @@ export async function POST(req: Request) {
       projectId,
     });
   } else {
+    const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
+    const conflict = getMessagePersistenceConflict(sessionId, incomingHistory);
+    if (conflict) {
+      return Response.json(
+        {
+          error: "session message history changed; refresh before sending again",
+          storedCount: conflict.storedCount,
+          incomingCount: conflict.incomingCount,
+        },
+        { status: 409 },
+      );
+    }
+
+    const activeRun = getActiveRunForSession(
+      sessionId,
+      ACTIVE_RUN_STALE_AFTER_MS,
+    );
+    if (activeRun) {
+      return Response.json(
+        {
+          error: "session already has a running agent turn",
+          runId: activeRun.id,
+        },
+        { status: 409 },
+      );
+    }
+
     if (!existing.projectId && projectId) {
       setSessionProject(sessionId, projectId);
     }
@@ -111,13 +146,6 @@ export async function POST(req: Request) {
       touchSession(sessionId, model);
     }
   }
-
-  const modelMessages = await convertToModelMessages(
-    prepareMessagesForModel(uiMessages),
-    {
-      convertDataPart: () => undefined,
-    },
-  );
 
   const runId = randomUUID();
   const startedAt = Date.now();
@@ -130,6 +158,12 @@ export async function POST(req: Request) {
     startedAt: new Date(startedAt),
     stepCount: 0,
   });
+
+  const modelMessages = await convertMessagesForRun(
+    uiMessages,
+    runId,
+    startedAt,
+  );
 
   const stream = createUIMessageStream<AntonUIMessage>({
     originalMessages: uiMessages,
@@ -181,13 +215,26 @@ export async function POST(req: Request) {
       }
     },
     onFinish: ({ messages }) => {
-      const persistedMessages = messages.filter(hasSubstantiveHistoryParts);
+      const persistedMessages = messages
+        .map(stripDurableTraceParts)
+        .filter(hasSubstantiveHistoryParts);
       if (persistedMessages.length === 0) return;
-      persistFinalToolApprovalStates(runId, persistedMessages);
-      replaceMessages<AntonUIMessage>(
-        sessionId,
-        redactValue(persistedMessages) as AntonUIMessage[],
-      );
+      persistFinalToolApprovalStates(runId, messages);
+      try {
+        saveMessagesIncrementally<AntonUIMessage>(
+          sessionId,
+          redactValue(persistedMessages) as AntonUIMessage[],
+        );
+      } catch (err) {
+        if (err instanceof MessagePersistenceConflictError) {
+          updateRun(runId, {
+            status: "error",
+            finishReason: "message_persistence_conflict",
+          });
+          return;
+        }
+        throw err;
+      }
     },
   });
 
@@ -202,6 +249,26 @@ function prepareMessagesForModel(messages: AntonUIMessage[]): AntonUIMessage[] {
     if (!parts.some(isSubstantiveModelContextPart)) return [];
     return [{ ...message, parts }];
   });
+}
+
+async function convertMessagesForRun(
+  messages: AntonUIMessage[],
+  runId: string,
+  startedAt: number,
+) {
+  try {
+    return await convertToModelMessages(prepareMessagesForModel(messages), {
+      convertDataPart: () => undefined,
+    });
+  } catch (err) {
+    updateRun(runId, {
+      status: "error",
+      finishedAt: new Date(),
+      durationMs: Math.max(0, Date.now() - startedAt),
+      finishReason: "message_conversion_error",
+    });
+    throw err;
+  }
 }
 
 function isModelContextPart(
@@ -672,6 +739,22 @@ function createTraceWriter({
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function stripDurableTraceParts(message: AntonUIMessage): AntonUIMessage {
+  const runPart = message.parts.find(isRunDataPart);
+  const metadata =
+    runPart && !message.metadata?.runId
+      ? { ...message.metadata, runId: runPart.data.runId }
+      : message.metadata;
+
+  return {
+    ...message,
+    metadata,
+    parts: message.parts.filter(
+      (part) => part.type !== "data-run" && part.type !== "data-activity",
+    ),
+  };
 }
 
 function errorMessageOrUndefined(error: unknown): string | undefined {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,7 +2,7 @@ import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 
-import { hydrateMessagesWithRunMetrics, type AntonUIMessage } from "@/src/lib/trace";
+import { hydrateMessagesWithRunState, type AntonUIMessage } from "@/src/lib/trace";
 import { db } from "./client";
 import {
   githubInstallations,
@@ -50,6 +50,13 @@ export type StoredMessage<UI extends UIMessage = UIMessage> = {
   metadata: UI["metadata"] | null;
   createdAt: Date;
 };
+
+export class MessagePersistenceConflictError extends Error {
+  constructor(message = "session message history changed before persistence") {
+    super(message);
+    this.name = "MessagePersistenceConflictError";
+  }
+}
 
 export function listSessions(): Session[] {
   return db.select().from(sessions).orderBy(desc(sessions.updatedAt)).all();
@@ -368,44 +375,126 @@ export function loadMessages<UI extends UIMessage>(
   });
 
   const sessionRuns = db
-    .select({
-      id: runs.id,
-      inputTokens: runs.inputTokens,
-      outputTokens: runs.outputTokens,
-      totalTokens: runs.totalTokens,
-      costUsd: runs.costUsd,
-    })
+    .select()
     .from(runs)
     .where(eq(runs.sessionId, sessionId))
+    .orderBy(asc(runs.startedAt))
     .all();
 
-  return hydrateMessagesWithRunMetrics(
+  const sessionRunEvents =
+    sessionRuns.length === 0
+      ? []
+      : db
+          .select()
+          .from(runEvents)
+          .where(
+            inArray(
+              runEvents.runId,
+              sessionRuns.map((run) => run.id),
+            ),
+          )
+          .orderBy(asc(runEvents.runId), asc(runEvents.sequence))
+          .all();
+
+  return hydrateMessagesWithRunState(
     loaded as unknown as AntonUIMessage[],
     sessionRuns,
+    sessionRunEvents,
   ) as unknown as UI[];
 }
 
-export function replaceMessages<UI extends UIMessage>(
+export function getActiveRunForSession(
+  sessionId: string,
+  staleAfterMs: number,
+): Run | undefined {
+  const cutoff = Date.now() - staleAfterMs;
+  return db
+    .select()
+    .from(runs)
+    .where(and(eq(runs.sessionId, sessionId), eq(runs.status, "running")))
+    .orderBy(desc(runs.startedAt))
+    .all()
+    .find((run) => run.startedAt.getTime() >= cutoff);
+}
+
+export function getMessagePersistenceConflict<UI extends UIMessage>(
+  sessionId: string,
+  incoming: UI[],
+): { storedCount: number; incomingCount: number } | undefined {
+  const stored = storedMessageIds(sessionId);
+  if (stored.length > incoming.length) {
+    return { storedCount: stored.length, incomingCount: incoming.length };
+  }
+
+  for (const [idx, storedId] of stored.entries()) {
+    if (storedId !== messageId(incoming[idx], sessionId, idx)) {
+      return { storedCount: stored.length, incomingCount: incoming.length };
+    }
+  }
+
+  return undefined;
+}
+
+export function saveMessagesIncrementally<UI extends UIMessage>(
   sessionId: string,
   incoming: UI[],
 ): void {
   db.transaction((tx) => {
-    tx.delete(messages).where(eq(messages.sessionId, sessionId)).run();
-    if (incoming.length === 0) return;
-    tx
-      .insert(messages)
-      .values(
-        incoming.map((m, idx) => ({
-          id: messageId(m, sessionId, idx),
-          sessionId,
-          role: m.role,
-          parts: m.parts as unknown,
-          metadata: (m.metadata ?? null) as unknown,
-          // Preserve ordering even when created_at ticks collide.
-          createdAt: new Date(Date.now() + idx),
-        })),
-      )
-      .run();
+    const existing = tx
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .orderBy(asc(messages.createdAt))
+      .all();
+
+    if (existing.length > incoming.length) {
+      throw new MessagePersistenceConflictError();
+    }
+
+    const now = Date.now();
+    for (const [idx, message] of incoming.entries()) {
+      const id = messageId(message, sessionId, idx);
+      const row = {
+        id,
+        sessionId,
+        role: message.role,
+        parts: message.parts as unknown,
+        metadata: (message.metadata ?? null) as unknown,
+      };
+
+      const current = existing[idx];
+      if (!current) {
+        tx.insert(messages)
+          .values({
+            ...row,
+            createdAt: new Date(now + idx),
+          })
+          .run();
+        continue;
+      }
+
+      if (current.id !== id) {
+        throw new MessagePersistenceConflictError();
+      }
+
+      if (
+        current.role === row.role &&
+        stableJson(current.parts) === stableJson(row.parts) &&
+        stableJson(current.metadata) === stableJson(row.metadata)
+      ) {
+        continue;
+      }
+
+      tx.update(messages)
+        .set({
+          role: row.role,
+          parts: row.parts,
+          metadata: row.metadata,
+        })
+        .where(eq(messages.id, id))
+        .run();
+    }
+
     tx
       .update(sessions)
       .set({ updatedAt: new Date() })
@@ -699,6 +788,20 @@ function messageId<UI extends UIMessage>(
   const id = message.id.trim();
   if (id.length > 0) return id;
   return `${sessionId}:message:${index}`;
+}
+
+function storedMessageIds(sessionId: string): string[] {
+  return db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(eq(messages.sessionId, sessionId))
+    .orderBy(asc(messages.createdAt))
+    .all()
+    .map((row) => row.id);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
 }
 
 function uniqueMcpNamespace(base: string, currentId?: string): string {

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -56,10 +56,32 @@ export type AntonRunData = {
 
 export type AntonRunMetricSnapshot = {
   id: string;
+  model?: string | null;
+  status?: AntonRunStatus | null;
+  startedAt?: Date | number | null;
+  finishedAt?: Date | number | null;
+  durationMs?: number | null;
   inputTokens?: number | null;
   outputTokens?: number | null;
   totalTokens?: number | null;
   costUsd?: number | null;
+  costMetadata?: unknown;
+  stepCount?: number | null;
+};
+
+export type AntonActivitySnapshot = {
+  id: string;
+  runId: string;
+  sequence: number;
+  kind: AntonActivityKind;
+  status: AntonActivityStatus;
+  label: string;
+  summary?: string | null;
+  startedAt: Date | number;
+  finishedAt?: Date | number | null;
+  durationMs?: number | null;
+  toolCallId?: string | null;
+  details?: unknown;
 };
 
 export type AntonActivityEvent = {
@@ -465,6 +487,63 @@ export function hydrateMessagesWithRunMetrics<UI extends AntonUIMessage>(
   });
 }
 
+export function hydrateMessagesWithRunState<UI extends AntonUIMessage>(
+  messages: UI[],
+  runs: AntonRunMetricSnapshot[],
+  events: AntonActivitySnapshot[],
+): UI[] {
+  const metricsHydrated = hydrateMessagesWithRunMetrics(messages, runs);
+  const runsById = new Map(runs.map((run) => [run.id, run]));
+  if (runsById.size === 0) return metricsHydrated;
+
+  const eventsByRunId = new Map<string, AntonActivitySnapshot[]>();
+  for (const event of events) {
+    const runEvents = eventsByRunId.get(event.runId) ?? [];
+    runEvents.push(event);
+    eventsByRunId.set(event.runId, runEvents);
+  }
+  for (const runEvents of eventsByRunId.values()) {
+    runEvents.sort((a, b) => a.sequence - b.sequence);
+  }
+
+  return metricsHydrated.map((message) => {
+    const runIds = messageRunIds(message);
+    if (runIds.length === 0) return message;
+
+    const durableRunParts = runIds
+      .map((runId) => runsById.get(runId))
+      .filter((run): run is AntonRunMetricSnapshot => run !== undefined)
+      .map((run) => ({
+        type: "data-run",
+        id: run.id,
+        data: runDataFromSnapshot(run),
+      }));
+
+    const durableActivityParts = runIds.flatMap((runId) =>
+      (eventsByRunId.get(runId) ?? []).map((event) => ({
+        type: "data-activity",
+        id: event.id,
+        data: activityDataFromSnapshot(event),
+      })),
+    );
+
+    if (durableRunParts.length === 0 && durableActivityParts.length === 0) {
+      return message;
+    }
+
+    return {
+      ...message,
+      parts: [
+        ...message.parts.filter(
+          (part) => !isRunDataPart(part) && !isActivityDataPart(part),
+        ),
+        ...durableRunParts,
+        ...durableActivityParts,
+      ] as UI["parts"],
+    };
+  });
+}
+
 function hydrateMetricRecord<T>(
   value: T,
   runsById: Map<string, AntonRunMetricSnapshot>,
@@ -486,6 +565,60 @@ function hydrateMetricRecord<T>(
   }
 
   return (next ?? value) as T;
+}
+
+function messageRunIds(message: AntonUIMessage): string[] {
+  const ids = new Set<string>();
+  const metadataRunId = message.metadata?.runId;
+  if (typeof metadataRunId === "string") ids.add(metadataRunId);
+  for (const part of message.parts) {
+    if (isRunDataPart(part)) ids.add(part.data.runId);
+  }
+  return Array.from(ids);
+}
+
+function runDataFromSnapshot(run: AntonRunMetricSnapshot): AntonRunData {
+  return {
+    runId: run.id,
+    model: run.model ?? "unknown",
+    status: run.status ?? "completed",
+    startedAt: toMillis(run.startedAt) ?? 0,
+    ...(toMillis(run.finishedAt) !== undefined
+      ? { finishedAt: toMillis(run.finishedAt) }
+      : {}),
+    ...(typeof run.durationMs === "number" ? { durationMs: run.durationMs } : {}),
+    ...(typeof run.inputTokens === "number" ? { inputTokens: run.inputTokens } : {}),
+    ...(typeof run.outputTokens === "number" ? { outputTokens: run.outputTokens } : {}),
+    ...(typeof run.totalTokens === "number" ? { totalTokens: run.totalTokens } : {}),
+    ...(typeof run.costUsd === "number" ? { costUsd: run.costUsd } : {}),
+    ...(isRecord(run.costMetadata) ? { costMetadata: run.costMetadata } : {}),
+    ...(typeof run.stepCount === "number" ? { stepCount: run.stepCount } : {}),
+  };
+}
+
+function activityDataFromSnapshot(event: AntonActivitySnapshot): AntonActivityEvent {
+  return {
+    id: event.id,
+    runId: event.runId,
+    sequence: event.sequence,
+    kind: event.kind,
+    status: event.status,
+    label: event.label,
+    ...(event.summary ? { summary: event.summary } : {}),
+    startedAt: toMillis(event.startedAt) ?? 0,
+    ...(toMillis(event.finishedAt) !== undefined
+      ? { finishedAt: toMillis(event.finishedAt) }
+      : {}),
+    ...(typeof event.durationMs === "number" ? { durationMs: event.durationMs } : {}),
+    ...(event.toolCallId ? { toolCallId: event.toolCallId } : {}),
+    ...(isRecord(event.details) ? { details: event.details } : {}),
+  };
+}
+
+function toMillis(value: Date | number | null | undefined): number | undefined {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
 }
 
 export function getMessageRunDurationMs(


### PR DESCRIPTION
## Summary
- Hydrate session run and activity trace parts from durable `runs` and `run_events` rows when loading messages.
- Persist finished chat messages incrementally instead of deleting and reinserting the whole transcript.
- Reject stale session histories and overlapping active runs with `409` responses to protect concurrent browser tabs.
- Mark the related Phase 3 roadmap items complete.

Refs #63

## Verification
- `pnpm typecheck`
- `pnpm lint`

## Notes
- No UI layout changes; visual verification was not applicable for this persistence/API slice.