### PR TITLE
[codex] Refresh GitHub project metadata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,8 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Added durable tool-call and approval audit rows tied to chat runs.
 - [✔️] Added provider, step-count, and cost metadata tracking for runs.
 - [✔️] Added profile-aware context budgeting, transcript pruning, and step/token run budgets.
+- [✔️] Added GitHub project metadata refresh.
+- [✔️] Added GitHub installation/account filtering in Workspaces settings.
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -110,8 +112,8 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 ## Phase 5: GitHub And Project Workflow
 
 - [✔️] Support importing existing local repositories without cloning from GitHub.
-- [] Support refreshing project metadata from GitHub.
-- [] Support multiple installations and account filtering in the UI.
+- [✔️] Support refreshing project metadata from GitHub.
+- [✔️] Support multiple installations and account filtering in the UI.
 - [✔️] Add project removal/archive behavior without deleting local files by default.
 - [] Add branch creation with default `codex/` prefix for agent work.
 - [] Add PR creation flow after successful local changes.

--- a/app/api/github/repositories/route.ts
+++ b/app/api/github/repositories/route.ts
@@ -18,12 +18,13 @@ export async function GET() {
   }
 
   try {
+    const installations = listGithubInstallations();
     const projects = listProjects();
     const projectByRepoId = new Map(
       projects.map((project) => [project.githubRepoId, project]),
     );
     const repositories = [];
-    for (const installation of listGithubInstallations()) {
+    for (const installation of installations) {
       const repos = await listInstallationRepositories(
         installation.installationId,
       );
@@ -33,6 +34,8 @@ export async function GET() {
           return {
             id: repo.id,
             installationId: installation.installationId,
+            accountLogin: installation.accountLogin,
+            accountType: installation.accountType,
             name: repo.name,
             fullName: repo.full_name,
             owner: repo.owner.login,
@@ -45,7 +48,14 @@ export async function GET() {
         }),
       );
     }
-    return Response.json({ repositories });
+    return Response.json({
+      installations: installations.map((installation) => ({
+        installationId: installation.installationId,
+        accountLogin: installation.accountLogin,
+        accountType: installation.accountType,
+      })),
+      repositories,
+    });
   } catch (err) {
     return Response.json({ error: errorMessage(err) }, { status: 500 });
   }

--- a/app/api/projects/[id]/refresh/route.ts
+++ b/app/api/projects/[id]/refresh/route.ts
@@ -1,0 +1,66 @@
+import { getProject, updateGithubProjectMetadata } from "@/src/db/queries";
+import { findInstallationRepository } from "@/src/github/app";
+import { serializeProject } from "@/src/lib/api-serializers";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (
+    project.provider !== "github" ||
+    project.githubRepoId === null ||
+    project.githubInstallationId === null
+  ) {
+    return Response.json(
+      { error: "project is not backed by GitHub" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const repository = await findInstallationRepository({
+      installationId: project.githubInstallationId,
+      repositoryId: project.githubRepoId,
+    });
+    if (!repository) {
+      return Response.json(
+        { error: "repository not found in GitHub installation" },
+        { status: 502 },
+      );
+    }
+
+    const refreshed = updateGithubProjectMetadata({
+      id: project.id,
+      githubRepoId: repository.id,
+      githubInstallationId: project.githubInstallationId,
+      owner: repository.owner.login,
+      name: repository.name,
+      fullName: repository.full_name,
+      defaultBranch: repository.default_branch,
+      cloneUrl: repository.clone_url,
+      status: "ready",
+      lastError: null,
+    });
+    if (!refreshed) {
+      return Response.json({ error: "project not found" }, { status: 404 });
+    }
+    return Response.json({ project: serializeProject(refreshed) });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 502 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/components/features/settings/hooks.ts
+++ b/components/features/settings/hooks.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import type {
+  GitHubInstallationSummary,
   GitHubRepositorySummary,
   ProjectSummary,
   WorkspaceSettingsSummary,
@@ -20,6 +21,10 @@ export function useWorkspaceSettings(
 ) {
   const [settings, setSettings] = useState<WorkspaceSettingsSummary | null>(null);
   const [rootDraft, setRootDraft] = useState("");
+  const [installations, setInstallations] = useState<GitHubInstallationSummary[]>(
+    [],
+  );
+  const [installationFilter, setInstallationFilter] = useState("all");
   const [repositories, setRepositories] = useState<GitHubRepositorySummary[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [localPathDraft, setLocalPathDraft] = useState("");
@@ -28,6 +33,9 @@ export function useWorkspaceSettings(
   const [cloningRepoId, setCloningRepoId] = useState<number | null>(null);
   const [importingLocal, setImportingLocal] = useState(false);
   const [removingProjectId, setRemovingProjectId] = useState<string | null>(null);
+  const [refreshingProjectId, setRefreshingProjectId] = useState<string | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -38,9 +46,10 @@ export function useWorkspaceSettings(
           "/api/workspace-settings",
         ),
         getJson<{ projects: ProjectSummary[] }>("/api/projects"),
-        getJson<{ repositories: GitHubRepositorySummary[] }>(
-          "/api/github/repositories",
-        ).catch(() => null),
+        getJson<{
+          installations: GitHubInstallationSummary[];
+          repositories: GitHubRepositorySummary[];
+        }>("/api/github/repositories").catch(() => null),
       ]);
 
       setSettings(settingsData.settings);
@@ -50,7 +59,16 @@ export function useWorkspaceSettings(
           "",
       );
       setProjects(projectsData.projects);
+      setInstallations(reposData?.installations ?? []);
       setRepositories(reposData?.repositories ?? []);
+      setInstallationFilter((current) => {
+        if (current === "all") return current;
+        return reposData?.installations.some(
+          (installation) => String(installation.installationId) === current,
+        )
+          ? current
+          : "all";
+      });
       setError(null);
     } catch (err) {
       setError(errorMessage(err, "Failed to load workspaces"));
@@ -148,13 +166,44 @@ export function useWorkspaceSettings(
     }
   };
 
+  const refreshProject = async (projectId: string) => {
+    setRefreshingProjectId(projectId);
+    try {
+      const data = await requestJson<{ project: ProjectSummary }>(
+        `/api/projects/${projectId}/refresh`,
+        { method: "POST" },
+      );
+      setProjects((current) =>
+        current.map((project) =>
+          project.id === data.project.id ? data.project : project,
+        ),
+      );
+      await refresh();
+    } catch (err) {
+      setError(errorMessage(err, "Project refresh failed"));
+    } finally {
+      setRefreshingProjectId(null);
+    }
+  };
+
+  const filteredRepositories =
+    installationFilter === "all"
+      ? repositories
+      : repositories.filter(
+          (repo) => String(repo.installationId) === installationFilter,
+        );
+
   return {
     settings,
     rootDraft,
     setRootDraft,
     localPathDraft,
     setLocalPathDraft,
+    installations,
+    installationFilter,
+    setInstallationFilter,
     repositories,
+    filteredRepositories,
     projects,
     readyProjects: projects.filter((project) => project.status === "ready"),
     loading,
@@ -162,6 +211,7 @@ export function useWorkspaceSettings(
     cloningRepoId,
     importingLocal,
     removingProjectId,
+    refreshingProjectId,
     error,
     refresh,
     saveRoot,
@@ -169,5 +219,6 @@ export function useWorkspaceSettings(
     cloneRepo,
     importLocalProject,
     removeProject,
+    refreshProject,
   };
 }

--- a/components/features/settings/workspace-settings-panel.tsx
+++ b/components/features/settings/workspace-settings-panel.tsx
@@ -24,6 +24,14 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 import { useWorkspaceSettings } from "./hooks";
@@ -42,13 +50,18 @@ export function WorkspaceSettingsPanel({
     setRootDraft,
     localPathDraft,
     setLocalPathDraft,
+    installations,
+    installationFilter,
+    setInstallationFilter,
     repositories,
+    filteredRepositories,
     readyProjects,
     loading,
     saving,
     cloningRepoId,
     importingLocal,
     removingProjectId,
+    refreshingProjectId,
     error,
     refresh,
     saveRoot,
@@ -56,7 +69,9 @@ export function WorkspaceSettingsPanel({
     cloneRepo,
     importLocalProject,
     removeProject,
+    refreshProject,
   } = useWorkspaceSettings(onActiveProjectChange);
+  const showAccountLabels = installations.length > 0;
 
   return (
     <SettingsPageShell
@@ -149,6 +164,32 @@ export function WorkspaceSettingsPanel({
                     {project.localPath}
                   </span>
                 </button>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => void refreshProject(project.id)}
+                  disabled={
+                    project.provider !== "github" ||
+                    refreshingProjectId === project.id
+                  }
+                  aria-label={
+                    project.provider === "github"
+                      ? `Refresh metadata for ${project.fullName}`
+                      : `Metadata refresh unavailable for ${project.fullName}`
+                  }
+                  title={
+                    project.provider === "github"
+                      ? "Refresh GitHub metadata"
+                      : "Local projects do not have GitHub metadata"
+                  }
+                >
+                  {refreshingProjectId === project.id ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <RefreshCw />
+                  )}
+                </Button>
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
                     <Button
@@ -216,53 +257,127 @@ export function WorkspaceSettingsPanel({
         {repositories.length === 0 ? (
           <EmptyState message="Connect GitHub and refresh to list repositories." />
         ) : (
-          <ul className="grid gap-2 lg:grid-cols-2">
-            {repositories.map((repo) => (
-              <li
-                key={`${repo.installationId}:${repo.id}`}
-                className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
-              >
-                <div className="flex items-start justify-between gap-3">
+          <div className="grid gap-3">
+            {installations.length > 0 && (
+              <div className="grid gap-2 border-b border-border pb-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0">
-                    <div className="truncate text-xs font-medium">
-                      {repo.fullName}
+                    <div className="text-xs font-medium">
+                      Connected GitHub accounts
                     </div>
-                    <div className="mt-0.5 text-[11px] text-muted-foreground">
-                      {repo.private ? "Private" : "Public"} - {repo.defaultBranch}
+                    <div className="text-[11px] text-muted-foreground">
+                      {installations.length}{" "}
+                      {installations.length === 1 ? "installation" : "installations"}
                     </div>
                   </div>
-                  {repo.clonedProjectId ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => {
-                        if (repo.clonedProjectId) selectProject(repo.clonedProjectId);
-                      }}
+                  <Select
+                    value={installationFilter}
+                    onValueChange={setInstallationFilter}
+                  >
+                    <SelectTrigger
+                      className="w-[min(220px,70vw)]"
+                      aria-label="GitHub account filter"
                     >
-                      Select
-                    </Button>
-                  ) : (
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={() => void cloneRepo(repo)}
-                      disabled={cloningRepoId === repo.id}
-                    >
-                      {cloningRepoId === repo.id ? (
-                        <Loader2 className="animate-spin" />
-                      ) : (
-                        <GitBranch />
-                      )}
-                      Clone
-                    </Button>
-                  )}
+                      <SelectValue placeholder="All accounts" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectViewport>
+                        <SelectItem value="all">All accounts</SelectItem>
+                        {installations.map((installation) => (
+                          <SelectItem
+                            key={installation.installationId}
+                            value={String(installation.installationId)}
+                          >
+                            {installation.accountLogin}
+                          </SelectItem>
+                        ))}
+                      </SelectViewport>
+                    </SelectContent>
+                  </Select>
                 </div>
-              </li>
-            ))}
-          </ul>
+                <ul className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                  {installations.map((installation) => (
+                    <li key={installation.installationId}>
+                      <span className="text-foreground/80">
+                        {installation.accountLogin}
+                      </span>{" "}
+                      - {installation.accountType} -{" "}
+                      {repositoryCountForInstallation(
+                        repositories,
+                        installation.installationId,
+                      )}{" "}
+                      repos
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {filteredRepositories.length === 0 ? (
+              <EmptyState message="No repositories for this account." />
+            ) : (
+              <ul className="grid gap-2 lg:grid-cols-2">
+                {filteredRepositories.map((repo) => (
+                  <li
+                    key={`${repo.installationId}:${repo.id}`}
+                    className="rounded-md bg-background/45 p-2.5 ring-1 ring-border"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-xs font-medium">
+                          {repo.fullName}
+                        </div>
+                        <div className="mt-0.5 text-[11px] text-muted-foreground">
+                          {repo.private ? "Private" : "Public"} -{" "}
+                          {repo.defaultBranch}
+                          {showAccountLabels
+                            ? ` - ${repo.accountLogin} (${repo.accountType})`
+                            : ""}
+                        </div>
+                      </div>
+                      {repo.clonedProjectId ? (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            if (repo.clonedProjectId) {
+                              selectProject(repo.clonedProjectId);
+                            }
+                          }}
+                        >
+                          Select
+                        </Button>
+                      ) : (
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => void cloneRepo(repo)}
+                          disabled={cloningRepoId === repo.id}
+                        >
+                          {cloningRepoId === repo.id ? (
+                            <Loader2 className="animate-spin" />
+                          ) : (
+                            <GitBranch />
+                          )}
+                          Clone
+                        </Button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         )}
       </SettingsCard>
     </SettingsPageShell>
   );
+}
+
+function repositoryCountForInstallation(
+  repositories: { installationId: number }[],
+  installationId: number,
+): number {
+  return repositories.filter((repo) => repo.installationId === installationId)
+    .length;
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -356,6 +356,37 @@ export function updateProjectStatus(
   return getProject(id);
 }
 
+export function updateGithubProjectMetadata(input: {
+  id: string;
+  githubRepoId: number;
+  githubInstallationId: number;
+  owner: string;
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  cloneUrl: string;
+  status: Project["status"];
+  lastError?: string | null;
+}): Project | undefined {
+  db
+    .update(projects)
+    .set({
+      githubRepoId: input.githubRepoId,
+      githubInstallationId: input.githubInstallationId,
+      owner: input.owner,
+      name: input.name,
+      fullName: input.fullName,
+      defaultBranch: input.defaultBranch,
+      cloneUrl: input.cloneUrl,
+      status: input.status,
+      lastError: input.lastError ?? null,
+      updatedAt: new Date(),
+    })
+    .where(eq(projects.id, input.id))
+    .run();
+  return getProject(input.id);
+}
+
 export function deleteProject(id: string): boolean {
   return db.transaction((tx) => {
     tx

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -63,6 +63,14 @@ export async function listInstallationRepositories(
   return repositoriesResponseSchema.parse(json).repositories;
 }
 
+export async function findInstallationRepository(input: {
+  installationId: number;
+  repositoryId: number;
+}): Promise<GitHubRepository | undefined> {
+  const repos = await listInstallationRepositories(input.installationId);
+  return repos.find((repo) => repo.id === input.repositoryId);
+}
+
 export async function createInstallationToken(installationId: number): Promise<{
   token: string;
   expiresAt: Date;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -8,6 +8,8 @@ export type WorkspaceSettingsSummary = {
 export type GitHubRepositorySummary = {
   id: number;
   installationId: number;
+  accountLogin: string;
+  accountType: string;
   name?: string;
   fullName: string;
   owner?: string;
@@ -16,6 +18,12 @@ export type GitHubRepositorySummary = {
   htmlUrl?: string;
   clonedProjectId: string | null;
   cloneStatus?: "cloning" | "ready" | "error" | null;
+};
+
+export type GitHubInstallationSummary = {
+  installationId: number;
+  accountLogin: string;
+  accountType: string;
 };
 
 export type ProjectSummary = {


### PR DESCRIPTION
## Summary

- Adds installation/account summaries to the GitHub repositories API and includes account identity on each repository row.
- Adds a GitHub project metadata refresh endpoint that updates stored repo metadata without changing local files or `localPath`.
- Adds Workspaces settings controls for GitHub account filtering and per-project metadata refresh.
- Marks the completed Phase 5 roadmap items.

Closes #86.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- API verification on `localhost:3000`: `GET /api/github/repositories` returned installations plus repository account fields with one connected installation.
- API verification on `localhost:3000`: `POST /api/projects/<github-project-id>/refresh` refreshed a GitHub project, preserved `localPath`, kept status `ready`, and cleared `lastError`.
- API verification on `localhost:3000`: `POST /api/projects/<local-project-id>/refresh` returned `400` with `project is not backed by GitHub`.
- Page smoke check on `localhost:3000`: root page returned HTTP 200 and rendered the Next app shell.

## Visual verification

- Browser automation was not available in this environment. The Workspaces UI changes are covered by typecheck/lint and the API smoke checks above; manual visual review should verify the account filter and refresh icon states before merging.