### PR TITLE
Add context budgeting for agent runs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Tailwind CSS v4 dark UI using shadcn-style primitives.
 - [✔️] OpenRouter provider integration through Vercel AI SDK v6.
 - [✔️] Streaming chat endpoint at `/api/chat` using `streamText`.
-- [✔️] Multi-step tool loop bounded by `stepCountIs(20)`.
+- [✔️] Multi-step tool loop bounded by profile-aware step budgets.
 - [✔️] SQLite persistence through `better-sqlite3` and Drizzle ORM.
 - [✔️] Session persistence with title, selected model, token total, and messages.
 - [✔️] Basic markdown rendering for assistant messages.
@@ -49,6 +49,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Updated Worklog and inline traces to share normalized trace helpers for consistent tool, approval, and timing UI.
 - [✔️] Added durable tool-call and approval audit rows tied to chat runs.
 - [✔️] Added provider, step-count, and cost metadata tracking for runs.
+- [✔️] Added profile-aware context budgeting, transcript pruning, and step/token run budgets.
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -97,9 +98,11 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add automatic verification policy after edits: detect package manager, run typecheck, lint, and build when appropriate.
 - [✔️] Add stack/repo inspection summary before the first coding action in a project.
 - [✔️] Add token-audit metadata, run profiles, filtered tool definitions, MCP gating, and accepted-plan context compaction.
-- [] Add context budgeting with repo map, recent diff summary, selected file summaries, and transcript pruning.
+- [✔️] Add profile-aware context budgeting and transcript pruning.
+- [] Add repo map, recent diff summary, and selected file summaries for richer context selection.
 - [✔️] Add model selection validation on the server; reject unsupported or disabled model IDs.
-- [] Add enforceable per-run token, cost, and step budgets.
+- [✔️] Add enforceable per-run token and step budgets.
+- [] Add enforceable dollar-cost budgets after reliable model pricing metadata is available.
 - [] Add resumable runs after tool approval, refresh, or network interruption.
 - [✔️] Add better system prompts for coding workflow: inspect, plan, edit, verify, summarize.
 - [✔️] Add final response structure that reports changed files, verification, and unresolved risks.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -21,10 +21,15 @@ import {
   type TokenAudit,
 } from "@/src/agent/loop";
 import {
+  budgetMessagesForModel,
+  type ContextBudgetReport,
+} from "@/src/agent/context-budget";
+import {
   buildSessionContextDigest,
   RunContextCollector,
   type RunContextStatus,
 } from "@/src/agent/context";
+import { budgetForProfile } from "@/src/agent/run-budget";
 import {
   buildToolApprovalMetadata,
   getNativeToolPermissionMetadata,
@@ -184,6 +189,39 @@ export async function POST(req: Request) {
     }
   }
 
+  const budget = budgetForProfile(profile);
+  const preservation = modelContextPreservation(uiMessages, profile);
+  const preparedMessages = prepareMessagesForModel(
+    uiMessages,
+    profile,
+    preservation,
+  );
+  const sessionContextDigest = mode === "chat"
+    ? undefined
+    : buildSessionContextDigest({
+        sessionId,
+        latestUserText: latestUserText(uiMessages),
+        budgetChars: budget.priorRunContextChars,
+      });
+  const contextDigestBytes = byteLength(
+    priorRunContextMessageText(sessionContextDigest) ?? "",
+  );
+  const contextBudget = budgetMessagesForModel({
+    messages: preparedMessages,
+    budget,
+    ...preservation,
+    contextDigestBytes,
+  });
+  if (!contextBudget.ok) {
+    return Response.json(
+      {
+        error: contextBudget.error,
+        contextBudget: contextBudget.report,
+      },
+      { status: contextBudget.status },
+    );
+  }
+
   const runId = randomUUID();
   const startedAt = Date.now();
   createRun({
@@ -196,15 +234,8 @@ export async function POST(req: Request) {
     stepCount: 0,
   });
 
-  const preparedMessages = prepareMessagesForModel(uiMessages, profile);
-  const sessionContextDigest = mode === "chat"
-    ? undefined
-    : buildSessionContextDigest({
-        sessionId,
-        latestUserText: latestUserText(uiMessages),
-      });
   const modelMessages = addPriorRunContextMessage(
-    await convertMessagesForRun(preparedMessages, runId, startedAt),
+    await convertMessagesForRun(contextBudget.messages, runId, startedAt),
     sessionContextDigest,
   );
   const contextCollector = new RunContextCollector(runId, sessionId);
@@ -223,6 +254,7 @@ export async function POST(req: Request) {
         responseKind: mode === "plan" ? "plan" : undefined,
       });
       trace.writeRun("running");
+      trace.noteContextBudget(contextBudget.report);
 
       try {
         const result = await runAgent({
@@ -232,6 +264,7 @@ export async function POST(req: Request) {
           mode,
           profile,
           requestBodyBytes,
+          contextBudget: contextBudget.report,
           thinkingEnabled: parsed.data.thinkingEnabled ?? false,
           permissionMode: parsed.data.permissionMode as
             | PermissionMode
@@ -262,18 +295,23 @@ export async function POST(req: Request) {
             providerMetadata,
             stepProviderMetadata,
             maxSteps,
+            maxTotalTokens,
             maxStepLimitReached,
+            tokenBudgetReached,
             tokenAudit,
           }) => {
-            contextTerminalStatus = maxStepLimitReached ? "error" : "completed";
+            const budgetLimitReached = maxStepLimitReached || tokenBudgetReached;
+            contextTerminalStatus = budgetLimitReached ? "error" : "completed";
             trace.finalize(
-              maxStepLimitReached ? "error" : "completed",
+              budgetLimitReached ? "error" : "completed",
               totalUsage,
               providerMetadata,
               finishReason,
               {
                 maxSteps,
+                maxTotalTokens,
                 maxStepLimitReached,
+                tokenBudgetReached,
                 tokenAudit,
                 stepProviderMetadata,
               },
@@ -352,28 +390,39 @@ function finalAssistantText(messages: AntonUIMessage[]): string | undefined {
 function prepareMessagesForModel(
   messages: AntonUIMessage[],
   profile: AgentRunProfile,
+  preservation = modelContextPreservation(messages, profile),
 ): AntonUIMessage[] {
-  const approvalContinuationMessageId = isToolApprovalContinuation(messages)
-    ? messages.at(-1)?.id
-    : undefined;
-  const acceptedPlanMessageId = isAcceptedPlanProfile(profile)
-    ? messages.findLast(isPlanAssistantMessage)?.id
-    : undefined;
-
   return messages.flatMap((message) => {
     const source =
-      message.id === acceptedPlanMessageId
+      message.id === preservation.acceptedPlanMessageId
         ? compactAcceptedPlanMessage(message, profile)
         : message;
     const parts = compactMessagePartsForModel(
       source,
-      source.id === approvalContinuationMessageId,
+      source.id === preservation.approvalContinuationMessageId,
     )
       .filter(isModelContextPart)
       .map(stripProviderReplayMetadata);
     if (!parts.some(isSubstantiveModelContextPart)) return [];
     return [{ ...source, parts }];
   });
+}
+
+function modelContextPreservation(
+  messages: AntonUIMessage[],
+  profile: AgentRunProfile,
+): {
+  approvalContinuationMessageId?: string;
+  acceptedPlanMessageId?: string;
+} {
+  return {
+    ...(isToolApprovalContinuation(messages)
+      ? { approvalContinuationMessageId: messages.at(-1)?.id }
+      : {}),
+    ...(isAcceptedPlanProfile(profile)
+      ? { acceptedPlanMessageId: messages.findLast(isPlanAssistantMessage)?.id }
+      : {}),
+  };
 }
 
 function compactMessagePartsForModel(
@@ -807,7 +856,9 @@ function createTraceWriter({
     finishReason?: FinishReason,
     limits: {
       maxSteps?: number;
+      maxTotalTokens?: number;
       maxStepLimitReached?: boolean;
+      tokenBudgetReached?: boolean;
       tokenAudit?: TokenAudit;
       stepProviderMetadata?: ProviderMetadata[];
     } = {},
@@ -839,6 +890,8 @@ function createTraceWriter({
     );
     const storedFinishReason = limits.maxStepLimitReached
       ? "max_step_limit"
+      : limits.tokenBudgetReached
+        ? "token_budget_limit"
       : effectiveStatus === "error" && failedToolCount > 0
         ? "tool_error"
       : finishReason;
@@ -869,6 +922,20 @@ function createTraceWriter({
         },
       });
     }
+    if (limits.tokenBudgetReached) {
+      startEvent({
+        id: `${runId}:token-budget:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Token budget reached",
+        summary: `Stopped after reaching the per-run token budget of ${limits.maxTotalTokens ?? "unknown"} tokens.`,
+        details: {
+          finishReason,
+          stepCount,
+          maxTotalTokens: limits.maxTotalTokens,
+        },
+      });
+    }
     updateRun(runId, {
       status: effectiveStatus,
       finishedAt: new Date(finishedAt),
@@ -885,6 +952,17 @@ function createTraceWriter({
 
   return {
     writeRun,
+    noteContextBudget(report: ContextBudgetReport) {
+      if (report.droppedMessages <= 0) return;
+      startEvent({
+        id: `${runId}:context-budget:${sequence + 1}`,
+        kind: "progress",
+        status: "completed",
+        label: "Context budget applied",
+        summary: `Kept ${report.preservedMessages} message${report.preservedMessages === 1 ? "" : "s"} and dropped ${report.droppedMessages} older message${report.droppedMessages === 1 ? "" : "s"} before the model call.`,
+        details: { contextBudget: report },
+      });
+    },
     startStep(stepNumber: number) {
       stepCount = Math.max(stepCount, stepNumber + 1);
       startEvent({

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -640,7 +640,6 @@ function createTraceWriter({
   let sequence = 0;
   let stepCount = 0;
   let finalized = false;
-  let failedToolCount = 0;
   const events = new Map<string, AntonActivityEvent>();
 
   const metadata = (
@@ -865,9 +864,7 @@ function createTraceWriter({
   ) => {
     if (finalized) return;
     finalized = true;
-    const effectiveStatus =
-      status === "completed" && failedToolCount > 0 ? "error" : status;
-    settleRunningEvents(effectiveStatus === "completed" ? "completed" : "error");
+    settleRunningEvents(status === "completed" ? "completed" : "error");
     const finishedAt = Date.now();
     const durationMs = Math.max(0, finishedAt - startedAt);
     const inputTokens = usage?.inputTokens;
@@ -892,10 +889,8 @@ function createTraceWriter({
       ? "max_step_limit"
       : limits.tokenBudgetReached
         ? "token_budget_limit"
-      : effectiveStatus === "error" && failedToolCount > 0
-        ? "tool_error"
       : finishReason;
-    writeRun(effectiveStatus, {
+    writeRun(status, {
       finishedAt,
       durationMs,
       inputTokens,
@@ -937,7 +932,7 @@ function createTraceWriter({
       });
     }
     updateRun(runId, {
-      status: effectiveStatus,
+      status,
       finishedAt: new Date(finishedAt),
       durationMs,
       inputTokens: inputTokens ?? null,
@@ -1072,7 +1067,6 @@ function createTraceWriter({
       const current = events.get(`${runId}:tool:${event.toolCallId}`);
       const error = toolError(event.success, event.output, event.error);
       const status = error ? "error" : "completed";
-      if (error) failedToolCount += 1;
       finishEvent(`${runId}:tool:${event.toolCallId}`, {
         status,
         label: toolLabel(event.toolName, event.input),
@@ -1309,18 +1303,7 @@ function runProfileForMessages(
   ) {
     return "accepted-plan-general";
   }
-  if (isCommandRunRequest(latestText)) return "command-run";
   return "general-chat";
-}
-
-function isCommandRunRequest(text: string): boolean {
-  if (/\b(fix|change|update|modify|implement|edit|write|delete|rename)\b/.test(text)) {
-    return false;
-  }
-  return (
-    /\b(run|execute|check|verify)\b/.test(text) &&
-    /\b(build|typecheck|type-check|lint|test|pnpm|npm|yarn|bun|next build|tsc|eslint)\b/.test(text)
-  );
 }
 
 function isAcceptedPlanProfile(profile: AgentRunProfile): boolean {

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -175,6 +175,7 @@ function MessageEvent({
   const showToolFailure =
     !isUser &&
     failedToolText.length > 0 &&
+    assistantText.length === 0 &&
     !pendingApproval &&
     assistantFinal &&
     responseKind !== "plan";

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -14,7 +14,6 @@ import {
   getAssistantTextDisplay,
   getMessageRunDurationMs,
   getRunData,
-  hasFailedToolOutput,
   hasPendingToolApproval,
   type AntonUIMessage,
   type AntonRunStatus,
@@ -63,11 +62,9 @@ export function RunTraceAccordion({
   const run = getRunData(message);
   const metadata = message.metadata;
   const transportRunning = status === "submitted" || status === "streaming";
-  const hasToolFailure = hasFailedToolOutput(message);
   const runStatus = effectiveRunStatus(
     run?.status ?? metadata?.status,
     transportRunning,
-    hasToolFailure,
   );
   const isRunning = runStatus === "running";
 
@@ -162,10 +159,8 @@ export function RunTraceAccordion({
 function effectiveRunStatus(
   status: AntonRunStatus | undefined,
   transportRunning: boolean,
-  hasToolFailure: boolean,
 ): AntonRunStatus {
   if (status === "running" && !transportRunning) return "aborted";
-  if (hasToolFailure) return "error";
   return status ?? "completed";
 }
 

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -163,7 +163,15 @@ export function getTraceRows(
   const latestToolPartIndexes = getLatestToolPartIndexes(message);
   const latestTodoPartIndexes = todoDisplay
     ? undefined
-    : getLatestTodoPartIndexes(message);
+      : getLatestTodoPartIndexes(message);
+  const hasFinalTextAfterLastTool =
+    lastToolIndex !== -1 &&
+    message.parts.some(
+      (part, index) =>
+        index > lastToolIndex &&
+        part.type === "text" &&
+        part.text.trim().length > 0,
+    );
 
   message.parts.forEach((part, index) => {
     if (isReasoningPart(part)) {
@@ -184,7 +192,7 @@ export function getTraceRows(
     if (
       part.type === "text" &&
       !isPlanResponse &&
-      (running || index < lastToolIndex)
+      (running || (hasFinalTextAfterLastTool && index < lastToolIndex))
     ) {
       const text = part.text.trim();
       if (!text) return;

--- a/src/agent/context-budget.ts
+++ b/src/agent/context-budget.ts
@@ -1,0 +1,185 @@
+import type { AntonUIMessage } from "@/src/lib/trace";
+
+import type { ContextBudgetAudit } from "./loop";
+import type { RunBudget } from "./run-budget";
+
+export type ContextBudgetReport = ContextBudgetAudit & {
+  ok: boolean;
+  reason?: "latest_user_too_large" | "required_context_too_large";
+};
+
+export type ContextBudgetResult =
+  | {
+      ok: true;
+      messages: AntonUIMessage[];
+      report: ContextBudgetReport;
+    }
+  | {
+      ok: false;
+      status: 413;
+      error: string;
+      report: ContextBudgetReport;
+    };
+
+export function budgetMessagesForModel({
+  messages,
+  budget,
+  approvalContinuationMessageId,
+  acceptedPlanMessageId,
+  contextDigestBytes = 0,
+}: {
+  messages: AntonUIMessage[];
+  budget: RunBudget;
+  approvalContinuationMessageId?: string;
+  acceptedPlanMessageId?: string;
+  contextDigestBytes?: number;
+}): ContextBudgetResult {
+  const beforeBytes = utf8Bytes(stableJson(messages));
+  const latestUserIndex = messages.findLastIndex((message) => message.role === "user");
+  const latestUserBytes =
+    latestUserIndex === -1 ? 0 : messageBytes(messages[latestUserIndex]);
+  const requiredIndexes = requiredMessageIndexes({
+    messages,
+    latestUserIndex,
+    approvalContinuationMessageId,
+    acceptedPlanMessageId,
+  });
+  const requiredMessages = requiredIndexes.size;
+  const baseReport = {
+    beforeBytes,
+    afterBytes: beforeBytes,
+    maxInputBytes: budget.maxInputBytes,
+    latestUserBytes,
+    preservedMessages: messages.length,
+    droppedMessages: 0,
+    prunedMessages: 0,
+    requiredMessages,
+    contextDigestBytes,
+  };
+
+  if (latestUserBytes > budget.latestUserMaxBytes) {
+    return {
+      ok: false,
+      status: 413,
+      error:
+        "Latest user message is too large for this run profile. Shorten the request or attach less context.",
+      report: {
+        ...baseReport,
+        ok: false,
+        reason: "latest_user_too_large",
+      },
+    };
+  }
+
+  const required = messages.filter((_, index) => requiredIndexes.has(index));
+  const requiredBytes = utf8Bytes(stableJson(required));
+  if (requiredBytes + contextDigestBytes > budget.maxInputBytes) {
+    return {
+      ok: false,
+      status: 413,
+      error:
+        "Required conversation state is too large for this run profile. Start a new session or reduce the accepted plan/current request.",
+      report: {
+        ...baseReport,
+        afterBytes: requiredBytes,
+        preservedMessages: required.length,
+        droppedMessages: messages.length - required.length,
+        prunedMessages: messages.length - required.length,
+        ok: false,
+        reason: "required_context_too_large",
+      },
+    };
+  }
+
+  const selectedIndexes = new Set(requiredIndexes);
+  let selectedBytes = requiredBytes;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (selectedIndexes.has(index)) continue;
+    const nextBytes = messageBytes(messages[index]);
+    if (selectedBytes + nextBytes + contextDigestBytes > budget.maxInputBytes) {
+      break;
+    }
+    selectedIndexes.add(index);
+    selectedBytes += nextBytes;
+  }
+
+  let selected = selectedMessages(messages, selectedIndexes);
+  let afterBytes = utf8Bytes(stableJson(selected));
+  while (afterBytes + contextDigestBytes > budget.maxInputBytes) {
+    const dropIndex = firstRemovableIndex(selectedIndexes, requiredIndexes);
+    if (dropIndex === undefined) break;
+    selectedIndexes.delete(dropIndex);
+    selected = selectedMessages(messages, selectedIndexes);
+    afterBytes = utf8Bytes(stableJson(selected));
+  }
+
+  const droppedMessages = messages.length - selected.length;
+  return {
+    ok: true,
+    messages: selected,
+    report: {
+      beforeBytes,
+      afterBytes,
+      maxInputBytes: budget.maxInputBytes,
+      latestUserBytes,
+      preservedMessages: selected.length,
+      droppedMessages,
+      prunedMessages: droppedMessages,
+      requiredMessages,
+      contextDigestBytes,
+      ok: true,
+    },
+  };
+}
+
+function selectedMessages(
+  messages: AntonUIMessage[],
+  selectedIndexes: Set<number>,
+): AntonUIMessage[] {
+  return messages.filter((_, index) => selectedIndexes.has(index));
+}
+
+function firstRemovableIndex(
+  selectedIndexes: Set<number>,
+  requiredIndexes: Set<number>,
+): number | undefined {
+  return Array.from(selectedIndexes)
+    .sort((left, right) => left - right)
+    .find((index) => !requiredIndexes.has(index));
+}
+
+function requiredMessageIndexes({
+  messages,
+  latestUserIndex,
+  approvalContinuationMessageId,
+  acceptedPlanMessageId,
+}: {
+  messages: AntonUIMessage[];
+  latestUserIndex: number;
+  approvalContinuationMessageId?: string;
+  acceptedPlanMessageId?: string;
+}): Set<number> {
+  const indexes = new Set<number>();
+  if (latestUserIndex >= 0) indexes.add(latestUserIndex);
+  for (const [index, message] of messages.entries()) {
+    if (
+      message.id === approvalContinuationMessageId ||
+      message.id === acceptedPlanMessageId
+    ) {
+      indexes.add(index);
+    }
+  }
+  return indexes;
+}
+
+function messageBytes(message: AntonUIMessage): number {
+  return utf8Bytes(stableJson(message));
+}
+
+function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -15,6 +15,11 @@ import {
 } from "@/src/lib/providers";
 import { buildTokenUsageMetrics } from "@/src/lib/token-usage";
 import { listMemories } from "@/src/db/queries";
+import {
+  budgetForProfile,
+  tokenBudgetStopCondition,
+  type RunBudget,
+} from "./run-budget";
 import { listSkills } from "./skills";
 import {
   createAntonTools,
@@ -30,9 +35,6 @@ import {
 } from "./sandbox";
 import type { PermissionMode } from "./permissions";
 
-const MAX_STEPS = 20;
-const CHAT_MAX_OUTPUT_TOKENS = 8_192;
-const PLAN_MAX_OUTPUT_TOKENS = 4_096;
 export type AgentRunMode = "chat" | "ask" | "plan" | "agent";
 export type AgentRunProfile =
   | "pure-chat"
@@ -56,9 +58,33 @@ export type TokenAudit = {
     totalCount: number;
     activeCount: number;
   };
+  budget: RunBudgetAudit;
   usage?: UsageAudit;
   steps: StepUsageAudit[];
 };
+
+export type ContextBudgetAudit = {
+  beforeBytes: number;
+  afterBytes: number;
+  maxInputBytes: number;
+  latestUserBytes: number;
+  preservedMessages: number;
+  droppedMessages: number;
+  prunedMessages: number;
+  requiredMessages: number;
+  contextDigestBytes: number;
+};
+
+type RunBudgetAudit = Pick<
+  RunBudget,
+  | "profile"
+  | "maxSteps"
+  | "maxOutputTokens"
+  | "maxInputTokens"
+  | "maxInputBytes"
+  | "maxTotalTokens"
+  | "priorRunContextChars"
+>;
 
 type UsageAudit = {
   inputTokens?: number;
@@ -323,6 +349,7 @@ export async function runAgent({
   enabledMcpServerIds,
   thinkingEnabled = false,
   requestBodyBytes,
+  contextBudget,
   onStepStart,
   onStepFinish,
   onToolCallStart,
@@ -341,6 +368,7 @@ export async function runAgent({
   enabledMcpServerIds?: string[];
   thinkingEnabled?: boolean;
   requestBodyBytes?: number;
+  contextBudget?: ContextBudgetAudit;
   onStepStart?: (event: { stepNumber: number }) => void;
   onStepFinish?: (event: { stepNumber: number }) => void;
   onToolCallStart?: (event: {
@@ -369,10 +397,13 @@ export async function runAgent({
     stepProviderMetadata: ProviderMetadata[];
     stepCount: number;
     maxSteps: number;
+    maxTotalTokens: number;
     maxStepLimitReached: boolean;
+    tokenBudgetReached: boolean;
     tokenAudit: TokenAudit;
   }) => void;
 }) {
+  const budget = budgetForProfile(profile);
   const nativeToolNames = PROFILE_NATIVE_TOOLS[profile];
   const allowMcpTools = profileAllowsMcp(profile);
   const mcpTools = allowMcpTools
@@ -423,17 +454,29 @@ export async function runAgent({
       totalCount: Object.keys(tools).length,
       activeCount: activeTools.length,
     },
+    budget: {
+      profile: budget.profile,
+      maxSteps: budget.maxSteps,
+      maxOutputTokens: budget.maxOutputTokens,
+      maxInputTokens: budget.maxInputTokens,
+      maxInputBytes: budget.maxInputBytes,
+      maxTotalTokens: budget.maxTotalTokens,
+      priorRunContextChars: budget.priorRunContextChars,
+    },
+    ...(contextBudget ? { contextBudget } : {}),
   };
 
   return streamText({
     model: openrouter(toOpenRouterModelId(selectedModel)),
     system,
     messages,
-    maxOutputTokens:
-      mode === "plan" ? PLAN_MAX_OUTPUT_TOKENS : CHAT_MAX_OUTPUT_TOKENS,
+    maxOutputTokens: budget.maxOutputTokens,
     tools,
     activeTools,
-    stopWhen: stepCountIs(MAX_STEPS),
+    stopWhen: [
+      stepCountIs(budget.maxSteps),
+      tokenBudgetStopCondition(budget.maxTotalTokens),
+    ],
     providerOptions: {
       openrouter: openRouterProviderOptions(profile, thinkingEnabled),
     },
@@ -519,9 +562,13 @@ export async function runAgent({
         providerMetadata,
         stepProviderMetadata,
         stepCount: observedStepCount,
-        maxSteps: MAX_STEPS,
+        maxSteps: budget.maxSteps,
+        maxTotalTokens: budget.maxTotalTokens,
         maxStepLimitReached:
-          observedStepCount >= MAX_STEPS && finishReason === "tool-calls",
+          observedStepCount >= budget.maxSteps && finishReason === "tool-calls",
+        tokenBudgetReached:
+          finiteNumber(totalUsage.totalTokens) !== undefined &&
+          (totalUsage.totalTokens ?? 0) >= budget.maxTotalTokens,
         tokenAudit,
       });
       await closeMcpTools();

--- a/src/agent/run-budget.ts
+++ b/src/agent/run-budget.ts
@@ -1,0 +1,115 @@
+import type { StopCondition, ToolSet } from "ai";
+
+import type { AgentRunProfile } from "./loop";
+
+export type RunBudget = {
+  profile: AgentRunProfile;
+  maxSteps: number;
+  maxOutputTokens: number;
+  maxInputTokens: number;
+  maxInputBytes: number;
+  maxTotalTokens: number;
+  priorRunContextChars: number;
+  latestUserMaxBytes: number;
+};
+
+const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+const RUN_BUDGETS = {
+  "pure-chat": {
+    maxSteps: 1,
+    maxOutputTokens: 4_096,
+    maxInputTokens: 24_000,
+    maxTotalTokens: 32_000,
+    priorRunContextChars: 0,
+  },
+  ask: {
+    maxSteps: 6,
+    maxOutputTokens: 4_096,
+    maxInputTokens: 32_000,
+    maxTotalTokens: 48_000,
+    priorRunContextChars: 4_000,
+  },
+  plan: {
+    maxSteps: 8,
+    maxOutputTokens: 4_096,
+    maxInputTokens: 48_000,
+    maxTotalTokens: 64_000,
+    priorRunContextChars: 5_000,
+  },
+  "accepted-plan-simple": {
+    maxSteps: 8,
+    maxOutputTokens: 4_096,
+    maxInputTokens: 32_000,
+    maxTotalTokens: 48_000,
+    priorRunContextChars: 3_000,
+  },
+  "accepted-plan-general": {
+    maxSteps: 16,
+    maxOutputTokens: 8_192,
+    maxInputTokens: 64_000,
+    maxTotalTokens: 96_000,
+    priorRunContextChars: 6_000,
+  },
+  "command-run": {
+    maxSteps: 6,
+    maxOutputTokens: 4_096,
+    maxInputTokens: 24_000,
+    maxTotalTokens: 40_000,
+    priorRunContextChars: 2_500,
+  },
+  "general-chat": {
+    maxSteps: 20,
+    maxOutputTokens: 8_192,
+    maxInputTokens: 64_000,
+    maxTotalTokens: 96_000,
+    priorRunContextChars: 6_000,
+  },
+  "approval-continuation": {
+    maxSteps: 20,
+    maxOutputTokens: 8_192,
+    maxInputTokens: 64_000,
+    maxTotalTokens: 96_000,
+    priorRunContextChars: 4_000,
+  },
+} as const satisfies Record<
+  AgentRunProfile,
+  Omit<RunBudget, "profile" | "maxInputBytes" | "latestUserMaxBytes">
+>;
+
+export function budgetForProfile(profile: AgentRunProfile): RunBudget {
+  const budget = RUN_BUDGETS[profile];
+  const maxInputBytes = budget.maxInputTokens * BYTES_PER_TOKEN_ESTIMATE;
+  return {
+    profile,
+    ...budget,
+    maxInputBytes,
+    latestUserMaxBytes: Math.floor(maxInputBytes * 0.8),
+  };
+}
+
+export function tokenBudgetStopCondition(
+  maxTotalTokens: number,
+): StopCondition<ToolSet> {
+  return ({ steps }) => {
+    return totalStepTokens(steps) >= maxTotalTokens;
+  };
+}
+
+function totalStepTokens(
+  steps: readonly { usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number } }[],
+): number {
+  return steps.reduce((sum, step) => {
+    const total = finiteNumber(step.usage?.totalTokens);
+    if (total !== undefined) return sum + total;
+    return (
+      sum +
+      (finiteNumber(step.usage?.inputTokens) ?? 0) +
+      (finiteNumber(step.usage?.outputTokens) ?? 0)
+    );
+  }, 0);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- Adds profile-aware run budgets for steps, output tokens, input-size estimates, prior-context size, and total token loop stopping.
- Budgets prepared model replay in `/api/chat`, preserving latest user intent, approval continuation state, and accepted-plan handoff while pruning older transcript messages.
- Records budget decisions in token audit/cost metadata and emits Worklog trace events when context is pruned or a budget limit stops the run.
- Updates `ROADMAP.md` to split richer repo-map/file-summary context and true dollar-cost caps into separate future items.

Closes #76.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- Manual helper checks with `pnpm exec tsx -e ...` for transcript pruning, approval-continuation preservation, and oversized latest-user 413 behavior.

## Notes
- No schema migration; budget audit data is stored in existing run metadata JSON.
- Dollar-cost budgets remain deferred until Anton has reliable model pricing metadata.
