### PR TITLE
Remove OpenRouter price-sorted routing

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -11,7 +11,6 @@ import {
 import {
   openrouter,
   DEFAULT_MODEL,
-  toOpenRouterModelId,
 } from "@/src/lib/providers";
 import { buildTokenUsageMetrics } from "@/src/lib/token-usage";
 import { listMemories } from "@/src/db/queries";
@@ -467,7 +466,7 @@ export async function runAgent({
   };
 
   return streamText({
-    model: openrouter(toOpenRouterModelId(selectedModel)),
+    model: openrouter(selectedModel),
     system,
     messages,
     maxOutputTokens: budget.maxOutputTokens,
@@ -622,12 +621,10 @@ function openRouterProviderOptions(
   profile: AgentRunProfile,
   thinkingEnabled: boolean,
 ): {
-  provider: { sort: "price" };
   reasoning?: ReturnType<typeof reasoningOptionsForProfile>;
   usage: { include: true };
 } {
   return {
-    provider: { sort: "price" },
     ...(thinkingEnabled ? { reasoning: reasoningOptionsForProfile(profile) } : {}),
     usage: { include: true },
   };

--- a/src/agent/tools/delegate.ts
+++ b/src/agent/tools/delegate.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import {
   DEFAULT_MODEL,
   openrouter,
-  toOpenRouterModelId,
 } from "@/src/lib/providers";
 import { listMemories } from "@/src/db/queries";
 import { listSkills } from "../skills";
@@ -64,14 +63,13 @@ export function createDelegateTaskTool({
     execute: async ({ task, maxSteps }) => {
       try {
         const result = await generateText({
-          model: openrouter(toOpenRouterModelId(model ?? DEFAULT_MODEL)),
+          model: openrouter(model ?? DEFAULT_MODEL),
           system: childSystemPrompt(workspaceRoot),
           prompt: task,
           tools: readOnlyTools,
           stopWhen: stepCountIs(maxSteps ?? DEFAULT_MAX_STEPS),
           providerOptions: {
             openrouter: {
-              provider: { sort: "price" },
               usage: { include: true },
             },
           },

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -19,17 +19,9 @@ export const DEFAULT_MODEL = stripOpenRouterRoutingSuffix(
   process.env.DEFAULT_MODEL ?? DEFAULT_MODEL_ID,
 );
 
-export function toOpenRouterModelId(modelId: string): string {
-  return hasOpenRouterRoutingSuffix(modelId) ? modelId : `${modelId}:floor`;
-}
-
 export function stripOpenRouterRoutingSuffix(modelId: string): string {
   const suffix = openRouterRoutingSuffix(modelId);
   return suffix ? modelId.slice(0, -suffix.length - 1) : modelId;
-}
-
-function hasOpenRouterRoutingSuffix(modelId: string): boolean {
-  return openRouterRoutingSuffix(modelId) !== null;
 }
 
 function openRouterRoutingSuffix(modelId: string): string | null {


### PR DESCRIPTION
## Summary
- Removes the implicit `:floor` suffix from OpenRouter model requests.
- Removes explicit `provider.sort = "price"` from main agent and delegate-agent provider options.
- Keeps OpenRouter usage metadata and reasoning options intact so run cost/cache metrics continue to work.

Closes #78.

## Verification
- `pnpm typecheck`
- `pnpm lint`

## Notes
- No UI changes; visual verification not applicable.
