### PR TITLE
Add explicit Plan mode and todo UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,7 +92,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 ## Phase 4: Agent Loop Quality
 
-- [] Add structured todo/planning state for multi-step coding tasks.
+- [✔️] Add structured todo/planning state for multi-step coding tasks.
 - [] Add explicit handling when the model reaches the max-step limit.
 - [] Add automatic verification policy after edits: detect package manager, run typecheck, lint, and build when appropriate.
 - [] Add stack/repo inspection summary before the first coding action in a project.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -117,7 +117,9 @@ export async function POST(req: Request) {
     });
   } else {
     const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
-    const conflict = getMessagePersistenceConflict(sessionId, incomingHistory);
+    const conflict = getMessagePersistenceConflict(sessionId, incomingHistory, {
+      mutableTailCount: isToolApprovalContinuation(incomingHistory) ? 1 : 0,
+    });
     if (conflict) {
       return Response.json(
         {
@@ -305,6 +307,15 @@ function hasSubstantiveHistoryParts(message: AntonUIMessage): boolean {
       return part.text.trim().length > 0;
     }
     return part.type !== "step-start";
+  });
+}
+
+function isToolApprovalContinuation(messages: AntonUIMessage[]): boolean {
+  const last = messages.at(-1);
+  if (!last || last.role !== "assistant") return false;
+  return last.parts.some((part) => {
+    if (!("state" in part) || typeof part.state !== "string") return false;
+    return part.state === "approval-responded";
   });
 }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -57,6 +57,8 @@ import type {
   AntonMessageMetadata,
   AntonRunData,
   AntonRunStatus,
+  AntonTodoItem,
+  AntonTodoSnapshot,
   AntonUIMessage,
 } from "@/src/lib/trace";
 
@@ -70,6 +72,7 @@ const bodySchema = z.object({
   model: z.string().min(1).optional(),
   permissionMode: z.enum(["default", "auto-review", "full-access"]).optional(),
   enabledMcpServerIds: z.array(z.string().min(1)).optional(),
+  mode: z.enum(["chat", "plan"]).optional(),
   messages: z.array(z.unknown()).min(1),
 });
 
@@ -84,6 +87,7 @@ export async function POST(req: Request) {
   }
 
   const { sessionId } = parsed.data;
+  const mode = parsed.data.mode ?? "chat";
   const uiMessages = parsed.data.messages as AntonUIMessage[];
   const model = parsed.data.model ?? DEFAULT_MODEL;
 
@@ -174,6 +178,7 @@ export async function POST(req: Request) {
         model,
         startedAt,
         workspaceRoot: project.localPath,
+        responseKind: mode === "plan" ? "plan" : undefined,
       });
       trace.writeRun("running");
 
@@ -182,6 +187,7 @@ export async function POST(req: Request) {
           messages: modelMessages,
           model,
           workspaceRoot: project.localPath,
+          mode,
           permissionMode: parsed.data.permissionMode as
             | PermissionMode
             | undefined,
@@ -318,12 +324,14 @@ function createTraceWriter({
   model,
   startedAt,
   workspaceRoot,
+  responseKind,
 }: {
   writer: UIMessageStreamWriter<AntonUIMessage>;
   runId: string;
   model: string;
   startedAt: number;
   workspaceRoot: string;
+  responseKind?: "plan";
 }) {
   let sequence = 0;
   let stepCount = 0;
@@ -335,6 +343,7 @@ function createTraceWriter({
     extra: Partial<AntonMessageMetadata> = {},
   ): AntonMessageMetadata => ({
     runId,
+    responseKind,
     model,
     status,
     startedAt,
@@ -388,6 +397,23 @@ function createTraceWriter({
     events.set(safeEvent.id, safeEvent);
     persistEvent(safeEvent);
     writer.write({ type: "data-activity", id: safeEvent.id, data: safeEvent });
+  };
+
+  const writeTodos = (items: AntonTodoItem[]) => {
+    const snapshot: AntonTodoSnapshot = {
+      runId,
+      items,
+      updatedAt: Date.now(),
+    };
+    writer.write({ type: "data-todos", id: `${runId}:todos`, data: snapshot });
+    startEvent({
+      id: `${runId}:todos:${sequence + 1}`,
+      kind: "progress",
+      status: "completed",
+      label: "Todos updated",
+      summary: todoSummary(items),
+      details: { todos: snapshot },
+    });
   };
 
   const startEvent = ({
@@ -697,6 +723,8 @@ function createTraceWriter({
           respondedAt: new Date(),
         });
       }
+      const todos = todoItemsFromToolOutput(event.toolName, event.output);
+      if (todos) writeTodos(todos);
     },
     handleStreamPart(part: TextStreamPart<ToolSet>) {
       if (part.type === "reasoning-start") {
@@ -734,6 +762,43 @@ function createTraceWriter({
     },
     finalize,
   };
+}
+
+function todoItemsFromToolOutput(
+  toolName: string,
+  output: unknown,
+): AntonTodoItem[] | undefined {
+  if (toolName !== "update_todos") return undefined;
+  if (!isRecord(output) || output.ok !== true || !Array.isArray(output.items)) {
+    return undefined;
+  }
+
+  const items = output.items.flatMap((item): AntonTodoItem[] => {
+    if (!isRecord(item)) return [];
+    const id = typeof item.id === "string" ? item.id : "";
+    const text = typeof item.text === "string" ? item.text : "";
+    const status = item.status;
+    if (
+      !id ||
+      !text ||
+      (status !== "pending" &&
+        status !== "in_progress" &&
+        status !== "completed")
+    ) {
+      return [];
+    }
+    return [{ id, text, status }];
+  });
+
+  return items.length > 0 ? items : undefined;
+}
+
+function todoSummary(items: AntonTodoItem[]): string {
+  const completed = items.filter((item) => item.status === "completed").length;
+  const inProgress = items.find((item) => item.status === "in_progress");
+  return inProgress
+    ? `${completed}/${items.length} complete; current: ${inProgress.text}`
+    : `${completed}/${items.length} complete`;
 }
 
 function errorMessage(error: unknown): string {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -91,6 +91,7 @@ function ChatSession({
   const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<string[]>([]);
   const [pendingMcpSend, setPendingMcpSend] = useState<{
     text: string;
+    mode: "chat" | "plan";
     untrusted: McpPreflightServer[];
   } | null>(null);
   const effectiveProjectId = initialProjectId ?? activeProjectId;
@@ -206,7 +207,10 @@ function ChatSession({
     };
   }, []);
 
-  const sendWithMcp = async (text: string): Promise<boolean> => {
+  const sendWithMcp = async (
+    text: string,
+    mode: "chat" | "plan" = "chat",
+  ): Promise<boolean> => {
     if (!effectiveProjectId) return false;
     const selectedIds = selectedMcpServerIds.filter((id) =>
       mcpServers.some((server) => server.id === id && server.enabled),
@@ -220,7 +224,7 @@ function ChatSession({
       body: JSON.stringify({ serverIds: selectedIds }),
     });
     if (!preflight.ok) {
-      setPendingMcpSend({ text, untrusted: preflight.untrusted });
+      setPendingMcpSend({ text, mode, untrusted: preflight.untrusted });
       return false;
     }
     void sendMessage(
@@ -229,6 +233,7 @@ function ChatSession({
         body: {
           projectId: effectiveProjectId,
           model,
+          mode,
           permissionMode,
           enabledMcpServerIds: selectedIds,
         },
@@ -252,7 +257,7 @@ function ChatSession({
       });
     }
     setPendingMcpSend(null);
-    await sendWithMcp(pending.text);
+    await sendWithMcp(pending.text, pending.mode);
   };
 
   const streaming = status === "streaming" || status === "submitted";
@@ -329,6 +334,10 @@ function ChatSession({
             status={status}
             recovering={recoveringMessages}
             onApproval={addToolApprovalResponse}
+            onAcceptPlan={(plan) => {
+              void sendWithMcp(`Implement this accepted plan:\n\n${plan}`, "chat");
+            }}
+            acceptPlanDisabled={streaming || !effectiveProjectId}
           />
 
           {displayMessages.length === 0 && !effectiveProjectId && (
@@ -343,6 +352,7 @@ function ChatSession({
 
           <Composer
             onSend={sendWithMcp}
+            onPlan={(text) => sendWithMcp(text, "plan")}
             onStop={stop}
             disabled={streaming || !effectiveProjectId}
             streaming={streaming}
@@ -406,7 +416,7 @@ function McpTrustDialog({
   onClose,
   onApprove,
 }: {
-  pending: { text: string; untrusted: McpPreflightServer[] } | null;
+  pending: { text: string; mode: "chat" | "plan"; untrusted: McpPreflightServer[] } | null;
   onClose: () => void;
   onApprove: () => void;
 }) {

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import {
   Select,
   SelectContent,
@@ -69,6 +70,7 @@ export function Composer({
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const [mcpOpen, setMcpOpen] = useState(false);
+  const [planMode, setPlanMode] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useLayoutEffect(() => {
@@ -80,19 +82,22 @@ export function Composer({
     el.style.overflowY = el.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
   }, [input]);
 
-  const submit = (mode: "chat" | "plan" = "chat") => {
+  const submit = () => {
     const trimmed = input.trim();
     if (!trimmed || disabled) return;
-    const handler = mode === "plan" ? onPlan : onSend;
+    const handler = planMode ? onPlan : onSend;
     void Promise.resolve(handler(trimmed)).then((sent) => {
-      if (sent) setInput("");
+      if (sent) {
+        setInput("");
+        setPlanMode(false);
+      }
     });
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      submit("chat");
+      submit();
     }
   };
 
@@ -100,7 +105,7 @@ export function Composer({
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        submit("chat");
+        submit();
       }}
       className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background/95 px-3 pb-2 pt-1 sm:px-4"
     >
@@ -112,7 +117,7 @@ export function Composer({
             onChange={(e) => setInput(e.target.value)}
             onInput={(e) => setInput(e.currentTarget.value)}
             onKeyDown={onKeyDown}
-            placeholder="Ask for follow-up changes"
+            placeholder={planMode ? "Ask Anton to plan the work" : "Ask for follow-up changes"}
             rows={1}
             className="field-sizing-fixed min-h-0 min-w-0 resize-none rounded-none border-0 bg-transparent p-0 font-mono text-xs leading-5 shadow-none placeholder:font-mono focus-visible:ring-0 dark:bg-transparent md:text-xs"
             style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
@@ -125,20 +130,27 @@ export function Composer({
                 size="xs"
                 className="h-5 px-1.5 text-[11px]"
                 disabled={disabled}
-                onClick={() => submit("plan")}
-                aria-label="Create implementation plan"
+                aria-label="Add context"
               >
-                <ScrollText />
-                Plan
+                <Plus />
               </Button>
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-xs"
+                size="xs"
+                className={cn(
+                  "h-5 px-1.5 text-[11px]",
+                  planMode
+                    ? "bg-primary/15 text-primary ring-1 ring-primary/30 hover:bg-primary/20"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                )}
                 disabled={disabled}
-                aria-label="Add context"
+                onClick={() => setPlanMode((active) => !active)}
+                aria-pressed={planMode}
+                aria-label={planMode ? "Disable plan mode" : "Enable plan mode"}
               >
-                <Plus />
+                <ScrollText />
+                Plan
               </Button>
               <PermissionsDropdown
                 value={permissionMode}

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -8,6 +8,7 @@ import {
   GitBranch,
   Monitor,
   Plus,
+  ScrollText,
   ShieldCheck,
   ShieldOff,
   ShieldQuestion,
@@ -32,6 +33,7 @@ import { ModelPicker } from "./model-picker";
 
 interface ComposerProps {
   onSend: (text: string) => boolean | Promise<boolean>;
+  onPlan: (text: string) => boolean | Promise<boolean>;
   onStop: () => void;
   disabled: boolean;
   streaming: boolean;
@@ -51,6 +53,7 @@ const MAX_HEIGHT = 44;
 
 export function Composer({
   onSend,
+  onPlan,
   onStop,
   disabled,
   streaming,
@@ -77,10 +80,11 @@ export function Composer({
     el.style.overflowY = el.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
   }, [input]);
 
-  const submit = () => {
+  const submit = (mode: "chat" | "plan" = "chat") => {
     const trimmed = input.trim();
     if (!trimmed || disabled) return;
-    void Promise.resolve(onSend(trimmed)).then((sent) => {
+    const handler = mode === "plan" ? onPlan : onSend;
+    void Promise.resolve(handler(trimmed)).then((sent) => {
       if (sent) setInput("");
     });
   };
@@ -88,7 +92,7 @@ export function Composer({
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      submit();
+      submit("chat");
     }
   };
 
@@ -96,7 +100,7 @@ export function Composer({
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        submit();
+        submit("chat");
       }}
       className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background/95 px-3 pb-2 pt-1 sm:px-4"
     >
@@ -115,6 +119,18 @@ export function Composer({
           />
           <div className="mt-1 flex items-center justify-between gap-2">
             <div className="flex min-w-0 items-center gap-1.5">
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="h-5 px-1.5 text-[11px]"
+                disabled={disabled}
+                onClick={() => submit("plan")}
+                aria-label="Create implementation plan"
+              >
+                <ScrollText />
+                Plan
+              </Button>
               <Button
                 type="button"
                 variant="ghost"

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -126,7 +126,9 @@ function MessageEvent({
     .trim();
   const assistantText = !isUser
     ? getAssistantTextDisplay(message, {
-        progressOnly: status === "submitted" || status === "streaming",
+        progressOnly:
+          message.metadata?.responseKind !== "plan" &&
+          (status === "submitted" || status === "streaming"),
       }).finalText
     : "";
   const pendingApproval = !isUser && hasPendingToolApproval(message);
@@ -230,7 +232,10 @@ function PlanMessageCard({
             size="sm"
             variant="ghost"
             disabled={disabled}
-            onClick={() => setEditing((value) => !value)}
+            onClick={() => {
+              if (!editing) setDraft(markdown);
+              setEditing((value) => !value);
+            }}
           >
             <Pencil className="size-3.5" />
             {editing ? "Preview" : "Edit"}

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -222,9 +222,6 @@ function PlanMessageCard({
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Plan
           </div>
-          <div className="truncate text-xs font-semibold text-foreground">
-            Implementation plan
-          </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <Button

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -217,16 +217,16 @@ function PlanMessageCard({
 
   return (
     <section className="overflow-hidden rounded-md bg-card/80 ring-1 ring-border">
-      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-1">
+      <div className="flex min-w-0 items-center justify-between gap-2 border-b border-border px-2.5 py-1.5">
         <div className="min-w-0">
-          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <div className="flex h-5 items-center text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Plan
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <Button
             type="button"
-            size="sm"
+            size="xs"
             variant="ghost"
             disabled={disabled}
             onClick={() => {
@@ -234,16 +234,16 @@ function PlanMessageCard({
               setEditing((value) => !value);
             }}
           >
-            <Pencil className="size-3.5" />
+            <Pencil className="size-3" />
             {editing ? "Preview" : "Edit"}
           </Button>
           <Button
             type="button"
-            size="sm"
+            size="xs"
             disabled={disabled || current.trim().length === 0}
             onClick={() => onAccept(current.trim())}
           >
-            <Play className="size-3.5" />
+            <Play className="size-3" />
             Accept
           </Button>
         </div>

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -217,7 +217,7 @@ function PlanMessageCard({
 
   return (
     <section className="overflow-hidden rounded-md bg-card/80 ring-1 ring-border">
-      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-1">
         <div className="min-w-0">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Plan

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -11,6 +11,8 @@ import {
   Cpu,
   DollarSign,
   Hash,
+  Pencil,
+  Play,
 } from "lucide-react";
 
 import {
@@ -22,6 +24,8 @@ import {
 } from "@/src/lib/trace";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import {
   formatMetricCost,
   formatMetricDuration,
@@ -41,6 +45,8 @@ interface MessageListProps {
   status: "submitted" | "streaming" | "ready" | "error";
   recovering?: boolean;
   onApproval: ChatAddToolApproveResponseFunction;
+  onAcceptPlan: (plan: string) => void;
+  acceptPlanDisabled?: boolean;
 }
 
 export function MessageList({
@@ -48,6 +54,8 @@ export function MessageList({
   status,
   recovering = false,
   onApproval,
+  onAcceptPlan,
+  acceptPlanDisabled = false,
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -82,6 +90,8 @@ export function MessageList({
             message={message}
             status={message.id === latestAssistantMessageId ? status : "ready"}
             onApproval={onApproval}
+            onAcceptPlan={onAcceptPlan}
+            acceptPlanDisabled={acceptPlanDisabled}
           />
         ))}
       </div>
@@ -99,10 +109,14 @@ function MessageEvent({
   message,
   status,
   onApproval,
+  onAcceptPlan,
+  acceptPlanDisabled,
 }: {
   message: AntonUIMessage;
   status: "submitted" | "streaming" | "ready" | "error";
   onApproval: ChatAddToolApproveResponseFunction;
+  onAcceptPlan: (plan: string) => void;
+  acceptPlanDisabled: boolean;
 }) {
   const isUser = message.role === "user";
   const userText = message.parts
@@ -130,7 +144,8 @@ function MessageEvent({
     !isUser &&
     responseText.length > 0 &&
     !pendingApproval &&
-    assistantFinal;
+    assistantFinal &&
+    message.metadata?.responseKind !== "plan";
 
   return (
     <div
@@ -163,6 +178,13 @@ function MessageEvent({
               </div>
             );
           })
+        ) : message.metadata?.responseKind === "plan" &&
+          responseText.length > 0 ? (
+          <PlanMessageCard
+            markdown={responseText}
+            onAccept={onAcceptPlan}
+            disabled={!assistantFinal || pendingApproval || acceptPlanDisabled}
+          />
         ) : responseText.length > 0 ? (
           <Markdown className="text-xs">{responseText}</Markdown>
         ) : null}
@@ -175,6 +197,68 @@ function MessageEvent({
         />
       )}
     </div>
+  );
+}
+
+function PlanMessageCard({
+  markdown,
+  disabled,
+  onAccept,
+}: {
+  markdown: string;
+  disabled: boolean;
+  onAccept: (plan: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(markdown);
+  const current = editing ? draft : markdown;
+
+  return (
+    <section className="overflow-hidden rounded-md bg-card/80 ring-1 ring-border">
+      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Plan
+          </div>
+          <div className="truncate text-xs font-semibold text-foreground">
+            Implementation plan
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={disabled}
+            onClick={() => setEditing((value) => !value)}
+          >
+            <Pencil className="size-3.5" />
+            {editing ? "Preview" : "Edit"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={disabled || current.trim().length === 0}
+            onClick={() => onAccept(current.trim())}
+          >
+            <Play className="size-3.5" />
+            Accept
+          </Button>
+        </div>
+      </div>
+      <div className="p-3">
+        {editing ? (
+          <Textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            className="min-h-72 resize-y font-mono text-xs leading-relaxed"
+            aria-label="Edit plan markdown"
+          />
+        ) : (
+          <Markdown className="text-xs">{current}</Markdown>
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/components/features/run-trace/todo-card.tsx
+++ b/components/features/run-trace/todo-card.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import {
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Circle,
   ListTodo,
   Loader2,
@@ -24,6 +27,7 @@ export function TodoCard({
   const completed = snapshot.items.filter(
     (item) => item.status === "completed",
   ).length;
+  const [open, setOpen] = useState(false);
 
   return (
     <section
@@ -32,22 +36,37 @@ export function TodoCard({
         compact ? "p-2" : "p-3",
       )}
     >
-      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+      <button
+        type="button"
+        className={cn(
+          "flex w-full min-w-0 items-center justify-between gap-2 rounded text-left",
+          open && "mb-2",
+        )}
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+      >
         <div className="flex min-w-0 items-center gap-1.5 font-semibold text-foreground">
           <ListTodo className="size-3.5 text-muted-foreground" />
           <span>Todos</span>
         </div>
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+        <span className="inline-flex shrink-0 items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
           {completed}/{snapshot.items.length}
+          {open ? (
+            <ChevronDown className="size-3" />
+          ) : (
+            <ChevronRight className="size-3" />
+          )}
         </span>
-      </div>
-      <ol className="grid gap-1.5">
-        {snapshot.items.map((item) => (
-          <li key={item.id}>
-            <TodoRow item={item} />
-          </li>
-        ))}
-      </ol>
+      </button>
+      {open && (
+        <ol className="grid gap-1.5">
+          {snapshot.items.map((item) => (
+            <li key={item.id}>
+              <TodoRow item={item} />
+            </li>
+          ))}
+        </ol>
+      )}
     </section>
   );
 }

--- a/components/features/run-trace/todo-card.tsx
+++ b/components/features/run-trace/todo-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  CheckCircle2,
+  Circle,
+  ListTodo,
+  Loader2,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type {
+  AntonTodoItem,
+  AntonTodoSnapshot,
+  AntonTodoStatus,
+} from "@/src/lib/trace";
+
+export function TodoCard({
+  snapshot,
+  compact = false,
+}: {
+  snapshot: AntonTodoSnapshot;
+  compact?: boolean;
+}) {
+  const completed = snapshot.items.filter(
+    (item) => item.status === "completed",
+  ).length;
+
+  return (
+    <section
+      className={cn(
+        "rounded-md bg-card/70 text-xs ring-1 ring-border",
+        compact ? "p-2" : "p-3",
+      )}
+    >
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5 font-semibold text-foreground">
+          <ListTodo className="size-3.5 text-muted-foreground" />
+          <span>Todos</span>
+        </div>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {completed}/{snapshot.items.length}
+        </span>
+      </div>
+      <ol className="grid gap-1.5">
+        {snapshot.items.map((item) => (
+          <li key={item.id}>
+            <TodoRow item={item} />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function TodoRow({ item }: { item: AntonTodoItem }) {
+  const meta = todoMeta(item.status);
+  return (
+    <div className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2">
+      <meta.Icon
+        className={cn("mt-0.5 size-3.5", meta.iconClass)}
+        aria-hidden
+      />
+      <span
+        className={cn(
+          "min-w-0 leading-relaxed text-foreground/85",
+          item.status === "completed" && "text-muted-foreground line-through",
+        )}
+      >
+        {item.text}
+      </span>
+    </div>
+  );
+}
+
+function todoMeta(status: AntonTodoStatus) {
+  if (status === "completed") {
+    return { Icon: CheckCircle2, iconClass: "text-emerald-400" };
+  }
+  if (status === "in_progress") {
+    return { Icon: Loader2, iconClass: "animate-spin text-sky-400" };
+  }
+  return { Icon: Circle, iconClass: "text-muted-foreground" };
+}

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -1,10 +1,13 @@
 import {
   getActivityEvents,
   getRunData,
+  getTodoSnapshots,
   getToolTraceEntries,
   isReasoningPart,
+  isTodosDataPart,
   type AntonRunStatus,
   type AntonActivityEvent,
+  type AntonTodoSnapshot,
   type AntonUIMessage,
   type ToolTraceEntry,
 } from "@/src/lib/trace";
@@ -37,6 +40,12 @@ export type TraceRow =
       order: number;
       kind: "progress";
       text: string;
+    }
+  | {
+      id: string;
+      order: number;
+      kind: "todos";
+      snapshot: AntonTodoSnapshot;
     }
   | {
       id: string;
@@ -88,10 +97,21 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
       return;
     }
 
+    if (isTodosDataPart(part)) {
+      rows.push({
+        id: part.id ?? `${message.id}:todos:${index}`,
+        order: index,
+        kind: "todos",
+        snapshot: part.data,
+      });
+      return;
+    }
+
     const toolCallId = toolCallIdForPart(part);
     if (!toolCallId) return;
     const tool = toolEntries.find((entry) => entry.id === toolCallId);
     if (!tool) return;
+    if (tool.name === "update_todos") return;
     rows.push({
       id: tool.id,
       order: index,
@@ -103,6 +123,7 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   for (const event of activities) {
     if (event.kind === "tool" || event.kind === "reasoning") continue;
     if (event.kind === "step") continue;
+    if (event.kind === "progress" && eventHasTodos(event)) continue;
     rows.push({
       id: event.id,
       order: 10_000 + event.sequence,
@@ -112,6 +133,14 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   }
 
   return rows.sort((a, b) => a.order - b.order);
+}
+
+function eventHasTodos(event: AntonActivityEvent): boolean {
+  return (
+    typeof event.details === "object" &&
+    event.details !== null &&
+    "todos" in event.details
+  );
 }
 
 function toolCallIdForPart(
@@ -242,6 +271,7 @@ export function getTraceDurationMs(rows: TraceRow[]): number | undefined {
       if (row.kind === "activity") return row.event.durationMs;
       if (row.kind === "reasoning") return row.event?.durationMs;
       if (row.kind === "progress") return undefined;
+      if (row.kind === "todos") return undefined;
       return row.tool.activity?.durationMs;
     })
     .filter((duration): duration is number => duration !== undefined);
@@ -264,6 +294,14 @@ export function getModelTurnSummary(
         : `${index + 1} ${formatDuration(duration)}`;
     })
     .join(", ")}`;
+}
+
+export function getSessionTodoSnapshots(
+  messages: AntonUIMessage[],
+): AntonTodoSnapshot[] {
+  return messages
+    .flatMap((message) => getTodoSnapshots(message))
+    .sort((a, b) => a.updatedAt - b.updatedAt);
 }
 
 export function toolTitle(entry: ToolTraceEntry, runStatus?: AntonRunStatus): {

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -62,6 +62,7 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   );
   const toolEntries = getToolTraceEntries([message]);
   const rows: TraceRow[] = [];
+  const isPlanResponse = message.metadata?.responseKind === "plan";
   let reasoningIndex = 0;
   const lastToolIndex = message.parts.findLastIndex((part) =>
     toolCallIdForPart(part)
@@ -85,7 +86,11 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
       return;
     }
 
-    if (part.type === "text" && (running || index < lastToolIndex)) {
+    if (
+      part.type === "text" &&
+      !isPlanResponse &&
+      (running || index < lastToolIndex)
+    ) {
       const text = part.text.trim();
       if (!text) return;
       rows.push({

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -20,6 +20,7 @@ import {
 
 import { formatDuration, type TraceRow, type StepGroup } from "./trace-data";
 import { ToolTraceRow } from "./tool-trace-row";
+import { TodoCard } from "./todo-card";
 
 export function TraceRowView({
   row,
@@ -46,6 +47,9 @@ export function TraceRowView({
   }
   if (row.kind === "progress") {
     return <ProgressRow text={row.text} />;
+  }
+  if (row.kind === "todos") {
+    return <TodoCard snapshot={row.snapshot} compact />;
   }
   return <ActivityRow event={row.event} runStatus={runStatus} />;
 }

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -58,12 +58,23 @@ export function Worklog({
   onClose,
 }: WorklogProps) {
   const [tabs, setTabs] = useState<SidebarTab[]>(["worklog"]);
-  const [activeTab, setActiveTab] = useState<SidebarTab>("worklog");
+  const [activeTab, setActiveTab] = useState<SidebarTab | null>("worklog");
   const [menuOpen, setMenuOpen] = useState(false);
 
   const addTab = (tab: SidebarTab) => {
     setTabs((current) => (current.includes(tab) ? current : [...current, tab]));
     setActiveTab(tab);
+    setMenuOpen(false);
+  };
+
+  const closeTab = (tab: SidebarTab) => {
+    setTabs((current) => {
+      const nextTabs = current.filter((item) => item !== tab);
+      setActiveTab((currentActive) =>
+        currentActive === tab ? (nextTabs.at(-1) ?? null) : currentActive,
+      );
+      return nextTabs;
+    });
     setMenuOpen(false);
   };
 
@@ -82,21 +93,36 @@ export function Worklog({
           {tabs.map((tab) => {
             const meta = tabMeta(tab);
             return (
-              <button
+              <div
                 key={tab}
-                type="button"
-                onClick={() => setActiveTab(tab)}
                 className={cn(
-                  "inline-flex h-7 min-w-0 items-center gap-1.5 rounded px-2 text-xs font-semibold transition-colors",
+                  "inline-flex h-7 min-w-0 items-center rounded text-xs font-semibold transition-colors",
                   activeTab === tab
                     ? "bg-secondary text-foreground"
                     : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
                 )}
-                aria-pressed={activeTab === tab}
+                role="group"
+                aria-label={`${meta.label} tab`}
               >
-                <meta.Icon className="size-3.5" />
-                <span className="truncate">{meta.label}</span>
-              </button>
+                <button
+                  type="button"
+                  onClick={() => closeTab(tab)}
+                  className="group/close relative ml-1 inline-flex size-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-label={`Close ${meta.label} tab`}
+                  title={`Close ${meta.label}`}
+                >
+                  <meta.Icon className="size-3.5 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
+                  <X className="absolute size-3.5 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveTab(tab)}
+                  className="min-w-0 rounded py-1 pl-0.5 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-pressed={activeTab === tab}
+                >
+                  <span className="block truncate">{meta.label}</span>
+                </button>
+              </div>
             );
           })}
           <div className="relative">
@@ -148,8 +174,10 @@ export function Worklog({
         <WorklogPanel messages={messages} onApproval={onApproval} />
       ) : activeTab === "plans" ? (
         <PlansPanel messages={messages} />
-      ) : (
+      ) : activeTab === "todos" ? (
         <TodosPanel messages={messages} />
+      ) : (
+        <EmptyTabsPanel />
       )}
     </aside>
   );
@@ -167,6 +195,14 @@ const SIDEBAR_TABS = [
 
 function tabMeta(tab: SidebarTab) {
   return SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
+}
+
+function EmptyTabsPanel() {
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+      Add a sidebar tab to view worklog activity, generated plans, or todos.
+    </div>
+  );
 }
 
 function WorklogPanel({

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -4,12 +4,17 @@ import { useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   CheckCircle2,
+  FileText,
+  ListTodo,
+  Plus,
   TerminalSquare,
   X,
   XCircle,
 } from "lucide-react";
 
 import {
+  getAssistantTextDisplay,
+  getPlanMessages,
   getToolTraceEntries,
   getApprovalMetadata,
   type AntonUIMessage,
@@ -17,6 +22,7 @@ import {
 } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { Markdown } from "@/components/features/chat/markdown";
 import { DiffView } from "./diff-view";
 import {
   isOkWriteFileOutput,
@@ -32,8 +38,11 @@ import {
 import { TerminalOutput } from "./terminal-output";
 import { LiveTerminalOutput } from "./live-terminal";
 import { ApprovalDetails } from "./approval-details";
+import { TodoCard } from "./todo-card";
+import { getSessionTodoSnapshots } from "./trace-data";
 
 export type WorklogEntry = ToolTraceEntry;
+type SidebarTab = "worklog" | "plans" | "todos";
 
 interface WorklogProps {
   messages: AntonUIMessage[];
@@ -48,11 +57,17 @@ export function Worklog({
   className,
   onClose,
 }: WorklogProps) {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const entries = getWorklogEntries(messages);
-  const latest = entries.at(-1);
-  const selected =
-    entries.find((entry) => entry.id === selectedId) ?? latest ?? null;
+  const [tabs, setTabs] = useState<SidebarTab[]>(["worklog"]);
+  const [activeTab, setActiveTab] = useState<SidebarTab>("worklog");
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const addTab = (tab: SidebarTab) => {
+    setTabs((current) => (current.includes(tab) ? current : [...current, tab]));
+    setActiveTab(tab);
+    setMenuOpen(false);
+  };
+
+  const availableTabs = SIDEBAR_TABS.filter((tab) => !tabs.includes(tab.id));
 
   return (
     <aside
@@ -60,31 +75,115 @@ export function Worklog({
         "flex min-h-0 flex-col border-l border-border bg-card/35",
         className,
       )}
-      aria-label="Worklog"
+      aria-label="Trace workspace"
     >
-      <header className="flex h-10 shrink-0 items-center justify-between border-b border-border px-3">
-        <div className="flex items-center gap-1.5 text-xs font-semibold">
-          <TerminalSquare className="size-3.5 text-muted-foreground" />
-          Worklog
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-            {entries.length}
-          </span>
-          {onClose && (
+      <header className="flex h-10 shrink-0 items-center justify-between border-b border-border px-2">
+        <div className="flex min-w-0 items-center gap-1">
+          {tabs.map((tab) => {
+            const meta = tabMeta(tab);
+            return (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={cn(
+                  "inline-flex h-7 min-w-0 items-center gap-1.5 rounded px-2 text-xs font-semibold transition-colors",
+                  activeTab === tab
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
+                )}
+                aria-pressed={activeTab === tab}
+              >
+                <meta.Icon className="size-3.5" />
+                <span className="truncate">{meta.label}</span>
+              </button>
+            );
+          })}
+          <div className="relative">
             <Button
               type="button"
               size="icon-sm"
               variant="ghost"
-              onClick={onClose}
-              aria-label="Close worklog"
+              onClick={() => setMenuOpen((open) => !open)}
+              disabled={availableTabs.length === 0}
+              aria-label="Add sidebar tab"
+              aria-expanded={menuOpen}
             >
-              <X />
+              <Plus />
             </Button>
-          )}
+            {menuOpen && availableTabs.length > 0 && (
+              <div className="absolute left-0 top-full z-50 mt-1 w-36 rounded-md bg-popover p-1 text-xs text-popover-foreground shadow-lg ring-1 ring-border">
+                {availableTabs.map((tab) => {
+                  const meta = tabMeta(tab.id);
+                  return (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-accent"
+                      onClick={() => addTab(tab.id)}
+                    >
+                      <meta.Icon className="size-3.5 text-muted-foreground" />
+                      {meta.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
         </div>
+        {onClose && (
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            onClick={onClose}
+            aria-label="Close trace workspace"
+          >
+            <X />
+          </Button>
+        )}
       </header>
 
+      {activeTab === "worklog" ? (
+        <WorklogPanel messages={messages} onApproval={onApproval} />
+      ) : activeTab === "plans" ? (
+        <PlansPanel messages={messages} />
+      ) : (
+        <TodosPanel messages={messages} />
+      )}
+    </aside>
+  );
+}
+
+const SIDEBAR_TABS = [
+  { id: "worklog", label: "Worklog", Icon: TerminalSquare },
+  { id: "plans", label: "Plans", Icon: FileText },
+  { id: "todos", label: "Todos", Icon: ListTodo },
+] as const satisfies readonly {
+  id: SidebarTab;
+  label: string;
+  Icon: typeof TerminalSquare;
+}[];
+
+function tabMeta(tab: SidebarTab) {
+  return SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
+}
+
+function WorklogPanel({
+  messages,
+  onApproval,
+}: {
+  messages: AntonUIMessage[];
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const entries = getWorklogEntries(messages);
+  const latest = entries.at(-1);
+  const selected =
+    entries.find((entry) => entry.id === selectedId) ?? latest ?? null;
+
+  return (
+    <>
       {entries.length === 0 ? (
         <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
           Tool activity will appear here when Anton reads, searches, edits, or
@@ -108,11 +207,84 @@ export function Worklog({
           )}
         </div>
       )}
-    </aside>
+    </>
   );
 }
 export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
   return getToolTraceEntries(messages);
+}
+
+function PlansPanel({ messages }: { messages: AntonUIMessage[] }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const plans = getPlanMessages(messages);
+  const selected = plans.find((plan) => plan.id === selectedId) ?? plans.at(-1);
+
+  if (plans.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+        Generated plans will appear here after using the Plan composer action.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <ol className="border-b border-border px-2 py-2">
+        {plans.map((plan, index) => (
+          <li key={plan.id}>
+            <button
+              type="button"
+              onClick={() => setSelectedId(plan.id)}
+              className={cn(
+                "grid w-full grid-cols-[0.875rem_1fr] gap-1.5 rounded-md px-1.5 py-1 text-left text-xs transition-colors",
+                plan.id === selected?.id ? "bg-accent/70" : "hover:bg-accent/40",
+              )}
+            >
+              <FileText className="mt-0.5 size-3 text-muted-foreground" />
+              <div className="min-w-0">
+                <div className="truncate font-mono text-[11px] text-foreground">
+                  Plan {index + 1}
+                </div>
+                <p className="truncate font-mono text-[10px] text-muted-foreground">
+                  {firstLine(getAssistantTextDisplay(plan).finalText)}
+                </p>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ol>
+      {selected && (
+        <section className="px-3 py-3">
+          <Markdown className="text-xs">
+            {getAssistantTextDisplay(selected).finalText}
+          </Markdown>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function TodosPanel({ messages }: { messages: AntonUIMessage[] }) {
+  const snapshots = getSessionTodoSnapshots(messages);
+  const latest = snapshots.at(-1);
+
+  if (!latest) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+        Todo snapshots will appear here when Anton starts implementation work.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      <TodoCard snapshot={latest} />
+    </div>
+  );
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "Markdown plan";
 }
 
 function WorklogRow({

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -313,8 +313,8 @@ function TodosPanel({ messages }: { messages: AntonUIMessage[] }) {
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-      <TodoCard snapshot={latest} />
+    <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+      <TodoCard snapshot={latest} compact />
     </div>
   );
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -22,8 +22,28 @@ import {
 import type { PermissionMode } from "./permissions";
 
 const MAX_STEPS = 20;
+export type AgentRunMode = "chat" | "plan";
 
-function systemPrompt(mcpTools: LoadedMcpTools, workspaceRoot?: string): string {
+const PLAN_MODE_TOOLS = [
+  "read_file",
+  "read_dir",
+  "stat",
+  "git_status",
+  "git_diff",
+  "git_show",
+  "grep",
+  "glob",
+  "list_memory",
+  "list_skills",
+  "read_skill",
+  "delegate_task",
+] as const;
+
+function systemPrompt(
+  mcpTools: LoadedMcpTools,
+  workspaceRoot?: string,
+  mode: AgentRunMode = "chat",
+): string {
   const root = workspaceRoot
     ? ensureWorkspaceRootAt(workspaceRoot)
     : ensureWorkspaceRoot();
@@ -66,6 +86,7 @@ function systemPrompt(mcpTools: LoadedMcpTools, workspaceRoot?: string): string 
     "- `list_skills()` - list project-local skills under `skills/<slug>/SKILL.md`.",
     "- `read_skill(slug)` - read one project-local skill before applying it.",
     "- `delegate_task(task, maxSteps?)` - run a bounded read-only sub-agent and return its summary.",
+    "- `update_todos(items)` - publish the full current implementation checklist. Use during normal implementation turns for multi-step coding tasks.",
     ...mcpToolPromptLines(mcpTools),
     "",
     ...projectMemoryPromptLines(),
@@ -74,6 +95,16 @@ function systemPrompt(mcpTools: LoadedMcpTools, workspaceRoot?: string): string 
     "",
     "Conventions:",
     "- Answer concisely. Prefer short, correct answers over long hedged ones.",
+    ...(mode === "plan"
+      ? [
+          "- You are in explicit Plan mode. Analyze the request and repository context, then produce a markdown implementation plan only.",
+          "- In Plan mode, do not edit files, run mutating commands, format files, commit, branch, or call workspace mutation tools.",
+          "- Use read-only inspection tools as needed. Do not call `update_todos` in Plan mode.",
+          "- The final response should be the plan itself with clear sections and enough implementation detail to execute in a later turn.",
+        ]
+      : [
+          "- For multi-step coding tasks, call `update_todos` with a full checklist snapshot before the first edit and update it as work progresses.",
+        ]),
     "- Plan first for multi-step tasks: explore read-only tools (`glob`, `grep`, `read_dir`, `stat`, `read_file`) before editing (`edit_file`, `write_file`) or running shell commands.",
     "- For existing-file edits, read the file first, then use `edit_file` with the returned `sha256` as `expectedHash`.",
     "- Use memory only for durable project preferences or facts that should carry across sessions.",
@@ -150,6 +181,7 @@ export async function runAgent({
   model,
   workspaceRoot,
   permissionMode,
+  mode = "chat",
   enabledMcpServerIds,
   onStepStart,
   onStepFinish,
@@ -164,6 +196,7 @@ export async function runAgent({
   model?: string;
   workspaceRoot?: string;
   permissionMode?: PermissionMode;
+  mode?: AgentRunMode;
   enabledMcpServerIds?: string[];
   onStepStart?: (event: { stepNumber: number }) => void;
   onStepFinish?: (event: { stepNumber: number }) => void;
@@ -210,9 +243,10 @@ export async function runAgent({
 
   return streamText({
     model: openrouter(selectedModel),
-    system: systemPrompt(mcpTools, workspaceRoot),
+    system: systemPrompt(mcpTools, workspaceRoot, mode),
     messages,
     tools,
+    activeTools: mode === "plan" ? [...PLAN_MODE_TOOLS] : undefined,
     stopWhen: stepCountIs(MAX_STEPS),
     providerOptions: {
       openrouter: {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -22,6 +22,8 @@ import {
 import type { PermissionMode } from "./permissions";
 
 const MAX_STEPS = 20;
+const CHAT_MAX_OUTPUT_TOKENS = 8_192;
+const PLAN_MAX_OUTPUT_TOKENS = 4_096;
 export type AgentRunMode = "chat" | "plan";
 
 const PLAN_MODE_TOOLS = [
@@ -245,6 +247,8 @@ export async function runAgent({
     model: openrouter(selectedModel),
     system: systemPrompt(mcpTools, workspaceRoot, mode),
     messages,
+    maxOutputTokens:
+      mode === "plan" ? PLAN_MAX_OUTPUT_TOKENS : CHAT_MAX_OUTPUT_TOKENS,
     tools,
     activeTools: mode === "plan" ? [...PLAN_MODE_TOOLS] : undefined,
     stopWhen: stepCountIs(MAX_STEPS),

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -195,6 +195,7 @@ export const NATIVE_TOOL_PERMISSION_METADATA = {
   list_skills: READ_ONLY,
   read_skill: READ_ONLY,
   delegate_task: READ_ONLY,
+  update_todos: READ_ONLY,
 } as const satisfies Record<string, ToolPermissionMetadata>;
 
 export function getNativeToolPermissionMetadata(
@@ -563,6 +564,16 @@ function buildNativeToolApprovalMetadata(
         details: [
           "Starts a bounded child Anton agent with read/search/skills/memory access only.",
           "The delegate cannot write files, run shell commands, or mutate memory.",
+        ],
+      };
+    case "update_todos":
+      return {
+        title: "Update todo checklist",
+        summary: metadata.summary,
+        riskCategories: metadata.categories,
+        details: [
+          "Publishes the current implementation checklist to the chat trace.",
+          "Does not read, write, or mutate workspace files.",
         ],
       };
     default:

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -54,6 +54,7 @@ import {
   readSkillTool,
 } from "./skills";
 import { createDelegateTaskTool } from "./delegate";
+import { createUpdateTodosTool, updateTodosTool } from "./todos";
 
 export const nativeAntonTools = applyNativeToolPermissionPolicy({
   read_file: readFileTool,
@@ -82,6 +83,7 @@ export const nativeAntonTools = applyNativeToolPermissionPolicy({
   forget_memory: forgetMemoryTool,
   list_skills: listSkillsTool,
   read_skill: readSkillTool,
+  update_todos: updateTodosTool,
 } as const);
 
 export function createAntonTools({
@@ -120,6 +122,7 @@ export function createAntonTools({
     list_skills: createListSkillsTool(workspaceRoot),
     read_skill: createReadSkillTool(workspaceRoot),
     delegate_task: createDelegateTaskTool({ model, workspaceRoot }),
+    update_todos: createUpdateTodosTool(),
   }, permissionMode);
 
   return {

--- a/src/agent/tools/todos.ts
+++ b/src/agent/tools/todos.ts
@@ -1,0 +1,51 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const TODO_LIMIT = 40;
+
+const todoStatusSchema = z.enum(["pending", "in_progress", "completed"]);
+
+const todoItemSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(80)
+    .describe("Stable todo identifier, reused across updates."),
+  text: z.string().min(1).max(240).describe("Short human-readable todo text."),
+  status: todoStatusSchema,
+});
+
+export function createUpdateTodosTool() {
+  return tool({
+    description:
+      "Publish the current implementation todo checklist. Sends the full current snapshot every time. Use during normal implementation turns for multi-step coding tasks.",
+    inputSchema: z.object({
+      items: z
+        .array(todoItemSchema)
+        .max(TODO_LIMIT)
+        .describe("Full ordered todo snapshot for the current run."),
+    }),
+    execute: async ({ items }) => {
+      const inProgressCount = items.filter(
+        (item) => item.status === "in_progress",
+      ).length;
+      if (inProgressCount > 1) {
+        return {
+          ok: false as const,
+          error: "Only one todo item can be in_progress.",
+        };
+      }
+
+      return {
+        ok: true as const,
+        items: items.map((item) => ({
+          id: item.id.trim(),
+          text: item.text.replace(/\s+/g, " ").trim(),
+          status: item.status,
+        })),
+      };
+    },
+  });
+}
+
+export const updateTodosTool = createUpdateTodosTool();

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -420,13 +420,21 @@ export function getActiveRunForSession(
 export function getMessagePersistenceConflict<UI extends UIMessage>(
   sessionId: string,
   incoming: UI[],
+  options: { mutableTailCount?: number } = {},
 ): { storedCount: number; incomingCount: number } | undefined {
   const stored = storedMessageIds(sessionId);
   if (stored.length > incoming.length) {
     return { storedCount: stored.length, incomingCount: incoming.length };
   }
 
-  for (const [idx, storedId] of stored.entries()) {
+  const mutableTailCount = Math.min(
+    options.mutableTailCount ?? 0,
+    stored.length,
+    incoming.length,
+  );
+  const stableCount = stored.length - mutableTailCount;
+
+  for (const [idx, storedId] of stored.slice(0, stableCount).entries()) {
     if (storedId !== messageId(incoming[idx], sessionId, idx)) {
       return { storedCount: stored.length, incomingCount: incoming.length };
     }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,6 +3,7 @@ export const DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4.5";
 export const MODEL_CATALOG = [
   { id: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
   { id: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { id: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
   { id: "openai/gpt-5", label: "GPT-5" },
   { id: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
 ] as const;

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -26,6 +26,7 @@ export type AntonActivityStatus =
 
 export type AntonMessageMetadata = {
   runId?: string;
+  responseKind?: "plan";
   model?: string;
   status?: AntonRunStatus;
   startedAt?: number;
@@ -99,9 +100,24 @@ export type AntonActivityEvent = {
   details?: Record<string, unknown>;
 };
 
+export type AntonTodoStatus = "pending" | "in_progress" | "completed";
+
+export type AntonTodoItem = {
+  id: string;
+  text: string;
+  status: AntonTodoStatus;
+};
+
+export type AntonTodoSnapshot = {
+  runId: string;
+  items: AntonTodoItem[];
+  updatedAt: number;
+};
+
 export type AntonDataParts = {
   run: AntonRunData;
   activity: AntonActivityEvent;
+  todos: AntonTodoSnapshot;
 };
 
 export type AntonUIMessage = UIMessage<
@@ -754,4 +770,34 @@ export function isActivityDataPart(
   part: AntonUIMessage["parts"][number],
 ): part is Extract<AntonUIMessage["parts"][number], { type: "data-activity" }> {
   return isDataUIPart(part) && part.type === "data-activity";
+}
+
+export function isTodosDataPart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-todos" }> {
+  return isDataUIPart(part) && part.type === "data-todos";
+}
+
+export function getTodoSnapshots(message: AntonUIMessage): AntonTodoSnapshot[] {
+  const snapshots: AntonTodoSnapshot[] = [];
+  for (const part of message.parts) {
+    if (isTodosDataPart(part)) snapshots.push(part.data);
+  }
+  return snapshots.sort((a, b) => a.updatedAt - b.updatedAt);
+}
+
+export function getLatestTodoSnapshot(
+  messages: AntonUIMessage[],
+): AntonTodoSnapshot | undefined {
+  return messages
+    .flatMap((message) => getTodoSnapshots(message))
+    .sort((a, b) => a.updatedAt - b.updatedAt)
+    .at(-1);
+}
+
+export function getPlanMessages(messages: AntonUIMessage[]): AntonUIMessage[] {
+  return messages.filter(
+    (message) =>
+      message.role === "assistant" && message.metadata?.responseKind === "plan",
+  );
 }


### PR DESCRIPTION
## Summary
- add explicit composer Plan mode that sends `/api/chat` with `mode: "plan"` and marks responses as plan messages
- render plan responses as markdown cards with edit and accept actions, where accept sends the edited/current plan as a normal implementation turn
- add `update_todos` and todo snapshots that render in the reasoning trace and new sidebar Todos tab
- convert the right trace sidebar into session-local tabs for Worklog, Plans, and Todos

Closes #65.

## Verification
- `pnpm typecheck` ?
- `pnpm lint` ?
- `pnpm build` ? (passes; existing Turbopack NFT warning remains for `next.config.ts -> src/workspace/local.ts -> app/api/projects/route.ts`)
- `Invoke-WebRequest http://localhost:3000` returned `200`

## Visual verification
- Dev server running at `http://localhost:3000` for manual Plan/Todos checks.
- UI states covered by code review: normal send path remains default chat mode, Plan action uses plan mode, plan cards expose Edit/Accept, sidebar can add Plans/Todos tabs, todo snapshots render through the shared TodoCard.
