### PR TITLE
[codex] Add local project lifecycle

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,10 +109,10 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 ## Phase 5: GitHub And Project Workflow
 
-- [] Support importing existing local repositories without cloning from GitHub.
+- [✔️] Support importing existing local repositories without cloning from GitHub.
 - [] Support refreshing project metadata from GitHub.
 - [] Support multiple installations and account filtering in the UI.
-- [] Add project removal/archive behavior without deleting local files by default.
+- [✔️] Add project removal/archive behavior without deleting local files by default.
 - [] Add branch creation with default `codex/` prefix for agent work.
 - [] Add PR creation flow after successful local changes.
 - [] Add issue selection and branch naming from GitHub issues.

--- a/app/api/projects/[id]/route.ts
+++ b/app/api/projects/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getProject } from "@/src/db/queries";
+import { deleteProject, getProject } from "@/src/db/queries";
 import { serializeProject } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
@@ -9,6 +9,20 @@ export async function GET(_req: Request, { params }: Ctx) {
   const { id } = await params;
   const project = getProject(id);
   if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  return Response.json({ project: serializeProject(project) });
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+
+  const deleted = deleteProject(id);
+  if (!deleted) {
     return Response.json({ error: "project not found" }, { status: 404 });
   }
   return Response.json({ project: serializeProject(project) });

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,16 +2,27 @@ import { z } from "zod";
 
 import { getLocalWorkspacesRoot } from "@/src/workspace/local";
 import { cloneGitHubRepository, CloneError } from "@/src/workspace/clone";
+import {
+  importLocalRepository,
+  LocalImportError,
+} from "@/src/workspace/import-local";
 import { listProjects } from "@/src/db/queries";
 import { listInstallationRepositories } from "@/src/github/app";
 import { serializeProject } from "@/src/lib/api-serializers";
 
 export const runtime = "nodejs";
 
-const createSchema = z.object({
-  repositoryId: z.number().int().positive(),
-  installationId: z.number().int().positive(),
-});
+const createSchema = z.union([
+  z.object({
+    source: z.literal("github").optional(),
+    repositoryId: z.number().int().positive(),
+    installationId: z.number().int().positive(),
+  }),
+  z.object({
+    source: z.literal("local"),
+    localPath: z.string().trim().min(1),
+  }),
+]);
 
 export async function GET() {
   return Response.json({
@@ -31,19 +42,28 @@ export async function POST(req: Request) {
   }
 
   try {
-    const repos = await listInstallationRepositories(parsed.data.installationId);
-    const repository = repos.find((repo) => repo.id === parsed.data.repositoryId);
+    const data = parsed.data;
+    if ("localPath" in data) {
+      const project = await importLocalRepository({
+        localPath: data.localPath,
+      });
+      return Response.json({ project: serializeProject(project) }, { status: 201 });
+    }
+
+    const repos = await listInstallationRepositories(data.installationId);
+    const repository = repos.find((repo) => repo.id === data.repositoryId);
     if (!repository) {
       return Response.json({ error: "repository not found" }, { status: 404 });
     }
 
     const project = await cloneGitHubRepository({
       repository,
-      installationId: parsed.data.installationId,
+      installationId: data.installationId,
     });
     return Response.json({ project: serializeProject(project) }, { status: 201 });
   } catch (err) {
-    const status = err instanceof CloneError ? 400 : 500;
+    const status =
+      err instanceof CloneError || err instanceof LocalImportError ? 400 : 500;
     return Response.json({ error: errorMessage(err) }, { status });
   }
 }

--- a/components/features/settings/hooks.ts
+++ b/components/features/settings/hooks.ts
@@ -22,9 +22,12 @@ export function useWorkspaceSettings(
   const [rootDraft, setRootDraft] = useState("");
   const [repositories, setRepositories] = useState<GitHubRepositorySummary[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [localPathDraft, setLocalPathDraft] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [cloningRepoId, setCloningRepoId] = useState<number | null>(null);
+  const [importingLocal, setImportingLocal] = useState(false);
+  const [removingProjectId, setRemovingProjectId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -106,20 +109,65 @@ export function useWorkspaceSettings(
     }
   };
 
+  const importLocalProject = async () => {
+    const localPath = localPathDraft.trim();
+    if (!localPath) return;
+
+    setImportingLocal(true);
+    try {
+      const data = await requestJson<{ project: ProjectSummary }>("/api/projects", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ source: "local", localPath }),
+      });
+      setLocalPathDraft("");
+      selectProject(data.project.id);
+      await refresh();
+    } catch (err) {
+      setError(errorMessage(err, "Import failed"));
+    } finally {
+      setImportingLocal(false);
+    }
+  };
+
+  const removeProject = async (projectId: string, activeProjectId: string | null) => {
+    setRemovingProjectId(projectId);
+    try {
+      await requestJson<{ project: ProjectSummary }>(`/api/projects/${projectId}`, {
+        method: "DELETE",
+      });
+      if (activeProjectId === projectId) {
+        writeActiveProjectId(null);
+        onActiveProjectChange(null);
+      }
+      await refresh();
+    } catch (err) {
+      setError(errorMessage(err, "Project removal failed"));
+    } finally {
+      setRemovingProjectId(null);
+    }
+  };
+
   return {
     settings,
     rootDraft,
     setRootDraft,
+    localPathDraft,
+    setLocalPathDraft,
     repositories,
     projects,
     readyProjects: projects.filter((project) => project.status === "ready"),
     loading,
     saving,
     cloningRepoId,
+    importingLocal,
+    removingProjectId,
     error,
     refresh,
     saveRoot,
     selectProject,
     cloneRepo,
+    importLocalProject,
+    removeProject,
   };
 }

--- a/components/features/settings/workspace-settings-panel.tsx
+++ b/components/features/settings/workspace-settings-panel.tsx
@@ -1,8 +1,27 @@
 "use client";
 
-import { Check, FolderGit2, GitBranch, Loader2, RefreshCw } from "lucide-react";
+import {
+  Check,
+  FolderGit2,
+  FolderPlus,
+  GitBranch,
+  Loader2,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 
 import { EmptyState, ErrorBanner } from "@/components/shared/feedback-states";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -21,22 +40,28 @@ export function WorkspaceSettingsPanel({
     settings,
     rootDraft,
     setRootDraft,
+    localPathDraft,
+    setLocalPathDraft,
     repositories,
     readyProjects,
     loading,
     saving,
     cloningRepoId,
+    importingLocal,
+    removingProjectId,
     error,
     refresh,
     saveRoot,
     selectProject,
     cloneRepo,
+    importLocalProject,
+    removeProject,
   } = useWorkspaceSettings(onActiveProjectChange);
 
   return (
     <SettingsPageShell
       title="Workspaces"
-      description="Choose where Anton clones repositories and which workspace new sessions use."
+      description="Choose where Anton stores cloned repositories and which workspace new sessions use."
     >
       {error && <ErrorBanner message={error} />}
       <SettingsCard title="Local workspace root" icon={<FolderGit2 />}>
@@ -62,37 +87,105 @@ export function WorkspaceSettingsPanel({
           <p className="mt-2 text-[11px] text-muted-foreground">
             Current:{" "}
             <span className="font-mono">{settings.resolvedLocalWorkspacesRoot}</span>
-            {" · "}
+            {" - "}
             {settings.source}
-            {settings.exists ? " · ready" : " · will be created"}
+            {settings.exists ? " - ready" : " - will be created"}
           </p>
         )}
       </SettingsCard>
 
+      <SettingsCard title="Import local repository" icon={<FolderPlus />}>
+        <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+          <Input
+            value={localPathDraft}
+            onChange={(event) => setLocalPathDraft(event.target.value)}
+            className="font-mono"
+            placeholder="M:\\Projects\\example-repo"
+            aria-label="Local repository path"
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void importLocalProject()}
+            disabled={importingLocal || localPathDraft.trim().length === 0}
+          >
+            {importingLocal ? <Loader2 className="animate-spin" /> : <FolderPlus />}
+            Import
+          </Button>
+        </div>
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Adds an existing Git repository to Anton without copying or deleting files.
+        </p>
+      </SettingsCard>
+
       <SettingsCard title="Active project" icon={<GitBranch />}>
         {readyProjects.length === 0 ? (
-          <EmptyState message="No cloned projects yet." />
+          <EmptyState message="No projects yet." />
         ) : (
           <ul className="grid gap-2">
             {readyProjects.map((project) => (
-              <li key={project.id}>
+              <li
+                key={project.id}
+                className={cn(
+                  "flex items-start gap-2 rounded-md p-2.5 ring-1 transition-colors",
+                  activeProjectId === project.id
+                    ? "bg-primary/10 ring-primary/50"
+                    : "bg-background/45 ring-border",
+                )}
+              >
                 <button
                   type="button"
                   onClick={() => selectProject(project.id)}
-                  className={cn(
-                    "w-full rounded-md p-2.5 text-left ring-1 transition-colors",
-                    activeProjectId === project.id
-                      ? "bg-primary/10 ring-primary/50"
-                      : "bg-background/45 ring-border hover:bg-accent",
-                  )}
+                  className="min-w-0 flex-1 text-left"
                 >
-                  <span className="block text-xs font-medium">
+                  <span className="block truncate text-xs font-medium">
                     {project.fullName}
+                  </span>
+                  <span className="mt-0.5 block text-[11px] text-muted-foreground">
+                    {project.provider === "local" ? "Local" : "GitHub"} -{" "}
+                    {project.defaultBranch}
                   </span>
                   <span className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">
                     {project.localPath}
                   </span>
                 </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      disabled={removingProjectId === project.id}
+                      aria-label={`Remove ${project.fullName}`}
+                    >
+                      {removingProjectId === project.id ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <Trash2 />
+                      )}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Remove project?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This removes {project.fullName} from Anton. The local
+                        repository files stay on disk.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        onClick={() =>
+                          void removeProject(project.id, activeProjectId)
+                        }
+                      >
+                        Remove
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </li>
             ))}
           </ul>
@@ -135,7 +228,7 @@ export function WorkspaceSettingsPanel({
                       {repo.fullName}
                     </div>
                     <div className="mt-0.5 text-[11px] text-muted-foreground">
-                      {repo.private ? "Private" : "Public"} · {repo.defaultBranch}
+                      {repo.private ? "Private" : "Public"} - {repo.defaultBranch}
                     </div>
                   </div>
                   {repo.clonedProjectId ? (

--- a/src/db/migrations/0009_panoramic_komodo.sql
+++ b/src/db/migrations/0009_panoramic_komodo.sql
@@ -1,0 +1,28 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TEMP TABLE `__project_session_links` AS SELECT `id`, `project_id` FROM `sessions` WHERE `project_id` IS NOT NULL;--> statement-breakpoint
+UPDATE `sessions` SET `project_id` = NULL WHERE `project_id` IS NOT NULL;--> statement-breakpoint
+CREATE TABLE `__new_projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`provider` text NOT NULL,
+	`github_repo_id` integer,
+	`github_installation_id` integer,
+	`owner` text NOT NULL,
+	`name` text NOT NULL,
+	`full_name` text NOT NULL,
+	`default_branch` text NOT NULL,
+	`clone_url` text,
+	`local_path` text NOT NULL,
+	`status` text NOT NULL,
+	`last_error` text,
+	`created_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_projects`("id", "provider", "github_repo_id", "github_installation_id", "owner", "name", "full_name", "default_branch", "clone_url", "local_path", "status", "last_error", "created_at", "updated_at") SELECT "id", "provider", "github_repo_id", "github_installation_id", "owner", "name", "full_name", "default_branch", "clone_url", "local_path", "status", "last_error", "created_at", "updated_at" FROM `projects`;--> statement-breakpoint
+DROP TABLE `projects`;--> statement-breakpoint
+ALTER TABLE `__new_projects` RENAME TO `projects`;--> statement-breakpoint
+UPDATE `sessions` SET `project_id` = (SELECT `project_id` FROM `__project_session_links` WHERE `__project_session_links`.`id` = `sessions`.`id`) WHERE `id` IN (SELECT `id` FROM `__project_session_links`);--> statement-breakpoint
+DROP TABLE `__project_session_links`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `projects_github_repo_id_unique` ON `projects` (`github_repo_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `projects_local_path_unique` ON `projects` (`local_path`);

--- a/src/db/migrations/meta/0009_snapshot.json
+++ b/src/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1288 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ff326b9d-d744-4db6-85ea-148fa1eb9b17",
+  "prevId": "dec04244-9ca7-42f6-b043-e48f43fac078",
+  "tables": {
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778772847996,
       "tag": "0008_bright_blink",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1779019724382,
+      "tag": "0009_panoramic_komodo",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -249,6 +249,14 @@ export function getProjectByGithubRepoId(
     .get();
 }
 
+export function getProjectByLocalPath(localPath: string): Project | undefined {
+  return db
+    .select()
+    .from(projects)
+    .where(eq(projects.localPath, localPath))
+    .get();
+}
+
 export function upsertProject(input: {
   githubRepoId: number;
   githubInstallationId: number;
@@ -303,6 +311,38 @@ export function upsertProject(input: {
   return row;
 }
 
+export function createLocalProject(input: {
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  cloneUrl: string | null;
+  localPath: string;
+}): Project {
+  const existing = getProjectByLocalPath(input.localPath);
+  if (existing) return existing;
+
+  const now = new Date();
+  const row: Project = {
+    id: randomUUID(),
+    provider: "local",
+    githubRepoId: null,
+    githubInstallationId: null,
+    owner: input.owner,
+    name: input.name,
+    fullName: input.fullName,
+    defaultBranch: input.defaultBranch,
+    cloneUrl: input.cloneUrl,
+    localPath: input.localPath,
+    status: "ready",
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(projects).values(row).run();
+  return row;
+}
+
 export function updateProjectStatus(
   id: string,
   status: Project["status"],
@@ -314,6 +354,18 @@ export function updateProjectStatus(
     .where(eq(projects.id, id))
     .run();
   return getProject(id);
+}
+
+export function deleteProject(id: string): boolean {
+  return db.transaction((tx) => {
+    tx
+      .update(sessions)
+      .set({ projectId: null, updatedAt: new Date() })
+      .where(eq(sessions.projectId, id))
+      .run();
+    const result = tx.delete(projects).where(eq(projects.id, id)).run();
+    return result.changes > 0;
+  });
 }
 
 export function listMemories(limit = 20): Memory[] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -36,14 +36,14 @@ export const projects = sqliteTable(
   "projects",
   {
     id: text("id").primaryKey(),
-    provider: text("provider", { enum: ["github"] }).notNull(),
-    githubRepoId: integer("github_repo_id").notNull(),
-    githubInstallationId: integer("github_installation_id").notNull(),
+    provider: text("provider", { enum: ["github", "local"] }).notNull(),
+    githubRepoId: integer("github_repo_id"),
+    githubInstallationId: integer("github_installation_id"),
     owner: text("owner").notNull(),
     name: text("name").notNull(),
     fullName: text("full_name").notNull(),
     defaultBranch: text("default_branch").notNull(),
-    cloneUrl: text("clone_url").notNull(),
+    cloneUrl: text("clone_url"),
     localPath: text("local_path").notNull(),
     status: text("status", {
       enum: ["cloning", "ready", "error"],

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -20,14 +20,14 @@ export type GitHubRepositorySummary = {
 
 export type ProjectSummary = {
   id: string;
-  provider: "github";
-  githubRepoId: number;
-  githubInstallationId: number;
+  provider: "github" | "local";
+  githubRepoId: number | null;
+  githubInstallationId: number | null;
   owner: string;
   name: string;
   fullName: string;
   defaultBranch: string;
-  cloneUrl: string;
+  cloneUrl: string | null;
   localPath: string;
   status: "cloning" | "ready" | "error";
   lastError: string | null;

--- a/src/lib/client-state/active-project.ts
+++ b/src/lib/client-state/active-project.ts
@@ -10,9 +10,13 @@ export function readActiveProjectId(): string | null {
   return localStorage.getItem(ACTIVE_PROJECT_KEY);
 }
 
-export function writeActiveProjectId(projectId: string): void {
+export function writeActiveProjectId(projectId: string | null): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+  if (projectId) {
+    localStorage.setItem(ACTIVE_PROJECT_KEY, projectId);
+  } else {
+    localStorage.removeItem(ACTIVE_PROJECT_KEY);
+  }
   window.dispatchEvent(
     new CustomEvent(ACTIVE_PROJECT_EVENT, { detail: projectId }),
   );
@@ -20,8 +24,11 @@ export function writeActiveProjectId(projectId: string): void {
 
 export function isActiveProjectChangeEvent(
   event: Event,
-): event is CustomEvent<string> {
-  return event instanceof CustomEvent && typeof event.detail === "string";
+): event is CustomEvent<string | null> {
+  return (
+    event instanceof CustomEvent &&
+    (typeof event.detail === "string" || event.detail === null)
+  );
 }
 
 export function useActiveProjectIdState(

--- a/src/workspace/import-local.ts
+++ b/src/workspace/import-local.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { createLocalProject } from "@/src/db/queries";
+
+const execFileAsync = promisify(execFile);
+
+export async function importLocalRepository(input: { localPath: string }) {
+  const requestedPath = path.resolve(input.localPath);
+  const stat = await fs.stat(requestedPath).catch(() => null);
+  if (!stat?.isDirectory()) {
+    throw new LocalImportError("Local project path must be an existing directory.");
+  }
+
+  const topLevel = await gitOutput(requestedPath, [
+    "rev-parse",
+    "--show-toplevel",
+  ]).catch(() => null);
+  if (!topLevel) {
+    throw new LocalImportError("Local project path must be inside a Git repository.");
+  }
+
+  let localPath: string;
+  try {
+    localPath = ensureWorkspaceRootAt(topLevel);
+  } catch (err) {
+    throw new LocalImportError(errorMessage(err));
+  }
+  const name = path.basename(localPath);
+  const owner = path.basename(path.dirname(localPath)) || "local";
+  const defaultBranch =
+    (await gitOutput(localPath, ["branch", "--show-current"]).catch(() => "")) ||
+    "main";
+  const cloneUrl =
+    (await gitOutput(localPath, ["config", "--get", "remote.origin.url"]).catch(
+      () => "",
+    )) || null;
+
+  return createLocalProject({
+    owner,
+    name,
+    fullName: `${owner}/${name}`,
+    defaultBranch,
+    cloneUrl,
+    localPath,
+  });
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+export class LocalImportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalImportError";
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}


### PR DESCRIPTION
## Summary

- Adds local Git repository import support for projects without cloning from GitHub.
- Adds non-destructive project removal through the projects API and Workspaces settings UI.
- Updates project persistence to support local projects and generated the Drizzle migration.
- Handles populated databases by preserving session project links while rebuilding `projects`.
- Marks the completed Phase 5 roadmap items.

Closes #84.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm db:migrate` against a temporary SQLite database
- `pnpm db:migrate` against a copy of the populated local `anton.db`
- `pnpm db:migrate` against the real local `anton.db`
- API verification on `localhost:3000`: imported `M:\Projects\mrgb\notes` as `mrgb/notes`
- API verification on `localhost:3000`: deleted a temporary local project with a session reference, confirmed the session `project_id` was cleared and the repository files remained on disk.

## Visual verification

- The user reproduced this in the Workspaces settings panel. I verified the failing paths through the same local API backing that UI; no separate screenshot was captured.
