### PR TITLE
Fix trace persistence and todo state regressions

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -47,6 +47,7 @@ import { DEFAULT_MODEL } from "@/src/lib/providers";
 import { isSupportedModelId } from "@/src/lib/models";
 import { redactText, redactValue } from "@/src/lib/redaction";
 import {
+  collapseAssistantContinuationMessages,
   getApprovalMetadata,
   getToolTraceEntries,
   isRunDataPart,
@@ -124,8 +125,10 @@ export async function POST(req: Request) {
     });
   } else {
     const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
+    const approvalContinuation = isToolApprovalContinuation(incomingHistory);
     const conflict = getMessagePersistenceConflict(sessionId, incomingHistory, {
-      mutableTailCount: isToolApprovalContinuation(incomingHistory) ? 1 : 0,
+      mutableTailCount: approvalContinuation ? 1 : 0,
+      allowExtraAssistantTail: approvalContinuation,
     });
     if (conflict) {
       return Response.json(
@@ -242,15 +245,24 @@ export async function POST(req: Request) {
       }
     },
     onFinish: ({ messages }) => {
-      const persistedMessages = messages
+      const visibleMessages = messages
         .map(stripDurableTraceParts)
         .filter(hasSubstantiveHistoryParts);
+      const persistedMessages =
+        collapseAssistantContinuationMessages(visibleMessages);
       if (persistedMessages.length === 0) return;
       persistFinalToolApprovalStates(runId, messages);
       try {
+        const approvalContinuation = isToolApprovalContinuation(persistedMessages);
+        const collapsedContinuations =
+          persistedMessages.length < visibleMessages.length;
         saveMessagesIncrementally<AntonUIMessage>(
           sessionId,
           redactValue(persistedMessages) as AntonUIMessage[],
+          {
+            pruneExtraAssistantTail:
+              approvalContinuation || collapsedContinuations,
+          },
         );
       } catch (err) {
         if (err instanceof MessagePersistenceConflictError) {
@@ -269,12 +281,43 @@ export async function POST(req: Request) {
 }
 
 function prepareMessagesForModel(messages: AntonUIMessage[]): AntonUIMessage[] {
+  const approvalContinuationMessageId = isToolApprovalContinuation(messages)
+    ? messages.at(-1)?.id
+    : undefined;
+
   return messages.flatMap((message) => {
-    const parts = message.parts
+    const parts = compactMessagePartsForModel(
+      message,
+      message.id === approvalContinuationMessageId,
+    )
       .filter(isModelContextPart)
       .map(stripProviderReplayMetadata);
     if (!parts.some(isSubstantiveModelContextPart)) return [];
     return [{ ...message, parts }];
+  });
+}
+
+function compactMessagePartsForModel(
+  message: AntonUIMessage,
+  approvalContinuation: boolean,
+): AntonUIMessage["parts"] {
+  if (message.role !== "assistant") return message.parts;
+  if (approvalContinuation) {
+    return message.parts.filter(isApprovalContinuationContextPart);
+  }
+
+  const lastToolIndex = message.parts.findLastIndex(isToolUIPart);
+  const finalTextParts = message.parts.filter((part, index) => {
+    return (
+      part.type === "text" &&
+      part.text.trim().length > 0 &&
+      (lastToolIndex === -1 || index > lastToolIndex)
+    );
+  });
+  if (finalTextParts.length > 0) return finalTextParts;
+
+  return message.parts.filter((part) => {
+    return part.type === "text" && part.text.trim().length > 0;
   });
 }
 
@@ -329,6 +372,16 @@ function hasSubstantiveHistoryParts(message: AntonUIMessage): boolean {
   });
 }
 
+function isApprovalContinuationContextPart(
+  part: AntonUIMessage["parts"][number],
+): boolean {
+  if (!("state" in part) || typeof part.state !== "string") return false;
+  return (
+    part.state === "approval-responded" ||
+    part.state === "output-denied"
+  );
+}
+
 function isToolApprovalContinuation(messages: AntonUIMessage[]): boolean {
   const last = messages.at(-1);
   if (!last || last.role !== "assistant") return false;
@@ -366,6 +419,7 @@ function createTraceWriter({
   let sequence = 0;
   let stepCount = 0;
   let finalized = false;
+  let failedToolCount = 0;
   const events = new Map<string, AntonActivityEvent>();
 
   const metadata = (
@@ -578,7 +632,9 @@ function createTraceWriter({
   ) => {
     if (finalized) return;
     finalized = true;
-    settleRunningEvents(status === "completed" ? "completed" : "error");
+    const effectiveStatus =
+      status === "completed" && failedToolCount > 0 ? "error" : status;
+    settleRunningEvents(effectiveStatus === "completed" ? "completed" : "error");
     const finishedAt = Date.now();
     const durationMs = Math.max(0, finishedAt - startedAt);
     const inputTokens = usage?.inputTokens;
@@ -588,8 +644,10 @@ function createTraceWriter({
     const costMetadata = openRouterCostMetadata(providerMetadata);
     const storedFinishReason = limits.maxStepLimitReached
       ? "max_step_limit"
+      : effectiveStatus === "error" && failedToolCount > 0
+        ? "tool_error"
       : finishReason;
-    writeRun(status, {
+    writeRun(effectiveStatus, {
       finishedAt,
       durationMs,
       inputTokens,
@@ -616,7 +674,7 @@ function createTraceWriter({
       });
     }
     updateRun(runId, {
-      status,
+      status: effectiveStatus,
       finishedAt: new Date(finishedAt),
       durationMs,
       inputTokens: inputTokens ?? null,
@@ -738,6 +796,7 @@ function createTraceWriter({
       const current = events.get(`${runId}:tool:${event.toolCallId}`);
       const error = toolError(event.success, event.output, event.error);
       const status = error ? "error" : "completed";
+      if (error) failedToolCount += 1;
       finishEvent(`${runId}:tool:${event.toolCallId}`, {
         status,
         label: toolLabel(event.toolName, event.input),
@@ -747,6 +806,7 @@ function createTraceWriter({
           toolName: event.toolName,
           stepNumber: event.stepNumber,
           success: event.success,
+          error,
         },
       });
       const currentApproval = structuredApprovalDetails(current?.details?.approval);

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -94,6 +94,9 @@ function ChatSession({
     mode: "chat" | "plan";
     untrusted: McpPreflightServer[];
   } | null>(null);
+  const [streamingResponseMode, setStreamingResponseMode] = useState<
+    "chat" | "plan" | null
+  >(null);
   const effectiveProjectId = initialProjectId ?? activeProjectId;
   const project = useProjectSummary(effectiveProjectId);
 
@@ -121,6 +124,7 @@ function ChatSession({
     messages: initialMessages,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onFinish: ({ messages: finishedMessages, isAbort }) => {
+      setStreamingResponseMode(null);
       const visibleMessages = finishedMessages.filter(hasVisibleMessageParts);
       if (visibleMessages.length > 0) {
         lastNonEmptyMessagesRef.current = visibleMessages;
@@ -227,6 +231,10 @@ function ChatSession({
       setPendingMcpSend({ text, mode, untrusted: preflight.untrusted });
       return false;
     }
+    if (lastNonEmptyMessagesRef.current.length > 0) {
+      setMessageDisplayOverride(lastNonEmptyMessagesRef.current);
+    }
+    setStreamingResponseMode(mode);
     void sendMessage(
       { text },
       {
@@ -261,8 +269,11 @@ function ChatSession({
   };
 
   const streaming = status === "streaming" || status === "submitted";
-  const displayMessages =
-    messages.length > 0 ? messages : messageDisplayOverride ?? messages;
+  const displayMessages = displayMessagesForRender({
+    current: messages,
+    fallback: messageDisplayOverride,
+    streaming,
+  });
   const recoveringMessages =
     restoringPersistedMessages && displayMessages.length === 0;
   const headerTitle = initialTitle ?? (sessionIdProp ? "Session" : "New chat");
@@ -333,9 +344,10 @@ function ChatSession({
             messages={displayMessages}
             status={status}
             recovering={recoveringMessages}
+            streamingResponseMode={streaming ? streamingResponseMode : null}
             onApproval={addToolApprovalResponse}
-            onAcceptPlan={(plan) => {
-              void sendWithMcp(`Implement this accepted plan:\n\n${plan}`, "chat");
+            onAcceptPlan={() => {
+              void sendWithMcp("Implement plan", "chat");
             }}
             acceptPlanDisabled={streaming || !effectiveProjectId}
           />
@@ -466,4 +478,27 @@ function hasVisibleMessageParts(message: AntonUIMessage): boolean {
     }
     return part.type !== "step-start";
   });
+}
+
+function displayMessagesForRender({
+  current,
+  fallback,
+  streaming,
+}: {
+  current: AntonUIMessage[];
+  fallback: AntonUIMessage[] | null;
+  streaming: boolean;
+}): AntonUIMessage[] {
+  if (current.length === 0) return fallback ?? current;
+  if (!streaming || !fallback || fallback.length === 0) return current;
+
+  const currentIds = new Set(current.map((message) => message.id));
+  const fallbackIds = new Set(fallback.map((message) => message.id));
+  const retainedHistory = fallback.every((message) => currentIds.has(message.id));
+  if (retainedHistory) return current;
+
+  return [
+    ...fallback,
+    ...current.filter((message) => !fallbackIds.has(message.id)),
+  ];
 }

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   ArrowDownToLine,
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 
 import {
+  failedToolOutputMessage,
   getAssistantTextDisplay,
   getRunData,
   getToolTraceEntries,
@@ -34,6 +35,7 @@ import {
   type ResponseMetrics,
 } from "./message-metrics";
 import { RunTraceAccordion } from "@/components/features/run-trace/run-trace";
+import { getTodoTraceDisplay } from "@/components/features/run-trace/trace-data";
 import {
   HoverCard,
   HoverCardContent,
@@ -44,6 +46,7 @@ interface MessageListProps {
   messages: AntonUIMessage[];
   status: "submitted" | "streaming" | "ready" | "error";
   recovering?: boolean;
+  streamingResponseMode?: "chat" | "plan" | null;
   onApproval: ChatAddToolApproveResponseFunction;
   onAcceptPlan: (plan: string) => void;
   acceptPlanDisabled?: boolean;
@@ -53,11 +56,13 @@ export function MessageList({
   messages,
   status,
   recovering = false,
+  streamingResponseMode = null,
   onApproval,
   onAcceptPlan,
   acceptPlanDisabled = false,
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const todoDisplay = useMemo(() => getTodoTraceDisplay(messages), [messages]);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({
@@ -74,9 +79,9 @@ export function MessageList({
     );
   }
 
-  const latestAssistantMessageId = messages.findLast(
-    (message) => message.role === "assistant",
-  )?.id;
+  const latestMessage = messages.at(-1);
+  const activeAssistantMessageId =
+    latestMessage?.role === "assistant" ? latestMessage.id : undefined;
 
   return (
     <div
@@ -88,7 +93,15 @@ export function MessageList({
           <MessageEvent
             key={message.id}
             message={message}
-            status={message.id === latestAssistantMessageId ? status : "ready"}
+            status={
+              message.id === activeAssistantMessageId ? status : "ready"
+            }
+            streamingResponseMode={
+              message.id === activeAssistantMessageId
+                ? streamingResponseMode
+                : null
+            }
+            todoDisplay={todoDisplay}
             onApproval={onApproval}
             onAcceptPlan={onAcceptPlan}
             acceptPlanDisabled={acceptPlanDisabled}
@@ -108,17 +121,25 @@ export function emptyMessageListText(recovering: boolean): string {
 function MessageEvent({
   message,
   status,
+  streamingResponseMode,
+  todoDisplay,
   onApproval,
   onAcceptPlan,
   acceptPlanDisabled,
 }: {
   message: AntonUIMessage;
   status: "submitted" | "streaming" | "ready" | "error";
+  streamingResponseMode: "chat" | "plan" | null;
+  todoDisplay: ReturnType<typeof getTodoTraceDisplay>;
   onApproval: ChatAddToolApproveResponseFunction;
   onAcceptPlan: (plan: string) => void;
   acceptPlanDisabled: boolean;
 }) {
   const isUser = message.role === "user";
+  const streaming = status === "submitted" || status === "streaming";
+  const responseKind =
+    message.metadata?.responseKind ??
+    (!isUser && streaming ? streamingResponseMode ?? undefined : undefined);
   const userText = message.parts
     .filter((p) => p.type === "text")
     .map((p) => (p as { text: string }).text)
@@ -127,14 +148,15 @@ function MessageEvent({
   const assistantText = !isUser
     ? getAssistantTextDisplay(message, {
         progressOnly:
-          message.metadata?.responseKind !== "plan" &&
-          (status === "submitted" || status === "streaming"),
+          responseKind !== "plan" && streaming,
       }).finalText
     : "";
   const pendingApproval = !isUser && hasPendingToolApproval(message);
+  const failedToolText = !isUser ? toolFailureFallbackText(message) : "";
   const assistantFinal = !isUser && isAssistantMessageFinal(message);
   const fallbackText = !isUser &&
     assistantText.length === 0 &&
+    failedToolText.length === 0 &&
     !pendingApproval &&
     assistantFinal
     ? toolResultFallbackText(message)
@@ -146,8 +168,21 @@ function MessageEvent({
     !isUser &&
     responseText.length > 0 &&
     !pendingApproval &&
+    failedToolText.length === 0 &&
     assistantFinal &&
-    message.metadata?.responseKind !== "plan";
+    responseKind !== "plan";
+  const showToolFailure =
+    !isUser &&
+    failedToolText.length > 0 &&
+    !pendingApproval &&
+    assistantFinal &&
+    responseKind !== "plan";
+  const showPlanCard =
+    !isUser &&
+    responseKind === "plan" &&
+    responseText.length > 0 &&
+    assistantFinal &&
+    !streaming;
 
   return (
     <div
@@ -168,6 +203,7 @@ function MessageEvent({
           <RunTraceAccordion
             message={message}
             status={status}
+            todoDisplay={todoDisplay}
             onApproval={onApproval}
           />
         )}
@@ -180,14 +216,18 @@ function MessageEvent({
               </div>
             );
           })
-        ) : message.metadata?.responseKind === "plan" &&
-          responseText.length > 0 ? (
+        ) : showPlanCard ? (
           <PlanMessageCard
             markdown={responseText}
             onAccept={onAcceptPlan}
             disabled={!assistantFinal || pendingApproval || acceptPlanDisabled}
           />
-        ) : responseText.length > 0 ? (
+        ) : showToolFailure ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            Tool failed: {failedToolText}
+          </div>
+        ) : responseKind === "plan" ? null
+        : responseText.length > 0 ? (
           <Markdown className="text-xs">{responseText}</Markdown>
         ) : null}
       </div>
@@ -267,6 +307,31 @@ function PlanMessageCard({
 function isAssistantMessageFinal(message: AntonUIMessage): boolean {
   const runStatus = getRunData(message)?.status ?? message.metadata?.status;
   return runStatus === undefined || runStatus !== "running";
+}
+
+function toolFailureFallbackText(message: AntonUIMessage): string {
+  const entries = getToolTraceEntries([message]);
+  const failed = entries.findLast((entry) => {
+    return (
+      entry.state === "output-error" ||
+      isFailedToolOutput(entry.output)
+    );
+  });
+  if (!failed) return "";
+  return (
+    failed.errorText ??
+    failedToolOutputMessage(failed.output) ??
+    `${failed.name} failed`
+  );
+}
+
+function isFailedToolOutput(output: unknown): boolean {
+  return (
+    typeof output === "object" &&
+    output !== null &&
+    "ok" in output &&
+    (output as { ok: unknown }).ok === false
+  );
 }
 
 function toolResultFallbackText(message: AntonUIMessage): string {

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -14,6 +14,7 @@ import {
   getAssistantTextDisplay,
   getMessageRunDurationMs,
   getRunData,
+  hasFailedToolOutput,
   hasPendingToolApproval,
   type AntonUIMessage,
   type AntonRunStatus,
@@ -26,6 +27,7 @@ import {
   getTraceDurationMs,
   getTraceRows,
   groupTraceRowsByStep,
+  type TodoTraceDisplay,
 } from "./trace-data";
 import { StepGroupView, TraceRowView } from "./trace-rows";
 
@@ -48,20 +50,24 @@ function buildInterleaved(
 interface RunTraceAccordionProps {
   message: AntonUIMessage;
   status: "submitted" | "streaming" | "ready" | "error";
+  todoDisplay?: TodoTraceDisplay;
   onApproval: ChatAddToolApproveResponseFunction;
 }
 
 export function RunTraceAccordion({
   message,
   status,
+  todoDisplay,
   onApproval,
 }: RunTraceAccordionProps) {
   const run = getRunData(message);
   const metadata = message.metadata;
   const transportRunning = status === "submitted" || status === "streaming";
+  const hasToolFailure = hasFailedToolOutput(message);
   const runStatus = effectiveRunStatus(
     run?.status ?? metadata?.status,
     transportRunning,
+    hasToolFailure,
   );
   const isRunning = runStatus === "running";
 
@@ -77,7 +83,10 @@ export function RunTraceAccordion({
   const forceOpen = pendingApproval;
 
   const now = useTick(isRunning);
-  const rows = useMemo(() => getTraceRows(message), [message]);
+  const rows = useMemo(
+    () => getTraceRows(message, todoDisplay),
+    [message, todoDisplay],
+  );
   const stepGroups = useMemo(() => groupTraceRowsByStep(message, rows), [message, rows]);
   const modelTurnSummary = useMemo(() => getModelTurnSummary(message), [message]);
 
@@ -153,8 +162,10 @@ export function RunTraceAccordion({
 function effectiveRunStatus(
   status: AntonRunStatus | undefined,
   transportRunning: boolean,
+  hasToolFailure: boolean,
 ): AntonRunStatus {
   if (status === "running" && !transportRunning) return "aborted";
+  if (hasToolFailure) return "error";
   return status ?? "completed";
 }
 

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -1,8 +1,11 @@
 import {
   getActivityEvents,
+  getAssistantTextDisplay,
   getRunData,
   getTodoSnapshots,
   getToolTraceEntries,
+  hasFailedToolOutput,
+  hasPendingToolApproval,
   isReasoningPart,
   isTodosDataPart,
   type AntonRunStatus,
@@ -54,7 +57,95 @@ export type TraceRow =
       tool: ToolTraceEntry;
     };
 
-export function getTraceRows(message: AntonUIMessage): TraceRow[] {
+export type TodoTraceDisplay = ReadonlyMap<string, AntonTodoSnapshot>;
+
+export function getTodoTraceDisplay(
+  messages: AntonUIMessage[],
+): TodoTraceDisplay {
+  const displayByFirstPart = new Map<string, AntonTodoSnapshot>();
+  const turnTodos = new Map<
+    number,
+    {
+      firstPartKey: string;
+      latestSnapshot: AntonTodoSnapshot;
+      latestOrder: number;
+    }
+  >();
+  let userTurn = 0;
+
+  const updateTurnSnapshot = (
+    turn: number,
+    snapshot: AntonTodoSnapshot,
+    order: number,
+    firstPartKey?: string,
+  ) => {
+    const current = turnTodos.get(turn);
+    if (!current) {
+      if (!firstPartKey) return;
+      turnTodos.set(turn, {
+        firstPartKey,
+        latestSnapshot: snapshot,
+        latestOrder: order,
+      });
+      return;
+    }
+    if (
+      snapshot.updatedAt > current.latestSnapshot.updatedAt ||
+      (snapshot.updatedAt === current.latestSnapshot.updatedAt &&
+        order > current.latestOrder)
+    ) {
+      current.latestSnapshot = snapshot;
+      current.latestOrder = order;
+    }
+  };
+
+  messages.forEach((message, messageIndex) => {
+    if (message.role === "user") userTurn += 1;
+    const messageHasFailedTool = hasFailedToolOutput(message);
+    const firstTodoPartIndex = message.parts.findIndex(isTodosDataPart);
+    const firstTodoPartKey =
+      firstTodoPartIndex === -1
+        ? undefined
+        : todoPartKey(message, firstTodoPartIndex);
+    message.parts.forEach((part, partIndex) => {
+      if (!isTodosDataPart(part)) return;
+      if (messageHasFailedTool) return;
+      const order = messageIndex * 10_000 + partIndex;
+      updateTurnSnapshot(userTurn, part.data, order, todoPartKey(message, partIndex));
+    });
+    getTodoSnapshots(message).forEach((snapshot, snapshotIndex) => {
+      updateTurnSnapshot(
+        userTurn,
+        snapshot,
+        messageIndex * 10_000 + message.parts.length + snapshotIndex,
+        firstTodoPartKey,
+      );
+    });
+    const current = turnTodos.get(userTurn);
+    if (
+      current &&
+      hasOpenTodos(current.latestSnapshot) &&
+      isSuccessfulCompletionMessage(message)
+    ) {
+      updateTurnSnapshot(
+        userTurn,
+        completedTodoSnapshot(current.latestSnapshot, message),
+        messageIndex * 10_000 + message.parts.length + 1_000,
+      );
+    }
+  });
+
+  for (const item of turnTodos.values()) {
+    displayByFirstPart.set(item.firstPartKey, item.latestSnapshot);
+  }
+
+  return displayByFirstPart;
+}
+
+export function getTraceRows(
+  message: AntonUIMessage,
+  todoDisplay?: TodoTraceDisplay,
+): TraceRow[] {
   const activities = getActivityEvents(message);
   const running = (getRunData(message)?.status ?? message.metadata?.status) === "running";
   const reasoningActivities = activities.filter(
@@ -69,6 +160,10 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
       ? toolEntries.some((entry) => entry.id === toolCallIdForPart(part))
       : false,
   );
+  const latestToolPartIndexes = getLatestToolPartIndexes(message);
+  const latestTodoPartIndexes = todoDisplay
+    ? undefined
+    : getLatestTodoPartIndexes(message);
 
   message.parts.forEach((part, index) => {
     if (isReasoningPart(part)) {
@@ -103,17 +198,24 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
     }
 
     if (isTodosDataPart(part)) {
+      const todoSnapshot = todoDisplay
+        ? todoDisplay.get(todoPartKey(message, index))
+        : latestTodoPartIndexes?.has(index)
+          ? part.data
+          : undefined;
+      if (!todoSnapshot) return;
       rows.push({
         id: part.id ?? `${message.id}:todos:${index}`,
         order: index,
         kind: "todos",
-        snapshot: part.data,
+        snapshot: todoSnapshot,
       });
       return;
     }
 
     const toolCallId = toolCallIdForPart(part);
     if (!toolCallId) return;
+    if (!latestToolPartIndexes.has(index)) return;
     const tool = toolEntries.find((entry) => entry.id === toolCallId);
     if (!tool) return;
     if (tool.name === "update_todos") return;
@@ -138,6 +240,44 @@ export function getTraceRows(message: AntonUIMessage): TraceRow[] {
   }
 
   return rows.sort((a, b) => a.order - b.order);
+}
+
+function getLatestToolPartIndexes(message: AntonUIMessage): Set<number> {
+  const latestByToolCallId = new Map<string, number>();
+  message.parts.forEach((part, index) => {
+    const toolCallId = toolCallIdForPart(part);
+    if (!toolCallId) return;
+    latestByToolCallId.set(toolCallId, index);
+  });
+  return new Set(latestByToolCallId.values());
+}
+
+function getLatestTodoPartIndexes(message: AntonUIMessage): Set<number> {
+  const latestByRunId = new Map<
+    string,
+    { index: number; updatedAt: number }
+  >();
+
+  message.parts.forEach((part, index) => {
+    if (!isTodosDataPart(part)) return;
+    const current = latestByRunId.get(part.data.runId);
+    if (
+      !current ||
+      part.data.updatedAt > current.updatedAt ||
+      (part.data.updatedAt === current.updatedAt && index > current.index)
+    ) {
+      latestByRunId.set(part.data.runId, {
+        index,
+        updatedAt: part.data.updatedAt,
+      });
+    }
+  });
+
+  return new Set(Array.from(latestByRunId.values(), (item) => item.index));
+}
+
+function todoPartKey(message: AntonUIMessage, partIndex: number): string {
+  return `${message.id}:todos:${partIndex}`;
 }
 
 function eventHasTodos(event: AntonActivityEvent): boolean {
@@ -304,9 +444,70 @@ export function getModelTurnSummary(
 export function getSessionTodoSnapshots(
   messages: AntonUIMessage[],
 ): AntonTodoSnapshot[] {
-  return messages
-    .flatMap((message) => getTodoSnapshots(message))
-    .sort((a, b) => a.updatedAt - b.updatedAt);
+  const snapshots: AntonTodoSnapshot[] = [];
+  let latest: AntonTodoSnapshot | undefined;
+
+  for (const message of messages) {
+    for (const snapshot of getTodoSnapshots(message)) {
+      snapshots.push(snapshot);
+      if (
+        !latest ||
+        snapshot.updatedAt > latest.updatedAt ||
+        (snapshot.updatedAt === latest.updatedAt &&
+          snapshots.indexOf(snapshot) > snapshots.indexOf(latest))
+      ) {
+        latest = snapshot;
+      }
+    }
+
+    if (latest && hasOpenTodos(latest) && isSuccessfulCompletionMessage(message)) {
+      latest = completedTodoSnapshot(latest, message);
+      snapshots.push(latest);
+    }
+  }
+
+  return snapshots.sort((a, b) => a.updatedAt - b.updatedAt);
+}
+
+function hasOpenTodos(snapshot: AntonTodoSnapshot): boolean {
+  return snapshot.items.some((item) => item.status !== "completed");
+}
+
+function completedTodoSnapshot(
+  snapshot: AntonTodoSnapshot,
+  message: AntonUIMessage,
+): AntonTodoSnapshot {
+  const run = getRunData(message);
+  const finishedAt = run?.finishedAt ?? message.metadata?.finishedAt;
+  return {
+    runId: run?.runId ?? message.metadata?.runId ?? snapshot.runId,
+    items: snapshot.items.map((item) => ({
+      ...item,
+      status: "completed",
+    })),
+    updatedAt: Math.max(snapshot.updatedAt + 1, finishedAt ?? 0),
+  };
+}
+
+function isSuccessfulCompletionMessage(message: AntonUIMessage): boolean {
+  if (message.role !== "assistant") return false;
+  if (message.metadata?.responseKind === "plan") return false;
+  if (hasPendingToolApproval(message)) return false;
+  if (hasFailedToolOutput(message)) return false;
+  const runStatus = getRunData(message)?.status ?? message.metadata?.status;
+  if (runStatus === "running" || runStatus === "error" || runStatus === "aborted") {
+    return false;
+  }
+
+  const text = getAssistantTextDisplay(message).finalText.toLowerCase();
+  if (!text) return false;
+  const positiveCompletion =
+    /\b(complete|completed|done|passed|passes)\b/.test(text);
+  const negativeCompletion =
+    /\b(failed|fails|error|blocked|unable|cannot|couldn't|could not)\b/.test(
+      text,
+    );
+  return positiveCompletion && !negativeCompletion;
 }
 
 export function toolTitle(entry: ToolTraceEntry, runStatus?: AntonRunStatus): {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -109,6 +109,7 @@ function systemPrompt(
         ]
       : [
           "- For multi-step coding tasks, call `update_todos` with a full checklist snapshot before the first edit and update it as work progresses.",
+          "- If the user says to implement an accepted plan, use the immediately preceding plan response as the source of truth. Do not rediscover files already named in the plan; read only the target files needed to get fresh hashes before editing.",
           "- Before the first coding action in a project, call `inspect_project`, then summarize the relevant stack, scripts, git state, and local instructions in your progress text.",
           "- After editing files, run `verify` before the final answer when the project exposes typecheck, lint, or build scripts. If verification is skipped or fails, say exactly why.",
         ]),

--- a/src/agent/tools/edit-utils.ts
+++ b/src/agent/tools/edit-utils.ts
@@ -26,12 +26,71 @@ export function applySingleFilePatch({
   patch: string;
   relPath: string;
 }): string {
-  const parsed = parseSingleFilePatch(patch, relPath);
-  const next = applyPatch(source, parsed, { fuzzFactor: 0 });
-  if (next === false) {
-    throw new Error("could not apply patch to current file content");
+  try {
+    const parsed = parseSingleFilePatch(patch, relPath);
+    const next = applyPatch(source, parsed, { fuzzFactor: 0 });
+    if (next === false) {
+      throw new Error("could not apply patch to current file content");
+    }
+    return next;
+  } catch (err) {
+    const fallback = applyExactHunkPatch(source, patch);
+    if (fallback !== undefined) return fallback;
+    throw err;
   }
-  return next;
+}
+
+function applyExactHunkPatch(
+  source: string,
+  patch: string,
+): string | undefined {
+  const rawLines = patch.replace(/\r\n/g, "\n").split("\n");
+  const hunkStart = rawLines.findIndex((line) => line.startsWith("@@"));
+  if (hunkStart === -1) return undefined;
+
+  const hunkLines = rawLines
+    .slice(hunkStart + 1)
+    .filter((line) => line.length > 0 && !line.startsWith("\\ No newline"));
+  if (hunkLines.length === 0) return undefined;
+  if (hunkLines.some((line) => !/^[-+ ]/.test(line))) return undefined;
+
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+  let removed = 0;
+  let added = 0;
+  for (const line of hunkLines) {
+    const prefix = line[0];
+    const content = line.slice(1);
+    if (prefix === " ") {
+      oldLines.push(content);
+      newLines.push(content);
+    } else if (prefix === "-") {
+      oldLines.push(content);
+      removed += 1;
+    } else if (prefix === "+") {
+      newLines.push(content);
+      added += 1;
+    }
+  }
+
+  if (removed === 0 && added === 0) return undefined;
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const normalizedSource = source.replace(/\r\n/g, "\n");
+  const oldBlock = oldLines.join("\n");
+  const newBlock = newLines.join("\n");
+  if (!oldBlock) return undefined;
+
+  const first = normalizedSource.indexOf(oldBlock);
+  if (first === -1) return undefined;
+  if (normalizedSource.indexOf(oldBlock, first + oldBlock.length) !== -1) {
+    return undefined;
+  }
+
+  return (
+    normalizedSource.slice(0, first) +
+    newBlock +
+    normalizedSource.slice(first + oldBlock.length)
+  ).replace(/\n/g, newline);
 }
 
 function parseSingleFilePatch(

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,7 +2,12 @@ import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 
-import { hydrateMessagesWithRunState, type AntonUIMessage } from "@/src/lib/trace";
+import {
+  collapseAssistantContinuationMessages,
+  hydrateMessagesWithRunState,
+  hydrateMessagesWithToolCallState,
+  type AntonUIMessage,
+} from "@/src/lib/trace";
 import { db } from "./client";
 import {
   githubInstallations,
@@ -373,6 +378,9 @@ export function loadMessages<UI extends UIMessage>(
       metadata: (row.metadata ?? undefined) as UI["metadata"],
     } as UI;
   });
+  const collapsed = collapseAssistantContinuationMessages(
+    loaded as unknown as AntonUIMessage[],
+  );
 
   const sessionRuns = db
     .select()
@@ -396,10 +404,34 @@ export function loadMessages<UI extends UIMessage>(
           .orderBy(asc(runEvents.runId), asc(runEvents.sequence))
           .all();
 
-  return hydrateMessagesWithRunState(
-    loaded as unknown as AntonUIMessage[],
+  const sessionToolCalls =
+    sessionRuns.length === 0
+      ? []
+      : db
+          .select({
+            toolCallId: toolCalls.toolCallId,
+            status: toolCalls.status,
+            approvalDecision: toolCalls.approvalDecision,
+          })
+          .from(toolCalls)
+          .where(
+            inArray(
+              toolCalls.runId,
+              sessionRuns.map((run) => run.id),
+            ),
+          )
+          .orderBy(asc(toolCalls.startedAt))
+          .all();
+
+  const withRunState = hydrateMessagesWithRunState(
+    collapsed,
     sessionRuns,
     sessionRunEvents,
+  );
+
+  return hydrateMessagesWithToolCallState(
+    withRunState,
+    sessionToolCalls,
   ) as unknown as UI[];
 }
 
@@ -420,21 +452,59 @@ export function getActiveRunForSession(
 export function getMessagePersistenceConflict<UI extends UIMessage>(
   sessionId: string,
   incoming: UI[],
-  options: { mutableTailCount?: number } = {},
+  options: {
+    mutableTailCount?: number;
+    allowExtraAssistantTail?: boolean;
+  } = {},
 ): { storedCount: number; incomingCount: number } | undefined {
-  const stored = storedMessageIds(sessionId);
+  const stored = storedMessagesForConflict(sessionId);
   if (stored.length > incoming.length) {
+    if (
+      incoming.length === 0 ||
+      !options.allowExtraAssistantTail ||
+      stored
+        .slice(incoming.length)
+        .some((message) => message.role !== "assistant")
+    ) {
+      return { storedCount: stored.length, incomingCount: incoming.length };
+    }
+    const stableIncomingCount = Math.max(0, incoming.length - 1);
+    for (const [idx, storedMessage] of stored
+      .slice(0, stableIncomingCount)
+      .entries()) {
+      if (storedMessage.id !== messageId(incoming[idx], sessionId, idx)) {
+        return { storedCount: stored.length, incomingCount: incoming.length };
+      }
+    }
+    const incomingTailId = messageId(
+      incoming[incoming.length - 1],
+      sessionId,
+      incoming.length - 1,
+    );
+    const storedTail = stored[incoming.length - 1];
+    const extraTail = stored.slice(incoming.length);
+    if (
+      storedTail?.id !== incomingTailId &&
+      extraTail.every((message) => message.id !== incomingTailId)
+    ) {
+      return { storedCount: stored.length, incomingCount: incoming.length };
+    }
+    return undefined;
+  }
+
+  const storedIds = stored.map((message) => message.id);
+  if (storedIds.length > incoming.length) {
     return { storedCount: stored.length, incomingCount: incoming.length };
   }
 
   const mutableTailCount = Math.min(
     options.mutableTailCount ?? 0,
-    stored.length,
+    storedIds.length,
     incoming.length,
   );
-  const stableCount = stored.length - mutableTailCount;
+  const stableCount = storedIds.length - mutableTailCount;
 
-  for (const [idx, storedId] of stored.slice(0, stableCount).entries()) {
+  for (const [idx, storedId] of storedIds.slice(0, stableCount).entries()) {
     if (storedId !== messageId(incoming[idx], sessionId, idx)) {
       return { storedCount: stored.length, incomingCount: incoming.length };
     }
@@ -446,6 +516,7 @@ export function getMessagePersistenceConflict<UI extends UIMessage>(
 export function saveMessagesIncrementally<UI extends UIMessage>(
   sessionId: string,
   incoming: UI[],
+  options: { pruneExtraAssistantTail?: boolean } = {},
 ): void {
   db.transaction((tx) => {
     const existing = tx
@@ -455,11 +526,8 @@ export function saveMessagesIncrementally<UI extends UIMessage>(
       .orderBy(asc(messages.createdAt))
       .all();
 
-    if (existing.length > incoming.length) {
-      throw new MessagePersistenceConflictError();
-    }
-
     const now = Date.now();
+    const existingById = new Map(existing.map((row) => [row.id, row]));
     for (const [idx, message] of incoming.entries()) {
       const id = messageId(message, sessionId, idx);
       const row = {
@@ -470,7 +538,9 @@ export function saveMessagesIncrementally<UI extends UIMessage>(
         metadata: (message.metadata ?? null) as unknown,
       };
 
-      const current = existing[idx];
+      const current = existing[idx]?.id === id
+        ? existing[idx]
+        : existingById.get(id);
       if (!current) {
         tx.insert(messages)
           .values({
@@ -479,10 +549,6 @@ export function saveMessagesIncrementally<UI extends UIMessage>(
           })
           .run();
         continue;
-      }
-
-      if (current.id !== id) {
-        throw new MessagePersistenceConflictError();
       }
 
       if (
@@ -501,6 +567,16 @@ export function saveMessagesIncrementally<UI extends UIMessage>(
         })
         .where(eq(messages.id, id))
         .run();
+    }
+
+    if (options.pruneExtraAssistantTail) {
+      const incomingIds = new Set(
+        incoming.map((message, index) => messageId(message, sessionId, index)),
+      );
+      for (const current of existing) {
+        if (incomingIds.has(current.id) || current.role !== "assistant") continue;
+        tx.delete(messages).where(eq(messages.id, current.id)).run();
+      }
     }
 
     tx
@@ -798,14 +874,29 @@ function messageId<UI extends UIMessage>(
   return `${sessionId}:message:${index}`;
 }
 
-function storedMessageIds(sessionId: string): string[] {
-  return db
-    .select({ id: messages.id })
+function storedMessagesForConflict(
+  sessionId: string,
+): { id: string; role: string }[] {
+  const stored = db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      parts: messages.parts,
+      metadata: messages.metadata,
+    })
     .from(messages)
     .where(eq(messages.sessionId, sessionId))
     .orderBy(asc(messages.createdAt))
-    .all()
-    .map((row) => row.id);
+    .all();
+
+  return collapseAssistantContinuationMessages(
+    stored.map((message) => ({
+      id: message.id,
+      role: message.role as AntonUIMessage["role"],
+      parts: message.parts as AntonUIMessage["parts"],
+      metadata: (message.metadata ?? undefined) as AntonUIMessage["metadata"],
+    })),
+  ).map((message) => ({ id: message.id, role: message.role }));
 }
 
 function stableJson(value: unknown): string {

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -154,6 +154,12 @@ export type ToolTraceEntry = {
   activity?: AntonActivityEvent;
 };
 
+export type AntonToolCallStateSnapshot = {
+  toolCallId: string;
+  status: "running" | "completed" | "error" | "denied";
+  approvalDecision?: "pending" | "approved" | "denied" | null;
+};
+
 export type ApprovalMetadata = {
   title: string;
   summary: string;
@@ -273,6 +279,27 @@ export function hasPendingToolApproval(message: AntonUIMessage): boolean {
   return getToolTraceEntries([message]).some(
     (entry) => entry.state === "approval-requested",
   );
+}
+
+export function hasFailedToolOutput(message: AntonUIMessage): boolean {
+  return getToolTraceEntries([message]).some((entry) => {
+    return entry.state === "output-error" || isFailedToolOutput(entry.output);
+  });
+}
+
+export function failedToolOutputMessage(output: unknown): string | undefined {
+  if (!isRecord(output)) return undefined;
+  const error = output.error;
+  if (typeof error === "string" && error.trim().length > 0) return error.trim();
+  const failedReason = output.failedReason;
+  if (typeof failedReason === "string" && failedReason.trim().length > 0) {
+    return failedReason.trim();
+  }
+  return undefined;
+}
+
+function isFailedToolOutput(output: unknown): boolean {
+  return isRecord(output) && output.ok === false;
 }
 
 function stringArray(value: unknown): string[] {
@@ -518,6 +545,13 @@ export function hydrateMessagesWithRunState<UI extends AntonUIMessage>(
   const metricsHydrated = hydrateMessagesWithRunMetrics(messages, runs);
   const runsById = new Map(runs.map((run) => [run.id, run]));
   if (runsById.size === 0) return metricsHydrated;
+  const referencedRunIds = new Set(messages.flatMap(messageRunIds));
+  const orphanRunIds = Array.from(runsById.keys()).filter(
+    (runId) => !referencedRunIds.has(runId),
+  );
+  const orphanTargetMessageId = messages.findLast(
+    (candidate) => candidate.role === "assistant",
+  )?.id;
 
   const eventsByRunId = new Map<string, AntonActivitySnapshot[]>();
   for (const event of events) {
@@ -530,7 +564,10 @@ export function hydrateMessagesWithRunState<UI extends AntonUIMessage>(
   }
 
   return metricsHydrated.map((message) => {
-    const runIds = messageRunIds(message);
+    const runIds = [
+      ...messageRunIds(message),
+      ...(message.id === orphanTargetMessageId ? orphanRunIds : []),
+    ];
     if (runIds.length === 0) return message;
 
     const durableRunParts = runIds
@@ -567,6 +604,112 @@ export function hydrateMessagesWithRunState<UI extends AntonUIMessage>(
   });
 }
 
+export function collapseAssistantContinuationMessages<UI extends AntonUIMessage>(
+  messages: UI[],
+): UI[] {
+  const collapsed: UI[] = [];
+
+  for (const message of messages) {
+    const previous = collapsed.at(-1);
+    if (
+      previous?.role === "assistant" &&
+      message.role === "assistant" &&
+      assistantMessageContainsPrefix(previous, message)
+    ) {
+      collapsed[collapsed.length - 1] = message;
+      continue;
+    }
+    collapsed.push(message);
+  }
+
+  return collapsed.length === messages.length ? messages : collapsed;
+}
+
+export function assistantMessageContainsPrefix(
+  previous: AntonUIMessage,
+  next: AntonUIMessage,
+): boolean {
+  const previousParts = nonDurablePartSignatures(previous);
+  const nextParts = nonDurablePartSignatures(next);
+  if (previousParts.length === 0 || previousParts.length >= nextParts.length) {
+    return false;
+  }
+
+  return previousParts.every((signature, index) => {
+    return signature === nextParts[index];
+  });
+}
+
+export function hydrateMessagesWithToolCallState<UI extends AntonUIMessage>(
+  messages: UI[],
+  toolCallStates: AntonToolCallStateSnapshot[],
+): UI[] {
+  const effectiveStates = effectiveStatesByToolCallId(toolCallStates);
+  if (effectiveStates.size === 0) return messages;
+
+  return messages.map((message) => {
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (!isToolUIPart(part)) return part;
+      const toolCallId =
+        "toolCallId" in part && typeof part.toolCallId === "string"
+          ? part.toolCallId
+          : undefined;
+      if (!toolCallId) return part;
+      const state = effectiveStates.get(toolCallId);
+      if (!state || !("state" in part) || part.state === state) return part;
+      changed = true;
+      return { ...part, state };
+    }) as UI["parts"];
+
+    return changed ? { ...message, parts } : message;
+  });
+}
+
+function effectiveStatesByToolCallId(
+  toolCallStates: AntonToolCallStateSnapshot[],
+): Map<string, ToolState> {
+  const byToolCallId = new Map<
+    string,
+    {
+      completed: boolean;
+      error: boolean;
+      denied: boolean;
+      approved: boolean;
+    }
+  >();
+
+  for (const toolCall of toolCallStates) {
+    const current = byToolCallId.get(toolCall.toolCallId) ?? {
+      completed: false,
+      error: false,
+      denied: false,
+      approved: false,
+    };
+    current.completed ||= toolCall.status === "completed";
+    current.error ||= toolCall.status === "error";
+    current.denied ||=
+      toolCall.status === "denied" || toolCall.approvalDecision === "denied";
+    current.approved ||=
+      toolCall.approvalDecision === "approved" || toolCall.status === "completed";
+    byToolCallId.set(toolCall.toolCallId, current);
+  }
+
+  const effectiveStates = new Map<string, ToolState>();
+  for (const [toolCallId, state] of byToolCallId.entries()) {
+    if (state.completed) {
+      effectiveStates.set(toolCallId, "output-available");
+    } else if (state.error) {
+      effectiveStates.set(toolCallId, "output-error");
+    } else if (state.denied) {
+      effectiveStates.set(toolCallId, "output-denied");
+    } else if (state.approved) {
+      effectiveStates.set(toolCallId, "approval-responded");
+    }
+  }
+  return effectiveStates;
+}
+
 function hydrateMetricRecord<T>(
   value: T,
   runsById: Map<string, AntonRunMetricSnapshot>,
@@ -586,9 +729,38 @@ function hydrateMetricRecord<T>(
     next ??= { ...record };
     next[key] = metric;
   }
+  for (const key of ["durationMs", "stepCount"] as const) {
+    const metric = run[key];
+    if (typeof metric !== "number" || !Number.isFinite(metric)) continue;
+    if (record[key] === metric) continue;
+    next ??= { ...record };
+    next[key] = metric;
+  }
+  if (typeof run.model === "string" && record.model !== run.model) {
+    next ??= { ...record };
+    next.model = run.model;
+  }
+  if (run.status && record.status !== run.status) {
+    next ??= { ...record };
+    next.status = run.status;
+  }
+  const startedAt = toMillis(run.startedAt);
+  if (startedAt !== undefined && record.startedAt !== startedAt) {
+    next ??= { ...record };
+    next.startedAt = startedAt;
+  }
+  const finishedAt = toMillis(run.finishedAt);
+  if (finishedAt !== undefined && record.finishedAt !== finishedAt) {
+    next ??= { ...record };
+    next.finishedAt = finishedAt;
+  }
   if (typeof run.finishReason === "string" && record.finishReason !== run.finishReason) {
     next ??= { ...record };
     next.finishReason = run.finishReason;
+  }
+  if (run.finishReason === "max_step_limit" && record.maxStepLimitReached !== true) {
+    next ??= { ...record };
+    next.maxStepLimitReached = true;
   }
 
   return (next ?? value) as T;
@@ -602,6 +774,41 @@ function messageRunIds(message: AntonUIMessage): string[] {
     if (isRunDataPart(part)) ids.add(part.data.runId);
   }
   return Array.from(ids);
+}
+
+function nonDurablePartSignatures(message: AntonUIMessage): string[] {
+  return message.parts
+    .filter((part) => !isRunDataPart(part) && !isActivityDataPart(part))
+    .map(stablePartSignature);
+}
+
+function stablePartSignature(part: AntonUIMessage["parts"][number]): string {
+  const record = part as Record<string, unknown>;
+  const signature: Record<string, unknown> = { type: part.type };
+
+  if (part.type === "text" || part.type === "reasoning") {
+    signature.text = part.text;
+  }
+  if ("toolCallId" in part && typeof part.toolCallId === "string") {
+    signature.toolCallId = part.toolCallId;
+  } else if ("state" in part && typeof part.state === "string") {
+    signature.state = part.state;
+  }
+  if (isTodosDataPart(part)) {
+    signature.id = part.id;
+    signature.runId = part.data.runId;
+    signature.updatedAt = part.data.updatedAt;
+    signature.items = part.data.items.map((item) => [
+      item.id,
+      item.text,
+      item.status,
+    ]);
+  }
+  if (part.type !== "text" && part.type !== "reasoning" && !isTodosDataPart(part)) {
+    signature.id = typeof record.id === "string" ? record.id : undefined;
+  }
+
+  return JSON.stringify(signature);
 }
 
 function runDataFromSnapshot(run: AntonRunMetricSnapshot): AntonRunData {
@@ -723,7 +930,7 @@ export function getActivityEvents(
 export function getToolTraceEntries(
   messages: AntonUIMessage[],
 ): ToolTraceEntry[] {
-  const entries: ToolTraceEntry[] = [];
+  const entriesById = new Map<string, ToolTraceEntry>();
   for (const message of messages) {
     const activityByToolCallId = new Map<string, AntonActivityEvent>();
     for (const activity of getActivityEvents(message)) {
@@ -739,8 +946,9 @@ export function getToolTraceEntries(
         "toolCallId" in part && typeof part.toolCallId === "string"
           ? part.toolCallId
           : undefined;
-      entries.push({
-        id: toolCallId ?? `${message.id}:${index}`,
+      const id = toolCallId ?? `${message.id}:${index}`;
+      const entry = {
+        id,
         sourceMessageId: message.id,
         name: String(getToolName(part)),
         state,
@@ -756,10 +964,12 @@ export function getToolTraceEntries(
         activity: toolCallId
           ? activityByToolCallId.get(toolCallId)
           : undefined,
-      });
+      };
+      if (entriesById.has(id)) entriesById.delete(id);
+      entriesById.set(id, entry);
     });
   }
-  return entries;
+  return Array.from(entriesById.values());
 }
 
 export function getReasoningTexts(message: AntonUIMessage): string[] {
@@ -795,10 +1005,75 @@ export function isTodosDataPart(
 
 export function getTodoSnapshots(message: AntonUIMessage): AntonTodoSnapshot[] {
   const snapshots: AntonTodoSnapshot[] = [];
-  for (const part of message.parts) {
-    if (isTodosDataPart(part)) snapshots.push(part.data);
+  const firstFailedToolIndex = message.parts.findIndex(isFailedToolPart);
+  const firstFailedToolSequence = firstFailedToolActivitySequence(message);
+  for (const [index, part] of message.parts.entries()) {
+    if (isTodosDataPart(part)) {
+      if (firstFailedToolSequence !== undefined) continue;
+      if (firstFailedToolIndex !== -1 && index > firstFailedToolIndex) continue;
+      snapshots.push(part.data);
+    }
+    if (isActivityDataPart(part)) {
+      if (
+        firstFailedToolSequence !== undefined &&
+        part.data.sequence > firstFailedToolSequence
+      ) {
+        continue;
+      }
+      const todos = todoSnapshotFromUnknown(part.data.details?.todos);
+      if (todos) snapshots.push(todos);
+    }
   }
   return snapshots.sort((a, b) => a.updatedAt - b.updatedAt);
+}
+
+function isFailedToolPart(part: AntonUIMessage["parts"][number]): boolean {
+  if (!isToolUIPart(part)) return false;
+  return (
+    ("state" in part && part.state === "output-error") ||
+    ("output" in part && isFailedToolOutput(part.output))
+  );
+}
+
+function firstFailedToolActivitySequence(
+  message: AntonUIMessage,
+): number | undefined {
+  return getActivityEvents(message)
+    .filter((event) => event.kind === "tool" && event.status === "error")
+    .sort((a, b) => a.sequence - b.sequence)
+    .at(0)?.sequence;
+}
+
+function todoSnapshotFromUnknown(value: unknown): AntonTodoSnapshot | undefined {
+  if (!isRecord(value)) return undefined;
+  const runId = value.runId;
+  const updatedAt = value.updatedAt;
+  const items = value.items;
+  if (
+    typeof runId !== "string" ||
+    typeof updatedAt !== "number" ||
+    !Array.isArray(items)
+  ) {
+    return undefined;
+  }
+  const parsedItems = items.flatMap((item): AntonTodoItem[] => {
+    if (!isRecord(item)) return [];
+    const id = item.id;
+    const text = item.text;
+    const status = item.status;
+    if (
+      typeof id !== "string" ||
+      typeof text !== "string" ||
+      (status !== "pending" &&
+        status !== "in_progress" &&
+        status !== "completed")
+    ) {
+      return [];
+    }
+    return [{ id, text, status }];
+  });
+  if (parsedItems.length === 0) return undefined;
+  return { runId, updatedAt, items: parsedItems };
 }
 
 export function getLatestTodoSnapshot(


### PR DESCRIPTION
## Summary
- collapse duplicate assistant continuation traces on persistence and load
- keep accepted plan cards stable while implementation starts
- make todo cards use the latest durable snapshot and handle failed tool output correctly
- mark failed tool runs as errors instead of rendering success
- improve exact one-line edit patch fallback handling

Fixes #70

## Verification
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`
- [x] `pnpm build`

## Notes
- `pnpm build` passed, with an existing Turbopack NFT trace warning through `next.config.ts -> src/workspace/local.ts -> app/api/projects/route.ts`.
- Visual verification was performed during the debugging sessions captured in the linked issue scope; no additional browser pass was run after committing.
