### PR TITLE
Add PR sidebar view for active project branches

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Added profile-aware context budgeting, transcript pruning, and step/token run budgets.
 - [✔️] Added GitHub project metadata refresh.
 - [✔️] Added GitHub installation/account filtering in Workspaces settings.
+- [✔️] Added right-sidebar PR view detection for active GitHub project branches.
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -118,6 +119,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [] Add branch creation with default `codex/` prefix for agent work.
 - [] Add PR creation flow after successful local changes.
 - [] Add issue selection and branch naming from GitHub issues.
+- [✔️] Add right-sidebar PR view for active GitHub project branches.
 - [] Add GitHub check/CI status display for pushed branches and PRs.
 - [] Add retry/debug workflow for failing GitHub Actions logs.
 - [] Store GitHub token expiry metadata and refresh tokens only when needed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Added GitHub project metadata refresh.
 - [✔️] Added GitHub installation/account filtering in Workspaces settings.
 - [✔️] Added right-sidebar PR view detection for active GitHub project branches.
+- [✔️] Added branch switch/create controls in the composer and workspace settings.
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -116,7 +117,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Support refreshing project metadata from GitHub.
 - [✔️] Support multiple installations and account filtering in the UI.
 - [✔️] Add project removal/archive behavior without deleting local files by default.
-- [] Add branch creation with default `codex/` prefix for agent work.
+- [✔️] Add branch creation with default `codex/` prefix for agent work.
 - [] Add PR creation flow after successful local changes.
 - [] Add issue selection and branch naming from GitHub issues.
 - [✔️] Add right-sidebar PR view for active GitHub project branches.

--- a/app/api/projects/[id]/git/branches/route.ts
+++ b/app/api/projects/[id]/git/branches/route.ts
@@ -1,0 +1,183 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { z } from "zod";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { getProject } from "@/src/db/queries";
+import type { ProjectBranchesSummary } from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+
+type Ctx = { params: Promise<{ id: string }> };
+
+const mutationSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("switch"),
+    branch: z.string().trim().min(1),
+    kind: z.enum(["local", "remote"]).default("local"),
+  }),
+  z.object({
+    action: z.literal("create"),
+    branch: z.string().trim().min(1),
+  }),
+]);
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const project = await readyProject(params);
+  if ("error" in project) return project.error;
+
+  try {
+    return Response.json({
+      branches: await branchSummary(project.project.id, project.project.defaultBranch, project.root),
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request, { params }: Ctx) {
+  const project = await readyProject(params);
+  if ("error" in project) return project.error;
+
+  const body = await req.json().catch(() => null);
+  const parsed = mutationSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const data = parsed.data;
+    if (data.action === "create") {
+      const branch = normalizeNewBranchName(data.branch);
+      await assertValidBranchName(project.root, branch);
+      await gitOutput(project.root, ["switch", "-c", branch]);
+    } else if (data.kind === "remote") {
+      const branch = normalizeRemoteBranchName(data.branch);
+      const localName = branch.replace(/^origin\//, "");
+      await assertValidBranchName(project.root, localName);
+      await gitOutput(project.root, ["switch", "--track", branch]);
+    } else {
+      await assertValidBranchName(project.root, data.branch);
+      await gitOutput(project.root, ["switch", data.branch]);
+    }
+
+    return Response.json({
+      branches: await branchSummary(
+        project.project.id,
+        project.project.defaultBranch,
+        project.root,
+      ),
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 409 },
+    );
+  }
+}
+
+async function readyProject(params: Promise<{ id: string }>): Promise<
+  | { project: NonNullable<ReturnType<typeof getProject>>; root: string }
+  | { error: Response }
+> {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return { error: Response.json({ error: "project not found" }, { status: 404 }) };
+  }
+  if (project.status !== "ready") {
+    return { error: Response.json({ error: "project is not ready" }, { status: 400 }) };
+  }
+  return { project, root: ensureWorkspaceRootAt(project.localPath) };
+}
+
+async function branchSummary(
+  projectId: string,
+  defaultBranch: string,
+  root: string,
+): Promise<ProjectBranchesSummary> {
+  const [currentBranch, localRaw, remoteRaw] = await Promise.all([
+    gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
+    gitOutput(root, ["for-each-ref", "--format=%(refname:short)", "refs/heads"]),
+    gitOutput(root, [
+      "for-each-ref",
+      "--format=%(refname:short)",
+      "refs/remotes/origin",
+    ]).catch(() => ""),
+  ]);
+  const current = currentBranch.trim() || null;
+  const localBranches = splitLines(localRaw);
+  const localNames = new Set(localBranches);
+  const remoteBranches = splitLines(remoteRaw)
+    .filter((branch) => branch !== "origin" && branch !== "origin/HEAD")
+    .filter((branch) => !localNames.has(branch.replace(/^origin\//, "")));
+
+  return {
+    projectId,
+    currentBranch: current,
+    defaultBranch,
+    branches: [
+      ...localBranches.map((name) => ({
+        name,
+        kind: "local" as const,
+        current: name === current,
+      })),
+      ...remoteBranches.map((name) => ({
+        name,
+        kind: "remote" as const,
+        current: false,
+      })),
+    ].sort(compareBranches(defaultBranch)),
+  };
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+async function assertValidBranchName(root: string, branch: string): Promise<void> {
+  if (branch.startsWith("-") || /[\s\0-\x1f]/.test(branch)) {
+    throw new Error(`invalid branch name: ${branch}`);
+  }
+  await gitOutput(root, ["check-ref-format", "--branch", branch]);
+}
+
+function normalizeNewBranchName(name: string): string {
+  return name.includes("/") ? name : `codex/${name}`;
+}
+
+function normalizeRemoteBranchName(name: string): string {
+  return name.startsWith("origin/") ? name : `origin/${name}`;
+}
+
+function splitLines(value: string): string[] {
+  return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function compareBranches(defaultBranch: string) {
+  return (
+    left: ProjectBranchesSummary["branches"][number],
+    right: ProjectBranchesSummary["branches"][number],
+  ): number => {
+    if (left.current !== right.current) return left.current ? -1 : 1;
+    if (left.name === defaultBranch) return -1;
+    if (right.name === defaultBranch) return 1;
+    if (left.kind !== right.kind) return left.kind === "local" ? -1 : 1;
+    return left.name.localeCompare(right.name);
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/git/branches/route.ts
+++ b/app/api/projects/[id]/git/branches/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
 import { getProject } from "@/src/db/queries";
+import { createInstallationToken } from "@/src/github/app";
 import type { ProjectBranchesSummary } from "@/src/lib/api-types";
 import { redactText } from "@/src/lib/redaction";
 
@@ -25,11 +26,15 @@ const mutationSchema = z.discriminatedUnion("action", [
   }),
 ]);
 
-export async function GET(_req: Request, { params }: Ctx) {
+export async function GET(req: Request, { params }: Ctx) {
   const project = await readyProject(params);
   if ("error" in project) return project.error;
 
   try {
+    const refresh = new URL(req.url).searchParams.get("refresh") === "1";
+    if (refresh) {
+      await fetchOrigin(project.project, project.root);
+    }
     return Response.json({
       branches: await branchSummary(project.project.id, project.project.defaultBranch, project.root),
     });
@@ -140,9 +145,42 @@ async function branchSummary(
   };
 }
 
-async function gitOutput(cwd: string, args: string[]): Promise<string> {
-  const result = await execFileAsync("git", args, { cwd });
+async function fetchOrigin(
+  project: { provider: string; githubInstallationId: number | null },
+  root: string,
+): Promise<void> {
+  const originUrl = await gitOutput(root, ["remote", "get-url", "origin"]).catch(() => "");
+  if (!originUrl) return;
+  const env = await gitAuthEnv(project);
+  await gitOutput(root, ["fetch", "--prune", "origin"], env);
+}
+
+async function gitOutput(
+  cwd: string,
+  args: string[],
+  extraEnv?: Record<string, string>,
+): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    env: extraEnv ? { ...process.env, ...extraEnv } : undefined,
+  });
   return result.stdout.trim();
+}
+
+async function gitAuthEnv(project: {
+  provider: string;
+  githubInstallationId: number | null;
+}): Promise<Record<string, string> | undefined> {
+  if (project.provider !== "github" || project.githubInstallationId === null) {
+    return undefined;
+  }
+  const { token } = await createInstallationToken(project.githubInstallationId);
+  const auth = Buffer.from(`x-access-token:${token}`, "utf8").toString("base64");
+  return {
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
+    GIT_CONFIG_VALUE_0: `Authorization: Basic ${auth}`,
+  };
 }
 
 async function assertValidBranchName(root: string, branch: string): Promise<void> {

--- a/app/api/projects/[id]/git/status/route.ts
+++ b/app/api/projects/[id]/git/status/route.ts
@@ -1,0 +1,79 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { getProject } from "@/src/db/queries";
+import type { ProjectGitStatusSummary } from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  try {
+    const root = ensureWorkspaceRootAt(project.localPath);
+    const [branch, status, upstream, remoteUrl, aheadBehind] = await Promise.all([
+      gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
+      gitOutput(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+      gitOutput(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).catch(
+        () => "",
+      ),
+      gitOutput(root, ["config", "--get", "remote.origin.url"]).catch(() => ""),
+      gitOutput(root, [
+        "rev-list",
+        "--left-right",
+        "--count",
+        `origin/${project.defaultBranch}...HEAD`,
+      ]).catch(() => ""),
+    ]);
+    const counts = parseAheadBehind(aheadBehind);
+    const currentBranch = branch.trim() || null;
+    const summary: ProjectGitStatusSummary = {
+      projectId: project.id,
+      branch: currentBranch,
+      defaultBranch: project.defaultBranch,
+      isDefaultBranch: currentBranch === project.defaultBranch,
+      dirtyCount: status.split("\0").filter(Boolean).length,
+      ahead: counts?.ahead ?? null,
+      behind: counts?.behind ?? null,
+      upstream: upstream.trim() || null,
+      remoteUrl: remoteUrl.trim() ? redactText(remoteUrl.trim()) : null,
+    };
+    return Response.json({ status: summary });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+function parseAheadBehind(value: string): { ahead: number; behind: number } | null {
+  const [behindRaw, aheadRaw] = value.trim().split(/\s+/, 2);
+  const behind = Number(behindRaw);
+  const ahead = Number(aheadRaw);
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null;
+  return { ahead, behind };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/github/pull-request/route.ts
+++ b/app/api/projects/[id]/github/pull-request/route.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+import { getProject } from "@/src/db/queries";
+import { findPullRequestForBranch } from "@/src/github/app";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+const querySchema = z.object({
+  branch: z.string().trim().min(1),
+});
+
+export async function GET(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (
+    project.provider !== "github" ||
+    project.githubInstallationId === null ||
+    project.status !== "ready"
+  ) {
+    return Response.json({ pullRequest: null });
+  }
+
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse({
+    branch: url.searchParams.get("branch"),
+  });
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid query", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  if (parsed.data.branch === project.defaultBranch) {
+    return Response.json({ pullRequest: null });
+  }
+
+  try {
+    const pullRequest = await findPullRequestForBranch({
+      installationId: project.githubInstallationId,
+      owner: project.owner,
+      repo: project.name,
+      branch: parsed.data.branch,
+    });
+    return Response.json({ pullRequest });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 502 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -154,4 +154,9 @@
     border: 3px solid transparent;
     background-clip: padding-box;
   }
+  .anton-diff-scrollbar::-webkit-scrollbar-button {
+    width: 0;
+    height: 0;
+    display: none;
+  }
 }

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -36,7 +36,10 @@ import { Worklog } from "@/components/features/run-trace/worklog";
 import { useSessionStore } from "@/components/features/sessions/session-store";
 import { useSidebar } from "@/components/features/sessions/session-sidebar";
 import { useActiveProjectIdState } from "@/src/lib/client-state/active-project";
-import { useProjectSummary } from "@/components/features/projects/hooks";
+import {
+  useProjectGitStatus,
+  useProjectSummary,
+} from "@/components/features/projects/hooks";
 import { SettingsDialog } from "@/components/features/settings/settings-dialog";
 
 interface ChatProps {
@@ -104,6 +107,7 @@ function ChatSession({
   );
   const effectiveProjectId = initialProjectId ?? activeProjectId;
   const project = useProjectSummary(effectiveProjectId);
+  const projectGitStatus = useProjectGitStatus(project ? effectiveProjectId : null);
 
   const transport = useMemo(
     () =>
@@ -382,6 +386,7 @@ function ChatSession({
             onThinkingEnabledChange={setThinkingEnabled}
             tokenUsage={tokenUsage}
             project={project}
+            projectBranch={projectGitStatus?.branch ?? null}
             permissionMode={permissionMode}
             onPermissionModeChange={setPermissionMode}
             mcpServers={mcpServers}
@@ -393,6 +398,8 @@ function ChatSession({
         <Worklog
           messages={displayMessages}
           onApproval={addToolApprovalResponse}
+          project={project}
+          visible={worklogOpen}
           expanded={worklogExpanded}
           onExpandToggle={() => setWorklogExpanded((value) => !value)}
           className={cn(
@@ -417,6 +424,8 @@ function ChatSession({
             <Worklog
               messages={displayMessages}
               onApproval={addToolApprovalResponse}
+              project={project}
+              visible
               className="ml-auto h-full w-[min(420px,100%)] border-l"
               onClose={() => setMobileWorklogOpen(false)}
             />

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -55,6 +55,7 @@ interface ComposerProps {
   onThinkingEnabledChange: (enabled: boolean) => void;
   tokenUsage: SessionTokenUsage;
   project: ProjectSummary | null;
+  projectBranch: string | null;
   permissionMode: PermissionMode;
   onPermissionModeChange: (mode: PermissionMode) => void;
   mcpServers: McpServerSummary[];
@@ -78,6 +79,7 @@ export function Composer({
   onThinkingEnabledChange,
   tokenUsage,
   project,
+  projectBranch,
   permissionMode,
   onPermissionModeChange,
   mcpServers,
@@ -88,6 +90,7 @@ export function Composer({
   const [mcpOpen, setMcpOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sendDisabled = disabled || (mode !== "chat" && !project);
+  const displayedProjectBranch = projectBranch ?? project?.defaultBranch ?? null;
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -209,12 +212,16 @@ export function Composer({
           <button
             type="button"
             className="inline-flex min-w-0 items-center gap-1.5 hover:text-foreground"
-            title={project ? `${project.fullName} : ${project.defaultBranch}` : undefined}
+            title={
+              project && displayedProjectBranch
+                ? `${project.fullName} : ${displayedProjectBranch}`
+                : undefined
+            }
           >
             <GitBranch className="size-3.5 shrink-0" />
             <span className="max-w-[20rem] truncate">
-              {project
-                ? `${project.fullName} : ${project.defaultBranch}`
+              {project && displayedProjectBranch
+                ? `${project.fullName} : ${displayedProjectBranch}`
                 : "No codebase selected"}
             </span>
             <ChevronDown className="size-3 shrink-0" />

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -12,7 +12,6 @@ import {
   ChevronDown,
   Code2,
   DatabaseZap,
-  GitBranch,
   MessageCircle,
   Monitor,
   Plus,
@@ -40,6 +39,7 @@ import type { ChatMode } from "@/src/lib/chat-modes";
 import type { PermissionMode } from "@/src/agent/permissions";
 import type { McpServerSummary, ProjectSummary } from "@/src/lib/api-types";
 import type { SessionTokenUsage } from "@/src/lib/token-usage";
+import { BranchSwitcher } from "@/components/features/projects/branch-switcher";
 import { ModelPicker } from "./model-picker";
 
 interface ComposerProps {
@@ -90,7 +90,6 @@ export function Composer({
   const [mcpOpen, setMcpOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sendDisabled = disabled || (mode !== "chat" && !project);
-  const displayedProjectBranch = projectBranch ?? project?.defaultBranch ?? null;
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -209,23 +208,12 @@ export function Composer({
             Work locally
             <ChevronDown className="size-3" />
           </button>
-          <button
-            type="button"
-            className="inline-flex min-w-0 items-center gap-1.5 hover:text-foreground"
-            title={
-              project && displayedProjectBranch
-                ? `${project.fullName} : ${displayedProjectBranch}`
-                : undefined
-            }
-          >
-            <GitBranch className="size-3.5 shrink-0" />
-            <span className="max-w-[20rem] truncate">
-              {project && displayedProjectBranch
-                ? `${project.fullName} : ${displayedProjectBranch}`
-                : "No codebase selected"}
-            </span>
-            <ChevronDown className="size-3 shrink-0" />
-          </button>
+          <BranchSwitcher
+            project={project}
+            currentBranch={projectBranch}
+            className="max-w-[20rem]"
+            contentAlign="start"
+          />
         </div>
       </div>
     </form>

--- a/components/features/projects/branch-switcher.tsx
+++ b/components/features/projects/branch-switcher.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Check,
   ChevronDown,
   GitBranch,
   Loader2,
   Plus,
+  RefreshCw,
   Search,
   X,
 } from "lucide-react";
@@ -65,12 +66,13 @@ export function BranchSwitcher({
     return items.filter((branch) => branch.name.toLowerCase().includes(needle));
   }, [branches, query]);
 
-  const loadBranches = async () => {
+  const loadBranches = useCallback(async ({ refresh = false } = {}) => {
     if (!project) return;
     setLoading(true);
     try {
+      const queryString = refresh ? "?refresh=1" : "";
       const data = await getJson<{ branches: ProjectBranchesSummary }>(
-        `/api/projects/${project.id}/git/branches`,
+        `/api/projects/${project.id}/git/branches${queryString}`,
       );
       setBranches(data.branches);
       setError(null);
@@ -79,7 +81,7 @@ export function BranchSwitcher({
     } finally {
       setLoading(false);
     }
-  };
+  }, [project]);
 
   const mutateBranch = async (body: Record<string, unknown>, busyLabel: string) => {
     if (!project) return;
@@ -131,7 +133,7 @@ export function BranchSwitcher({
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (next) void loadBranches();
+        if (next) void loadBranches({ refresh: true });
       }}
     >
       <PopoverTrigger asChild>
@@ -175,9 +177,9 @@ export function BranchSwitcher({
         side="top"
         className="w-72 overflow-hidden p-0"
       >
-        <div className="border-b border-border p-2">
-          <div className="grid grid-cols-[0.875rem_1fr_auto] items-center gap-2 rounded-md bg-background/70 px-2 py-1.5 ring-1 ring-border">
-            <Search className="size-3.5 text-muted-foreground" />
+        <div className="border-b border-border p-1.5">
+          <div className="grid grid-cols-[0.75rem_1fr_auto] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
+            <Search className="size-3 text-muted-foreground" />
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
@@ -185,19 +187,32 @@ export function BranchSwitcher({
               className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
               aria-label="Search branches"
             />
-            {loading ? <Loader2 className="size-3 animate-spin text-muted-foreground" /> : null}
+            <button
+              type="button"
+              onClick={() => void loadBranches({ refresh: true })}
+              disabled={loading || switching !== null}
+              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+              aria-label="Refresh branches"
+              title="Refresh branches"
+            >
+              {loading ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+            </button>
           </div>
         </div>
-        <div className="max-h-56 overflow-y-auto p-1">
-          <div className="px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+        <div className="max-h-52 overflow-y-auto p-0.5">
+          <div className="px-1.5 py-1 text-[10px] font-medium uppercase text-muted-foreground">
             Branches
           </div>
           {error ? (
-            <div className="mx-1 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+            <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
               {error}
             </div>
           ) : filteredBranches.length === 0 ? (
-            <div className="px-2 py-4 text-center text-[11px] text-muted-foreground">
+            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
               {loading ? "Loading branches..." : "No branches found."}
             </div>
           ) : (
@@ -208,12 +223,12 @@ export function BranchSwitcher({
                     type="button"
                     onClick={() => selectBranch(branch)}
                     disabled={switching !== null}
-                    className="grid w-full grid-cols-[0.875rem_minmax(0,1fr)_0.875rem] items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
+                    className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
                   >
                     {switching === branch.name ? (
-                      <Loader2 className="size-3.5 animate-spin text-primary" />
+                      <Loader2 className="size-3 animate-spin text-primary" />
                     ) : (
-                      <GitBranch className="size-3.5 text-muted-foreground" />
+                      <GitBranch className="size-3 text-muted-foreground" />
                     )}
                     <span className="min-w-0">
                       <span className="block truncate font-mono font-medium">
@@ -226,7 +241,7 @@ export function BranchSwitcher({
                       ) : null}
                     </span>
                     {branch.current ? (
-                      <Check className="size-3.5 text-primary" />
+                      <Check className="size-3 text-primary" />
                     ) : null}
                   </button>
                 </li>
@@ -234,7 +249,7 @@ export function BranchSwitcher({
             </ul>
           )}
         </div>
-        <div className="border-t border-border p-1">
+        <div className="border-t border-border p-0.5">
           {createMode ? (
             <div className="grid grid-cols-[1fr_auto_auto] items-center gap-1">
               <Input
@@ -250,7 +265,7 @@ export function BranchSwitcher({
                     setNewBranch("");
                   }
                 }}
-                className="h-7 font-mono text-[11px]"
+                className="h-6 font-mono text-[11px]"
                 placeholder="codex/new-branch"
                 aria-label="New branch name"
                 autoFocus
@@ -283,9 +298,9 @@ export function BranchSwitcher({
             <button
               type="button"
               onClick={() => setCreateMode(true)}
-              className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex h-6 w-full items-center gap-1.5 rounded-md px-1.5 text-left text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
-              <Plus className="size-3.5" />
+              <Plus className="size-3" />
               Create and checkout new branch...
             </button>
           )}

--- a/components/features/projects/branch-switcher.tsx
+++ b/components/features/projects/branch-switcher.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  GitBranch,
+  Loader2,
+  Plus,
+  Search,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectBranchesSummary,
+  ProjectBranchSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
+import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
+
+import { notifyProjectGitChanged } from "./hooks";
+
+export function BranchSwitcher({
+  project,
+  currentBranch,
+  className,
+  triggerClassName,
+  contentAlign = "center",
+  showProjectName = true,
+  iconOnly = false,
+  onBranchChanged,
+}: {
+  project: ProjectSummary | null;
+  currentBranch: string | null;
+  className?: string;
+  triggerClassName?: string;
+  contentAlign?: "start" | "center" | "end";
+  showProjectName?: boolean;
+  iconOnly?: boolean;
+  onBranchChanged?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [branches, setBranches] = useState<ProjectBranchesSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [switching, setSwitching] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createMode, setCreateMode] = useState(false);
+  const [newBranch, setNewBranch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const displayedBranch = currentBranch ?? project?.defaultBranch ?? null;
+
+  const filteredBranches = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const items = branches?.branches ?? [];
+    if (!needle) return items;
+    return items.filter((branch) => branch.name.toLowerCase().includes(needle));
+  }, [branches, query]);
+
+  const loadBranches = async () => {
+    if (!project) return;
+    setLoading(true);
+    try {
+      const data = await getJson<{ branches: ProjectBranchesSummary }>(
+        `/api/projects/${project.id}/git/branches`,
+      );
+      setBranches(data.branches);
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to load branches"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const mutateBranch = async (body: Record<string, unknown>, busyLabel: string) => {
+    if (!project) return;
+    setSwitching(busyLabel);
+    setCreating(body.action === "create");
+    try {
+      const data = await requestJson<{ branches: ProjectBranchesSummary }>(
+        `/api/projects/${project.id}/git/branches`,
+        {
+          method: "POST",
+          headers: jsonHeaders(),
+          body: JSON.stringify(body),
+        },
+      );
+      setBranches(data.branches);
+      setCreateMode(false);
+      setNewBranch("");
+      setError(null);
+      notifyProjectGitChanged(project.id);
+      onBranchChanged?.();
+      setOpen(false);
+    } catch (err) {
+      setError(errorMessage(err, "Branch operation failed"));
+    } finally {
+      setSwitching(null);
+      setCreating(false);
+    }
+  };
+
+  const selectBranch = (branch: ProjectBranchSummary) => {
+    if (branch.current) {
+      setOpen(false);
+      return;
+    }
+    void mutateBranch(
+      { action: "switch", branch: branch.name, kind: branch.kind },
+      branch.name,
+    );
+  };
+
+  const createBranch = () => {
+    const trimmed = newBranch.trim();
+    if (!trimmed) return;
+    void mutateBranch({ action: "create", branch: trimmed }, trimmed);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) void loadBranches();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={!project}
+          className={cn(
+            iconOnly
+              ? "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+              : "inline-flex min-w-0 items-center gap-1.5 rounded-md px-1 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
+            triggerClassName,
+          )}
+          aria-label={
+            project && displayedBranch
+              ? `Switch branch for ${project.fullName}, current branch ${displayedBranch}`
+              : "Switch branch"
+          }
+          title={
+            project && displayedBranch
+              ? `${project.fullName} : ${displayedBranch}`
+              : undefined
+          }
+        >
+          <GitBranch className="size-3.5 shrink-0" />
+          {!iconOnly && (
+            <>
+              <span className={cn("truncate", className)}>
+                {project && displayedBranch
+                  ? showProjectName
+                    ? `${project.fullName} : ${displayedBranch}`
+                    : displayedBranch
+                  : "No codebase selected"}
+              </span>
+              <ChevronDown className="size-3 shrink-0" />
+            </>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align={contentAlign}
+        side="top"
+        className="w-72 overflow-hidden p-0"
+      >
+        <div className="border-b border-border p-2">
+          <div className="grid grid-cols-[0.875rem_1fr_auto] items-center gap-2 rounded-md bg-background/70 px-2 py-1.5 ring-1 ring-border">
+            <Search className="size-3.5 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search branches"
+              className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
+              aria-label="Search branches"
+            />
+            {loading ? <Loader2 className="size-3 animate-spin text-muted-foreground" /> : null}
+          </div>
+        </div>
+        <div className="max-h-56 overflow-y-auto p-1">
+          <div className="px-2 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+            Branches
+          </div>
+          {error ? (
+            <div className="mx-1 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+              {error}
+            </div>
+          ) : filteredBranches.length === 0 ? (
+            <div className="px-2 py-4 text-center text-[11px] text-muted-foreground">
+              {loading ? "Loading branches..." : "No branches found."}
+            </div>
+          ) : (
+            <ul className="grid gap-0.5">
+              {filteredBranches.map((branch) => (
+                <li key={`${branch.kind}:${branch.name}`}>
+                  <button
+                    type="button"
+                    onClick={() => selectBranch(branch)}
+                    disabled={switching !== null}
+                    className="grid w-full grid-cols-[0.875rem_minmax(0,1fr)_0.875rem] items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
+                  >
+                    {switching === branch.name ? (
+                      <Loader2 className="size-3.5 animate-spin text-primary" />
+                    ) : (
+                      <GitBranch className="size-3.5 text-muted-foreground" />
+                    )}
+                    <span className="min-w-0">
+                      <span className="block truncate font-mono font-medium">
+                        {branch.name}
+                      </span>
+                      {branch.kind === "remote" ? (
+                        <span className="text-[10px] text-muted-foreground">
+                          remote
+                        </span>
+                      ) : null}
+                    </span>
+                    {branch.current ? (
+                      <Check className="size-3.5 text-primary" />
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="border-t border-border p-1">
+          {createMode ? (
+            <div className="grid grid-cols-[1fr_auto_auto] items-center gap-1">
+              <Input
+                value={newBranch}
+                onChange={(event) => setNewBranch(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    createBranch();
+                  }
+                  if (event.key === "Escape") {
+                    setCreateMode(false);
+                    setNewBranch("");
+                  }
+                }}
+                className="h-7 font-mono text-[11px]"
+                placeholder="codex/new-branch"
+                aria-label="New branch name"
+                autoFocus
+              />
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="ghost"
+                onClick={createBranch}
+                disabled={creating || newBranch.trim().length === 0}
+                aria-label="Create and checkout branch"
+              >
+                {creating ? <Loader2 className="animate-spin" /> : <Check />}
+              </Button>
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="ghost"
+                onClick={() => {
+                  setCreateMode(false);
+                  setNewBranch("");
+                }}
+                disabled={creating}
+                aria-label="Cancel new branch"
+              >
+                <X />
+              </Button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setCreateMode(true)}
+              className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <Plus className="size-3.5" />
+              Create and checkout new branch...
+            </button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/features/projects/branch-switcher.tsx
+++ b/components/features/projects/branch-switcher.tsx
@@ -228,17 +228,20 @@ export function BranchSwitcher({
                     {switching === branch.name ? (
                       <Loader2 className="size-3 animate-spin text-primary" />
                     ) : (
-                      <GitBranch className="size-3 text-muted-foreground" />
+                      <GitBranch
+                        className={cn(
+                          "size-3",
+                          branch.kind === "remote"
+                            ? "text-sky-400"
+                            : "text-muted-foreground",
+                        )}
+                        aria-label={branch.kind === "remote" ? "Remote branch" : "Local branch"}
+                      />
                     )}
                     <span className="min-w-0">
                       <span className="block truncate font-mono font-medium">
                         {branch.name}
                       </span>
-                      {branch.kind === "remote" ? (
-                        <span className="text-[10px] text-muted-foreground">
-                          remote
-                        </span>
-                      ) : null}
                     </span>
                     {branch.current ? (
                       <Check className="size-3 text-primary" />

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -5,6 +5,8 @@ import { useEffect, useState } from "react";
 import type { ProjectGitStatusSummary, ProjectSummary } from "@/src/lib/api-types";
 import { getJson } from "@/src/lib/client-fetch";
 
+export const PROJECT_GIT_CHANGED_EVENT = "anton-project-git-change";
+
 export function useProjectSummary(projectId: string | null): ProjectSummary | null {
   const [loadedProject, setLoadedProject] = useState<{
     projectId: string;
@@ -61,11 +63,26 @@ export function useProjectGitStatus(
     };
     void loadStatus();
     const interval = window.setInterval(() => void loadStatus(), 15000);
+    const onProjectGitChanged = (event: Event) => {
+      if (
+        event instanceof CustomEvent &&
+        typeof event.detail === "string" &&
+        event.detail === projectId
+      ) {
+        void loadStatus();
+      }
+    };
+    window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     return () => {
       cancelled = true;
       window.clearInterval(interval);
+      window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     };
   }, [projectId]);
 
   return loadedStatus?.projectId === projectId ? loadedStatus.status : null;
+}
+
+export function notifyProjectGitChanged(projectId: string): void {
+  window.dispatchEvent(new CustomEvent(PROJECT_GIT_CHANGED_EVENT, { detail: projectId }));
 }

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import type { ProjectSummary } from "@/src/lib/api-types";
+import type { ProjectGitStatusSummary, ProjectSummary } from "@/src/lib/api-types";
 import { getJson } from "@/src/lib/client-fetch";
 
 export function useProjectSummary(projectId: string | null): ProjectSummary | null {
@@ -28,4 +28,44 @@ export function useProjectSummary(projectId: string | null): ProjectSummary | nu
   }, [projectId]);
 
   return loadedProject?.projectId === projectId ? loadedProject.project : null;
+}
+
+export function useProjectGitStatus(
+  projectId: string | null,
+): ProjectGitStatusSummary | null {
+  const [loadedStatus, setLoadedStatus] = useState<{
+    projectId: string;
+    status: ProjectGitStatusSummary | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!projectId) {
+      queueMicrotask(() => setLoadedStatus(null));
+      return;
+    }
+
+    let cancelled = false;
+    const loadStatus = async () => {
+      try {
+        const data = await getJson<{ status: ProjectGitStatusSummary }>(
+          `/api/projects/${projectId}/git/status`,
+        );
+        if (!cancelled) {
+          setLoadedStatus({ projectId, status: data.status });
+        }
+      } catch {
+        if (!cancelled) {
+          setLoadedStatus({ projectId, status: null });
+        }
+      }
+    };
+    void loadStatus();
+    const interval = window.setInterval(() => void loadStatus(), 15000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [projectId]);
+
+  return loadedStatus?.projectId === projectId ? loadedStatus.status : null;
 }

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -60,7 +60,8 @@ const COMPACT_DIFF_OPTIONS = {
       --diffs-selection-base: var(--primary);
       --diffs-gap-block: 0;
       --diffs-gap-inline: 0;
-      --diffs-scrollbar-gutter-override: 8px;
+      --diffs-scrollbar-gutter-override: 10px;
+      --diffs-min-number-column-width: 3ch;
     }
 
     [data-code] {
@@ -68,19 +69,25 @@ const COMPACT_DIFF_OPTIONS = {
       background: transparent;
       overflow-x: auto;
       overflow-y: clip;
-      scrollbar-color: color-mix(in oklch, var(--muted-foreground) 45%, transparent) transparent;
+      scrollbar-color: color-mix(in oklch, var(--foreground) 16%, transparent) transparent;
     }
 
     [data-code]::-webkit-scrollbar {
-      height: 8px;
-      width: 8px;
+      width: 10px;
+      height: 10px;
     }
 
     [data-code]::-webkit-scrollbar-thumb {
-      border: 2px solid transparent;
+      border: 3px solid transparent;
       border-radius: 999px;
-      background-color: color-mix(in oklch, var(--muted-foreground) 45%, transparent);
-      background-clip: content-box;
+      background: color-mix(in oklch, var(--foreground) 16%, transparent);
+      background-clip: padding-box;
+    }
+
+    [data-code]::-webkit-scrollbar-thumb:hover {
+      border: 3px solid transparent;
+      background: color-mix(in oklch, var(--foreground) 24%, transparent);
+      background-clip: padding-box;
     }
 
     [data-code]::-webkit-scrollbar-track,
@@ -96,9 +103,13 @@ const COMPACT_DIFF_OPTIONS = {
     }
 
     [data-column-number] {
-      min-width: 2.5rem;
-      padding-inline: 0.375rem;
+      min-width: 0;
+      padding-inline: 0.125rem 0.25rem;
       color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+    }
+
+    [data-line-number-content] {
+      min-width: 3ch;
     }
 
     [data-separator="line-info-basic"] {

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -60,8 +60,8 @@ const COMPACT_DIFF_OPTIONS = {
       --diffs-selection-base: var(--primary);
       --diffs-gap-block: 0;
       --diffs-gap-inline: 0;
-      --diffs-scrollbar-gutter-override: 10px;
-      --diffs-min-number-column-width: 3ch;
+      --diffs-scrollbar-gutter-override: 6px;
+      --diffs-min-number-column-width: 4ch;
     }
 
     [data-code] {
@@ -69,23 +69,30 @@ const COMPACT_DIFF_OPTIONS = {
       background: transparent;
       overflow-x: auto;
       overflow-y: clip;
+      scrollbar-width: thin;
       scrollbar-color: color-mix(in oklch, var(--foreground) 16%, transparent) transparent;
     }
 
     [data-code]::-webkit-scrollbar {
-      width: 10px;
-      height: 10px;
+      width: 6px;
+      height: 6px;
+    }
+
+    [data-code]::-webkit-scrollbar-button {
+      width: 0;
+      height: 0;
+      display: none;
     }
 
     [data-code]::-webkit-scrollbar-thumb {
-      border: 3px solid transparent;
+      border: 2px solid transparent;
       border-radius: 999px;
       background: color-mix(in oklch, var(--foreground) 16%, transparent);
       background-clip: padding-box;
     }
 
     [data-code]::-webkit-scrollbar-thumb:hover {
-      border: 3px solid transparent;
+      border: 2px solid transparent;
       background: color-mix(in oklch, var(--foreground) 24%, transparent);
       background-clip: padding-box;
     }
@@ -103,13 +110,13 @@ const COMPACT_DIFF_OPTIONS = {
     }
 
     [data-column-number] {
-      min-width: 0;
-      padding-inline: 0.125rem 0.25rem;
+      min-width: 4ch;
+      padding-inline: 0.5rem 0.375rem;
       color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
     }
 
     [data-line-number-content] {
-      min-width: 3ch;
+      min-width: 4ch;
     }
 
     [data-separator="line-info-basic"] {
@@ -205,9 +212,7 @@ function DiffFrame({
         className,
       )}
     >
-      <div className="min-w-0 max-w-full overflow-x-auto overflow-y-hidden">
-        {children}
-      </div>
+      <div className="min-w-0 max-w-full overflow-hidden">{children}</div>
     </div>
   );
 }

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -48,7 +48,7 @@ const COMPACT_DIFF_OPTIONS = {
       font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size: 10px;
       line-height: 1.45;
-      --diffs-bg: transparent;
+      --diffs-bg: var(--background);
       --diffs-fg: var(--foreground);
       --diffs-fg-number: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
       --diffs-bg-context: transparent;
@@ -77,22 +77,34 @@ const COMPACT_DIFF_OPTIONS = {
       height: 10px;
     }
 
+    [data-code]::-webkit-scrollbar-button {
+      width: 0;
+      height: 0;
+      display: none;
+    }
+
     [data-code]::-webkit-scrollbar-thumb {
       border: 3px solid transparent;
       border-radius: 999px;
-      background: color-mix(in oklch, var(--foreground) 16%, transparent);
+      background-color: color-mix(in oklch, var(--foreground) 16%, transparent);
       background-clip: padding-box;
     }
 
     [data-code]::-webkit-scrollbar-thumb:hover {
       border: 3px solid transparent;
-      background: color-mix(in oklch, var(--foreground) 24%, transparent);
+      background-color: color-mix(in oklch, var(--foreground) 24%, transparent);
       background-clip: padding-box;
     }
 
     [data-code]::-webkit-scrollbar-track,
     [data-code]::-webkit-scrollbar-corner {
       background: transparent;
+    }
+
+    [data-gutter] {
+      z-index: 5;
+      background-color: var(--diffs-bg);
+      box-shadow: 1px 0 0 var(--border);
     }
 
     [data-line],

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -30,10 +30,10 @@ const COMPACT_DIFF_OPTIONS = {
   theme: { light: "pierre-light", dark: "pierre-dark" },
   themeType: "dark",
   diffStyle: "unified",
-  diffIndicators: "classic",
+  diffIndicators: "bars",
   disableFileHeader: true,
-  disableLineNumbers: true,
-  hunkSeparators: "metadata",
+  disableLineNumbers: false,
+  hunkSeparators: "line-info-basic",
   lineDiffType: "word",
   maxLineDiffLength: 500,
   overflow: "scroll",
@@ -52,8 +52,8 @@ const COMPACT_DIFF_OPTIONS = {
       --diffs-fg: var(--foreground);
       --diffs-fg-number: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
       --diffs-bg-context: transparent;
-      --diffs-bg-context-gutter: color-mix(in oklch, var(--muted) 40%, transparent);
-      --diffs-bg-separator: color-mix(in oklch, var(--muted) 46%, transparent);
+      --diffs-bg-context-gutter: color-mix(in oklch, var(--muted) 34%, transparent);
+      --diffs-bg-separator: color-mix(in oklch, var(--muted) 42%, transparent);
       --diffs-bg-buffer: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
       --diffs-addition-base: oklch(0.76 0.16 153);
       --diffs-deletion-base: var(--destructive);
@@ -71,20 +71,23 @@ const COMPACT_DIFF_OPTIONS = {
     [data-column-number],
     [data-no-newline] {
       min-height: 1.25rem;
-      padding-inline: 0.5rem;
+      padding-inline: 0.375rem;
     }
 
-    [data-indicators="classic"] [data-line] {
-      padding-inline-start: 1.5rem;
+    [data-column-number] {
+      min-width: 2.5rem;
+      padding-inline: 0.375rem;
+      color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
     }
 
-    [data-separator="metadata"] {
-      height: 1.5rem;
+    [data-separator="line-info-basic"] {
+      min-height: 1.5rem;
     }
 
-    [data-separator="metadata"] [data-separator-wrapper] {
+    [data-separator="line-info-basic"] [data-separator-wrapper] {
+      border-radius: 0.25rem;
       color: var(--muted-foreground);
-      background-color: color-mix(in oklch, var(--muted) 44%, transparent);
+      background-color: color-mix(in oklch, var(--muted) 50%, transparent);
       font-size: 10px;
     }
   `,
@@ -93,7 +96,6 @@ const COMPACT_DIFF_OPTIONS = {
 export function DiffView({
   previous,
   next,
-  newFile,
   filename = "diff.txt",
   className,
 }: DiffViewProps) {
@@ -111,15 +113,7 @@ export function DiffView({
   }
 
   return (
-    <DiffFrame
-      className={className}
-      header={
-        <>
-          <span>diff</span>
-          {newFile ? <span className="text-emerald-400">new file</span> : null}
-        </>
-      }
-    >
+    <DiffFrame className={className}>
       <MultiFileDiff
         oldFile={oldFile}
         newFile={newFileContents}
@@ -168,11 +162,9 @@ export function PatchDiffView({
 function DiffFrame({
   children,
   className,
-  header,
 }: {
   children: ReactNode;
   className?: string;
-  header?: ReactNode;
 }) {
   return (
     <div
@@ -181,11 +173,6 @@ function DiffFrame({
         className,
       )}
     >
-      {header ? (
-        <div className="flex items-center gap-3 border-b border-border px-2 py-1 text-[10px] uppercase text-muted-foreground">
-          {header}
-        </div>
-      ) : null}
       <div className="min-w-0 max-w-full overflow-hidden">{children}</div>
     </div>
   );

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -60,10 +60,31 @@ const COMPACT_DIFF_OPTIONS = {
       --diffs-selection-base: var(--primary);
       --diffs-gap-block: 0;
       --diffs-gap-inline: 0;
+      --diffs-scrollbar-gutter-override: 8px;
     }
 
     [data-code] {
       max-width: 100%;
+      background: transparent;
+      overflow-x: auto;
+      overflow-y: clip;
+      scrollbar-color: color-mix(in oklch, var(--muted-foreground) 45%, transparent) transparent;
+    }
+
+    [data-code]::-webkit-scrollbar {
+      height: 8px;
+      width: 8px;
+    }
+
+    [data-code]::-webkit-scrollbar-thumb {
+      border: 2px solid transparent;
+      border-radius: 999px;
+      background-color: color-mix(in oklch, var(--muted-foreground) 45%, transparent);
+      background-clip: content-box;
+    }
+
+    [data-code]::-webkit-scrollbar-track,
+    [data-code]::-webkit-scrollbar-corner {
       background: transparent;
     }
 
@@ -173,7 +194,9 @@ function DiffFrame({
         className,
       )}
     >
-      <div className="min-w-0 max-w-full overflow-hidden">{children}</div>
+      <div className="min-w-0 max-w-full overflow-x-auto overflow-y-hidden">
+        {children}
+      </div>
     </div>
   );
 }

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -1,100 +1,254 @@
 "use client";
 
-import { useMemo } from "react";
-import { diffLines } from "diff";
+import { useMemo, type ReactNode } from "react";
+import {
+  MultiFileDiff,
+  PatchDiff,
+  type DiffBasePropsReact,
+  type FileContents,
+} from "@pierre/diffs/react";
+
 import { cn } from "@/lib/utils";
 
 interface DiffViewProps {
   previous: string;
   next: string;
   newFile?: boolean;
+  filename?: string;
+  className?: string;
 }
 
-export function DiffView({ previous, next, newFile }: DiffViewProps) {
-  const rows = useMemo(() => buildRows(previous, next), [previous, next]);
-  const { added, removed } = useMemo(() => countChanges(rows), [rows]);
+interface PatchDiffViewProps {
+  patch: string | null;
+  filename: string;
+  previousFilename?: string | null;
+  status?: string;
+  className?: string;
+}
 
-  if (rows.length === 0) {
-    return (
-      <div className="rounded bg-background/60 px-3 py-2 text-[11px] text-muted-foreground ring-1 ring-border">
-        No changes.
-      </div>
-    );
+const COMPACT_DIFF_OPTIONS = {
+  theme: { light: "pierre-light", dark: "pierre-dark" },
+  themeType: "dark",
+  diffStyle: "unified",
+  diffIndicators: "classic",
+  disableFileHeader: true,
+  disableLineNumbers: true,
+  hunkSeparators: "metadata",
+  lineDiffType: "word",
+  maxLineDiffLength: 500,
+  overflow: "scroll",
+  tokenizeMaxLineLength: 500,
+  unsafeCSS: `
+    :host {
+      display: block;
+      min-width: 0;
+      max-width: 100%;
+      color: var(--foreground);
+      background: transparent;
+      font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      font-size: 10px;
+      line-height: 1.45;
+      --diffs-bg: transparent;
+      --diffs-fg: var(--foreground);
+      --diffs-fg-number: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+      --diffs-bg-context: transparent;
+      --diffs-bg-context-gutter: color-mix(in oklch, var(--muted) 40%, transparent);
+      --diffs-bg-separator: color-mix(in oklch, var(--muted) 46%, transparent);
+      --diffs-bg-buffer: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
+      --diffs-addition-base: oklch(0.76 0.16 153);
+      --diffs-deletion-base: var(--destructive);
+      --diffs-selection-base: var(--primary);
+      --diffs-gap-block: 0;
+      --diffs-gap-inline: 0;
+    }
+
+    [data-code] {
+      max-width: 100%;
+      background: transparent;
+    }
+
+    [data-line],
+    [data-column-number],
+    [data-no-newline] {
+      min-height: 1.25rem;
+      padding-inline: 0.5rem;
+    }
+
+    [data-indicators="classic"] [data-line] {
+      padding-inline-start: 1.5rem;
+    }
+
+    [data-separator="metadata"] {
+      height: 1.5rem;
+    }
+
+    [data-separator="metadata"] [data-separator-wrapper] {
+      color: var(--muted-foreground);
+      background-color: color-mix(in oklch, var(--muted) 44%, transparent);
+      font-size: 10px;
+    }
+  `,
+} satisfies NonNullable<DiffBasePropsReact<undefined>["options"]>;
+
+export function DiffView({
+  previous,
+  next,
+  newFile,
+  filename = "diff.txt",
+  className,
+}: DiffViewProps) {
+  const oldFile = useMemo(
+    () => fileContents(filename, previous, "old"),
+    [filename, previous],
+  );
+  const newFileContents = useMemo(
+    () => fileContents(filename, next, "new"),
+    [filename, next],
+  );
+
+  if (previous === next) {
+    return <DiffFallback>No changes.</DiffFallback>;
   }
 
   return (
-    <div className="rounded-md bg-background/60 font-mono text-[11px] leading-snug ring-1 ring-border">
-      <div className="flex items-center gap-3 border-b border-border px-3 py-1 text-[10px] uppercase text-muted-foreground">
-        <span>diff</span>
-        {newFile ? (
-          <span className="text-emerald-600 dark:text-emerald-400">
-            new file
-          </span>
-        ) : null}
-        <span className="ml-auto tabular-nums">
-          <span className="text-emerald-600 dark:text-emerald-400">+{added}</span>
-          <span className="mx-1 text-muted-foreground/50">/</span>
-          <span className="text-destructive">-{removed}</span>
-        </span>
-      </div>
-      <div className="overflow-x-auto">
-        <pre className="m-0 p-0">
-          {rows.map((row, i) => (
-            <div
-              key={i}
-              className={cn(
-                "flex gap-2 px-3 whitespace-pre",
-                row.kind === "add" && "bg-emerald-500/10",
-                row.kind === "remove" && "bg-destructive/10",
-              )}
-            >
-              <span
-                aria-hidden
-                className={cn(
-                  "w-3 shrink-0 select-none text-center",
-                  row.kind === "add" && "text-emerald-600 dark:text-emerald-400",
-                  row.kind === "remove" && "text-destructive",
-                  row.kind === "context" && "text-muted-foreground/50",
-                )}
-              >
-                {row.kind === "add" ? "+" : row.kind === "remove" ? "-" : " "}
-              </span>
-              <span className="flex-1">{row.text || " "}</span>
-            </div>
-          ))}
-        </pre>
-      </div>
+    <DiffFrame
+      className={className}
+      header={
+        <>
+          <span>diff</span>
+          {newFile ? <span className="text-emerald-400">new file</span> : null}
+        </>
+      }
+    >
+      <MultiFileDiff
+        oldFile={oldFile}
+        newFile={newFileContents}
+        options={COMPACT_DIFF_OPTIONS}
+        className="block min-w-0 max-w-full"
+      />
+    </DiffFrame>
+  );
+}
+
+export function PatchDiffView({
+  patch,
+  filename,
+  previousFilename,
+  status,
+  className,
+}: PatchDiffViewProps) {
+  const normalizedPatch = useMemo(
+    () =>
+      patch
+        ? normalizePatchForPierre({
+            patch,
+            filename,
+            previousFilename,
+            status,
+          })
+        : null,
+    [filename, patch, previousFilename, status],
+  );
+
+  if (!normalizedPatch) {
+    return <DiffFallback>Diff preview unavailable for this file.</DiffFallback>;
+  }
+
+  return (
+    <DiffFrame className={className}>
+      <PatchDiff
+        patch={normalizedPatch}
+        options={COMPACT_DIFF_OPTIONS}
+        className="block min-w-0 max-w-full"
+      />
+    </DiffFrame>
+  );
+}
+
+function DiffFrame({
+  children,
+  className,
+  header,
+}: {
+  children: ReactNode;
+  className?: string;
+  header?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 max-w-full overflow-hidden rounded-md bg-background/70 font-mono text-[10px] leading-relaxed ring-1 ring-border",
+        className,
+      )}
+    >
+      {header ? (
+        <div className="flex items-center gap-3 border-b border-border px-2 py-1 text-[10px] uppercase text-muted-foreground">
+          {header}
+        </div>
+      ) : null}
+      <div className="min-w-0 max-w-full overflow-hidden">{children}</div>
     </div>
   );
 }
 
-type DiffRow = { kind: "add" | "remove" | "context"; text: string };
-
-function buildRows(previous: string, next: string): DiffRow[] {
-  const parts = diffLines(previous, next);
-  const rows: DiffRow[] = [];
-  for (const part of parts) {
-    const kind: DiffRow["kind"] = part.added
-      ? "add"
-      : part.removed
-        ? "remove"
-        : "context";
-    const lines = stripTrailingNewline(part.value).split("\n");
-    for (const line of lines) rows.push({ kind, text: line });
-  }
-  return rows;
+function DiffFallback({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded bg-background/60 px-3 py-2 text-[11px] text-muted-foreground ring-1 ring-border">
+      {children}
+    </div>
+  );
 }
 
-function stripTrailingNewline(s: string): string {
-  return s.endsWith("\n") ? s.slice(0, -1) : s;
+function fileContents(
+  filename: string,
+  contents: string,
+  side: "old" | "new",
+): FileContents {
+  return {
+    name: filename,
+    contents,
+    cacheKey: `${side}:${filename}:${contents.length}:${hashString(contents)}`,
+  };
 }
 
-function countChanges(rows: DiffRow[]): { added: number; removed: number } {
-  let added = 0;
-  let removed = 0;
-  for (const r of rows) {
-    if (r.kind === "add") added++;
-    else if (r.kind === "remove") removed++;
+function normalizePatchForPierre({
+  patch,
+  filename,
+  previousFilename,
+  status,
+}: {
+  patch: string;
+  filename: string;
+  previousFilename?: string | null;
+  status?: string;
+}): string {
+  if (/^diff --git /m.test(patch) || /^---\s/m.test(patch)) {
+    return patch;
   }
-  return { added, removed };
+
+  const currentPath = normalizePatchPath(filename);
+  const oldPath = normalizePatchPath(previousFilename ?? filename);
+  const isAdded = status === "added";
+  const isDeleted = status === "removed" || status === "deleted";
+  const oldHeader = isAdded ? "/dev/null" : `a/${oldPath}`;
+  const newHeader = isDeleted ? "/dev/null" : `b/${currentPath}`;
+
+  return [
+    `diff --git a/${oldPath} b/${currentPath}`,
+    `--- ${oldHeader}`,
+    `+++ ${newHeader}`,
+    patch,
+  ].join("\n");
+}
+
+function normalizePatchPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function hashString(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = Math.imul(31, hash) + value.charCodeAt(i);
+  }
+  return String(hash >>> 0);
 }

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -60,7 +60,7 @@ const COMPACT_DIFF_OPTIONS = {
       --diffs-selection-base: var(--primary);
       --diffs-gap-block: 0;
       --diffs-gap-inline: 0;
-      --diffs-scrollbar-gutter-override: 6px;
+      --diffs-scrollbar-gutter-override: 10px;
       --diffs-min-number-column-width: 4ch;
     }
 
@@ -69,30 +69,23 @@ const COMPACT_DIFF_OPTIONS = {
       background: transparent;
       overflow-x: auto;
       overflow-y: clip;
-      scrollbar-width: thin;
       scrollbar-color: color-mix(in oklch, var(--foreground) 16%, transparent) transparent;
     }
 
     [data-code]::-webkit-scrollbar {
-      width: 6px;
-      height: 6px;
-    }
-
-    [data-code]::-webkit-scrollbar-button {
-      width: 0;
-      height: 0;
-      display: none;
+      width: 10px;
+      height: 10px;
     }
 
     [data-code]::-webkit-scrollbar-thumb {
-      border: 2px solid transparent;
+      border: 3px solid transparent;
       border-radius: 999px;
       background: color-mix(in oklch, var(--foreground) 16%, transparent);
       background-clip: padding-box;
     }
 
     [data-code]::-webkit-scrollbar-thumb:hover {
-      border: 2px solid transparent;
+      border: 3px solid transparent;
       background: color-mix(in oklch, var(--foreground) 24%, transparent);
       background-clip: padding-box;
     }
@@ -120,7 +113,8 @@ const COMPACT_DIFF_OPTIONS = {
     }
 
     [data-separator="line-info-basic"] {
-      min-height: 1.5rem;
+      height: 1.125rem;
+      min-height: 1.125rem;
     }
 
     [data-separator="line-info-basic"] [data-separator-wrapper] {
@@ -128,6 +122,12 @@ const COMPACT_DIFF_OPTIONS = {
       color: var(--muted-foreground);
       background-color: color-mix(in oklch, var(--muted) 50%, transparent);
       font-size: 10px;
+      line-height: 1.125rem;
+    }
+
+    [data-separator="line-info-basic"] [data-separator-content] {
+      height: 1.125rem;
+      padding-inline: 0.5ch;
     }
   `,
 } satisfies NonNullable<DiffBasePropsReact<undefined>["options"]>;

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -42,7 +42,9 @@ const COMPACT_DIFF_OPTIONS = {
     :host {
       display: block;
       min-width: 0;
-      max-width: 100%;
+      width: 100%;
+      min-width: max-content;
+      max-width: none;
       color: var(--foreground);
       background: transparent;
       font-family: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -65,46 +67,29 @@ const COMPACT_DIFF_OPTIONS = {
     }
 
     [data-code] {
-      max-width: 100%;
+      width: 100%;
+      min-width: max-content;
+      max-width: none;
       background: transparent;
-      overflow-x: auto;
-      overflow-y: clip;
-      scrollbar-color: color-mix(in oklch, var(--foreground) 16%, transparent) transparent;
+      overflow: visible;
+      padding-bottom: 0;
     }
 
     [data-code]::-webkit-scrollbar {
-      width: 10px;
-      height: 10px;
-    }
-
-    [data-code]::-webkit-scrollbar-button {
+      display: none;
       width: 0;
       height: 0;
-      display: none;
-    }
-
-    [data-code]::-webkit-scrollbar-thumb {
-      border: 3px solid transparent;
-      border-radius: 999px;
-      background-color: color-mix(in oklch, var(--foreground) 16%, transparent);
-      background-clip: padding-box;
-    }
-
-    [data-code]::-webkit-scrollbar-thumb:hover {
-      border: 3px solid transparent;
-      background-color: color-mix(in oklch, var(--foreground) 24%, transparent);
-      background-clip: padding-box;
-    }
-
-    [data-code]::-webkit-scrollbar-track,
-    [data-code]::-webkit-scrollbar-corner {
-      background: transparent;
     }
 
     [data-gutter] {
       z-index: 5;
       background-color: var(--diffs-bg);
       box-shadow: 1px 0 0 var(--border);
+    }
+
+    [data-overflow="scroll"] [data-gutter] {
+      position: relative;
+      left: auto;
     }
 
     [data-line],
@@ -224,7 +209,9 @@ function DiffFrame({
         className,
       )}
     >
-      <div className="min-w-0 max-w-full overflow-hidden">{children}</div>
+      <div className="anton-diff-scrollbar min-w-0 max-w-full overflow-x-auto overflow-y-hidden">
+        {children}
+      </div>
     </div>
   );
 }

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -263,18 +263,20 @@ function ChangesView({
               type="button"
               onClick={() => onSelect(file.filename)}
               className={cn(
-                "grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
                 selected?.filename === file.filename
                   ? "bg-accent/70"
                   : "hover:bg-accent/40",
               )}
             >
+              <FileStatusBadge status={file.status} />
               <span className="min-w-0">
                 <span className="block truncate font-medium">{file.filename}</span>
-                <span className="font-mono text-[10px] text-muted-foreground">
-                  {file.status}
-                  {file.previousFilename ? ` from ${file.previousFilename}` : ""}
-                </span>
+                {file.previousFilename ? (
+                  <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                    from {file.previousFilename}
+                  </span>
+                ) : null}
               </span>
               <span className="font-mono text-[10px] tabular-nums">
                 <span className="text-emerald-500">+{file.additions}</span>
@@ -288,6 +290,63 @@ function ChangesView({
       {selected ? <PatchView file={selected} /> : null}
     </div>
   );
+}
+
+function FileStatusBadge({ status }: { status: string }) {
+  const meta = fileStatusMeta(status);
+  return (
+    <span
+      className={cn(
+        "inline-flex size-4 items-center justify-center rounded-sm font-mono text-[10px] font-semibold ring-1",
+        meta.className,
+      )}
+      title={meta.label}
+      aria-label={meta.label}
+    >
+      {meta.char}
+    </span>
+  );
+}
+
+function fileStatusMeta(status: string): {
+  char: string;
+  label: string;
+  className: string;
+} {
+  switch (status) {
+    case "added":
+      return {
+        char: "A",
+        label: "Added",
+        className: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
+      };
+    case "modified":
+    case "changed":
+      return {
+        char: "M",
+        label: "Modified",
+        className: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+      };
+    case "removed":
+    case "deleted":
+      return {
+        char: "D",
+        label: "Deleted",
+        className: "bg-destructive/15 text-red-300 ring-destructive/30",
+      };
+    case "renamed":
+      return {
+        char: "R",
+        label: "Renamed",
+        className: "bg-sky-500/15 text-sky-300 ring-sky-500/30",
+      };
+    default:
+      return {
+        char: status.slice(0, 1).toUpperCase() || "?",
+        label: status || "Unknown",
+        className: "bg-secondary text-muted-foreground ring-border",
+      };
+  }
 }
 
 function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -48,7 +48,7 @@ export function PullRequestPanel({
     null;
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
       <section className="border-b border-border px-3 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
@@ -65,7 +65,7 @@ export function PullRequestPanel({
               <span className="rounded bg-secondary px-1.5 py-0.5">
                 {pullRequest.baseBranch}
               </span>
-              <span>←</span>
+              <span>&lt;-</span>
               <span className="rounded bg-secondary px-1.5 py-0.5">
                 {pullRequest.headBranch}
               </span>
@@ -115,7 +115,7 @@ export function PullRequestPanel({
         ) : null}
       </section>
 
-      <Tabs defaultValue="changes" className="gap-0">
+      <Tabs defaultValue="changes" className="min-w-0 gap-0">
         <div className="border-b border-border px-2 py-1.5">
           <TabsList className="gap-1">
             <TabsTrigger value="changes" className="h-6 px-2 py-0 text-[11px]">
@@ -132,7 +132,7 @@ export function PullRequestPanel({
             </TabsTrigger>
           </TabsList>
         </div>
-        <TabsContent value="changes" className="m-0">
+        <TabsContent value="changes" className="m-0 min-w-0">
           <ChangesView
             files={pullRequest.files}
             selected={selected}
@@ -255,8 +255,8 @@ function ChangesView({
   }
 
   return (
-    <div className="grid min-h-0 grid-rows-[auto_1fr]">
-      <ol className="max-h-56 overflow-y-auto border-b border-border px-2 py-2">
+    <div className="grid min-h-0 min-w-0 grid-rows-[auto_1fr] overflow-hidden">
+      <ol className="max-h-56 min-w-0 overflow-y-auto border-b border-border px-2 py-2">
         {files.map((file) => (
           <li key={file.filename}>
             <button
@@ -300,22 +300,24 @@ function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
     );
   }
   return (
-    <div className="overflow-x-auto p-2">
-      <pre className="rounded-md bg-background/70 py-2 font-mono text-[10px] leading-relaxed ring-1 ring-border">
-        {lines.map((line, index) => (
-          <div
-            key={`${index}:${line}`}
-            className={cn(
-              "min-w-max px-2 whitespace-pre",
-              line.startsWith("+") && "bg-emerald-500/10 text-emerald-300",
-              line.startsWith("-") && "bg-destructive/10 text-red-300",
-              line.startsWith("@@") && "bg-sky-500/10 text-sky-300",
-            )}
-          >
-            {line || " "}
-          </div>
-        ))}
-      </pre>
+    <div className="min-w-0 max-w-full overflow-hidden p-2">
+      <div className="max-w-full overflow-x-auto rounded-md bg-background/70 font-mono text-[10px] leading-relaxed ring-1 ring-border">
+        <pre className="m-0 w-max min-w-full py-2">
+          {lines.map((line, index) => (
+            <div
+              key={`${index}:${line}`}
+              className={cn(
+                "w-max min-w-full px-2 whitespace-pre",
+                line.startsWith("+") && "bg-emerald-500/10 text-emerald-300",
+                line.startsWith("-") && "bg-destructive/10 text-red-300",
+                line.startsWith("@@") && "bg-sky-500/10 text-sky-300",
+              )}
+            >
+              {line || " "}
+            </div>
+          ))}
+        </pre>
+      </div>
     </div>
   );
 }
@@ -340,7 +342,7 @@ function ChecksView({
         <meta.Icon className={cn("size-3.5", meta.className)} />
         <span className="font-medium">{meta.label}</span>
         <span className="text-muted-foreground">
-          {pullRequest.checks.passed} passed · {pullRequest.checks.pending} pending ·{" "}
+          {pullRequest.checks.passed} passed / {pullRequest.checks.pending} pending /{" "}
           {pullRequest.checks.failed} failed
         </span>
       </div>

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   AlertCircle,
   CheckCircle2,
@@ -27,6 +27,7 @@ import type {
   ProjectPullRequestFileSummary,
   ProjectPullRequestSummary,
 } from "@/src/lib/api-types";
+import { PatchDiffView } from "./diff-view";
 
 export function PullRequestPanel({
   pullRequest,
@@ -350,33 +351,14 @@ function fileStatusMeta(status: string): {
 }
 
 function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
-  const lines = useMemo(() => file.patch?.split("\n") ?? [], [file.patch]);
-  if (!file.patch) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        Diff preview unavailable for this file.
-      </div>
-    );
-  }
   return (
     <div className="min-w-0 max-w-full overflow-hidden p-2">
-      <div className="max-w-full overflow-x-auto rounded-md bg-background/70 font-mono text-[10px] leading-relaxed ring-1 ring-border">
-        <pre className="m-0 w-max min-w-full py-2">
-          {lines.map((line, index) => (
-            <div
-              key={`${index}:${line}`}
-              className={cn(
-                "w-max min-w-full px-2 whitespace-pre",
-                line.startsWith("+") && "bg-emerald-500/10 text-emerald-300",
-                line.startsWith("-") && "bg-destructive/10 text-red-300",
-                line.startsWith("@@") && "bg-sky-500/10 text-sky-300",
-              )}
-            >
-              {line || " "}
-            </div>
-          ))}
-        </pre>
-      </div>
+      <PatchDiffView
+        patch={file.patch}
+        filename={file.filename}
+        previousFilename={file.previousFilename}
+        status={file.status}
+      />
     </div>
   );
 }

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -1,0 +1,475 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  FileText,
+  GitCommit,
+  GitPullRequest,
+  MessageSquare,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectGitStatusSummary,
+  ProjectPullRequestFileSummary,
+  ProjectPullRequestSummary,
+} from "@/src/lib/api-types";
+
+export function PullRequestPanel({
+  pullRequest,
+  gitStatus,
+  loading,
+  error,
+  onRefresh,
+}: {
+  pullRequest: ProjectPullRequestSummary;
+  gitStatus: ProjectGitStatusSummary | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const selected =
+    pullRequest.files.find((file) => file.filename === selectedFile) ??
+    pullRequest.files[0] ??
+    null;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <section className="border-b border-border px-3 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+              <StateBadge pullRequest={pullRequest} />
+              <span className="truncate text-muted-foreground">
+                PR #{pullRequest.number}
+              </span>
+            </div>
+            <h2 className="mt-1 line-clamp-2 text-sm font-semibold leading-5">
+              {pullRequest.title}
+            </h2>
+            <div className="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
+              <span className="rounded bg-secondary px-1.5 py-0.5">
+                {pullRequest.baseBranch}
+              </span>
+              <span>←</span>
+              <span className="rounded bg-secondary px-1.5 py-0.5">
+                {pullRequest.headBranch}
+              </span>
+              {gitStatus?.dirtyCount ? (
+                <span className="text-amber-500">
+                  {gitStatus.dirtyCount} dirty
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              onClick={onRefresh}
+              disabled={loading}
+              aria-label="Refresh pull request"
+              title="Refresh pull request"
+            >
+              <RefreshCw className={cn(loading && "animate-spin")} />
+            </Button>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              asChild
+              aria-label="Open pull request on GitHub"
+              title="Open pull request on GitHub"
+            >
+              <a href={pullRequest.htmlUrl} target="_blank" rel="noreferrer">
+                <ExternalLink />
+              </a>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-3 grid grid-cols-3 gap-2 text-[11px]">
+          <Metric label="Files" value={pullRequest.changedFiles} />
+          <Metric label="Add" value={`+${pullRequest.additions}`} tone="add" />
+          <Metric label="Del" value={`-${pullRequest.deletions}`} tone="delete" />
+        </div>
+        {error ? (
+          <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+            {error}
+          </div>
+        ) : null}
+      </section>
+
+      <Tabs defaultValue="changes" className="gap-0">
+        <div className="border-b border-border px-2 py-1.5">
+          <TabsList className="gap-1">
+            <TabsTrigger value="changes" className="h-6 px-2 py-0 text-[11px]">
+              Changes
+            </TabsTrigger>
+            <TabsTrigger value="discussion" className="h-6 px-2 py-0 text-[11px]">
+              Discussion
+            </TabsTrigger>
+            <TabsTrigger value="commits" className="h-6 px-2 py-0 text-[11px]">
+              Commits
+            </TabsTrigger>
+            <TabsTrigger value="checks" className="h-6 px-2 py-0 text-[11px]">
+              Checks
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <TabsContent value="changes" className="m-0">
+          <ChangesView
+            files={pullRequest.files}
+            selected={selected}
+            onSelect={setSelectedFile}
+          />
+        </TabsContent>
+        <TabsContent value="discussion" className="m-0">
+          <SummaryList
+            rows={[
+              {
+                icon: MessageSquare,
+                label: "Comments",
+                value: pullRequest.comments,
+              },
+              {
+                icon: FileText,
+                label: "Review comments",
+                value: pullRequest.reviewComments,
+              },
+            ]}
+          />
+        </TabsContent>
+        <TabsContent value="commits" className="m-0">
+          <SummaryList
+            rows={[
+              { icon: GitCommit, label: "Commits", value: pullRequest.commits },
+              {
+                icon: GitCommit,
+                label: "Head",
+                value: pullRequest.headSha.slice(0, 7),
+              },
+            ]}
+          />
+        </TabsContent>
+        <TabsContent value="checks" className="m-0">
+          <ChecksView pullRequest={pullRequest} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export function PullRequestEmptyPanel({
+  gitStatus,
+  loading,
+  error,
+  onRefresh,
+}: {
+  gitStatus: ProjectGitStatusSummary | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <section className="border-b border-border px-3 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border">
+              <GitPullRequest className="size-3" />
+              No PR
+            </div>
+            <h2 className="mt-2 text-sm font-semibold">Pull request</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {emptyPullRequestMessage(gitStatus)}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            onClick={onRefresh}
+            disabled={loading}
+            aria-label="Refresh pull request"
+            title="Refresh pull request"
+          >
+            <RefreshCw className={cn(loading && "animate-spin")} />
+          </Button>
+        </div>
+        {gitStatus ? (
+          <div className="mt-3 grid grid-cols-2 gap-2 text-[11px]">
+            <Metric label="Branch" value={gitStatus.branch ?? "detached"} />
+            <Metric label="Dirty" value={gitStatus.dirtyCount} />
+          </div>
+        ) : null}
+        {error ? (
+          <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+            {error}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function emptyPullRequestMessage(gitStatus: ProjectGitStatusSummary | null): string {
+  if (!gitStatus) return "Loading current branch status.";
+  if (!gitStatus.branch) return "The project is not on a named local branch.";
+  if (gitStatus.isDefaultBranch) {
+    return `The current branch is ${gitStatus.defaultBranch}; PR lookup starts on non-default branches.`;
+  }
+  return `No GitHub pull request matches ${gitStatus.branch}.`;
+}
+
+function ChangesView({
+  files,
+  selected,
+  onSelect,
+}: {
+  files: ProjectPullRequestFileSummary[];
+  selected: ProjectPullRequestFileSummary | null;
+  onSelect: (filename: string) => void;
+}) {
+  if (files.length === 0) {
+    return (
+      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+        No changed files reported.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-0 grid-rows-[auto_1fr]">
+      <ol className="max-h-56 overflow-y-auto border-b border-border px-2 py-2">
+        {files.map((file) => (
+          <li key={file.filename}>
+            <button
+              type="button"
+              onClick={() => onSelect(file.filename)}
+              className={cn(
+                "grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                selected?.filename === file.filename
+                  ? "bg-accent/70"
+                  : "hover:bg-accent/40",
+              )}
+            >
+              <span className="min-w-0">
+                <span className="block truncate font-medium">{file.filename}</span>
+                <span className="font-mono text-[10px] text-muted-foreground">
+                  {file.status}
+                  {file.previousFilename ? ` from ${file.previousFilename}` : ""}
+                </span>
+              </span>
+              <span className="font-mono text-[10px] tabular-nums">
+                <span className="text-emerald-500">+{file.additions}</span>
+                <span className="mx-1 text-muted-foreground/50">/</span>
+                <span className="text-destructive">-{file.deletions}</span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ol>
+      {selected ? <PatchView file={selected} /> : null}
+    </div>
+  );
+}
+
+function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
+  const lines = useMemo(() => file.patch?.split("\n") ?? [], [file.patch]);
+  if (!file.patch) {
+    return (
+      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+        Diff preview unavailable for this file.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto p-2">
+      <pre className="rounded-md bg-background/70 py-2 font-mono text-[10px] leading-relaxed ring-1 ring-border">
+        {lines.map((line, index) => (
+          <div
+            key={`${index}:${line}`}
+            className={cn(
+              "min-w-max px-2 whitespace-pre",
+              line.startsWith("+") && "bg-emerald-500/10 text-emerald-300",
+              line.startsWith("-") && "bg-destructive/10 text-red-300",
+              line.startsWith("@@") && "bg-sky-500/10 text-sky-300",
+            )}
+          >
+            {line || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+function ChecksView({
+  pullRequest,
+}: {
+  pullRequest: ProjectPullRequestSummary;
+}) {
+  const meta = checkStateMeta(pullRequest.checks.state);
+  if (pullRequest.checks.total === 0) {
+    return (
+      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+        No check runs reported.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-3 py-3">
+      <div className="mb-3 flex items-center gap-2 text-xs">
+        <meta.Icon className={cn("size-3.5", meta.className)} />
+        <span className="font-medium">{meta.label}</span>
+        <span className="text-muted-foreground">
+          {pullRequest.checks.passed} passed · {pullRequest.checks.pending} pending ·{" "}
+          {pullRequest.checks.failed} failed
+        </span>
+      </div>
+      <ol className="grid gap-1.5">
+        {pullRequest.checks.runs.map((run) => {
+          const runMeta = runStateMeta(run);
+          return (
+            <li key={`${run.name}:${run.htmlUrl ?? ""}`}>
+              <a
+                href={run.htmlUrl ?? pullRequest.htmlUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="grid grid-cols-[0.875rem_1fr] gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent/50"
+              >
+                <runMeta.Icon className={cn("mt-0.5 size-3.5", runMeta.className)} />
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">{run.name}</span>
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {run.conclusion ?? run.status}
+                  </span>
+                </span>
+              </a>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+function SummaryList({
+  rows,
+}: {
+  rows: { icon: typeof MessageSquare; label: string; value: string | number }[];
+}) {
+  return (
+    <div className="px-3 py-3">
+      <dl className="grid gap-2">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="grid grid-cols-[0.875rem_1fr_auto] items-center gap-2 rounded-md bg-background/45 px-2 py-2 text-xs ring-1 ring-border"
+          >
+            <row.icon className="size-3.5 text-muted-foreground" />
+            <dt className="text-muted-foreground">{row.label}</dt>
+            <dd className="font-mono text-foreground">{row.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function StateBadge({
+  pullRequest,
+}: {
+  pullRequest: ProjectPullRequestSummary;
+}) {
+  const label = pullRequest.merged
+    ? "Merged"
+    : pullRequest.state === "open"
+      ? "Open"
+      : "Closed";
+  const className = pullRequest.merged
+    ? "bg-purple-500/15 text-purple-300 ring-purple-500/30"
+    : pullRequest.state === "open"
+      ? "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30"
+      : "bg-secondary text-muted-foreground ring-border";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] ring-1",
+        className,
+      )}
+    >
+      <GitPullRequest className="size-3" />
+      {label}
+    </span>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  tone?: "add" | "delete";
+}) {
+  return (
+    <div className="rounded-md bg-background/45 px-2 py-1.5 ring-1 ring-border">
+      <div className="text-[10px] uppercase text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "font-mono text-xs font-semibold",
+          tone === "add" && "text-emerald-400",
+          tone === "delete" && "text-destructive",
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function checkStateMeta(state: ProjectPullRequestSummary["checks"]["state"]) {
+  switch (state) {
+    case "success":
+      return { Icon: CheckCircle2, label: "Checks passed", className: "text-emerald-400" };
+    case "failure":
+      return { Icon: XCircle, label: "Checks failed", className: "text-destructive" };
+    case "error":
+      return { Icon: AlertCircle, label: "Checks errored", className: "text-destructive" };
+    case "pending":
+      return { Icon: Clock, label: "Checks pending", className: "text-amber-400" };
+    case "unknown":
+      return { Icon: AlertCircle, label: "Checks unknown", className: "text-muted-foreground" };
+  }
+}
+
+function runStateMeta(
+  run: ProjectPullRequestSummary["checks"]["runs"][number],
+) {
+  if (run.status !== "completed") {
+    return { Icon: Clock, className: "text-amber-400" };
+  }
+  if (["success", "neutral", "skipped"].includes(run.conclusion ?? "")) {
+    return { Icon: CheckCircle2, className: "text-emerald-400" };
+  }
+  return { Icon: XCircle, className: "text-destructive" };
+}

--- a/components/features/run-trace/tool-card.tsx
+++ b/components/features/run-trace/tool-card.tsx
@@ -161,6 +161,7 @@ function EditFileBody({
         <DiffView
           previous={output.previousContent ?? ""}
           next={output.nextContent ?? ""}
+          filename={output.path ?? relPath ?? undefined}
         />
       </div>
     );
@@ -218,6 +219,7 @@ function WriteFileBody({
             previous={output.previousContent ?? ""}
             next={nextContent}
             newFile={output.existed === false}
+            filename={output.path ?? relPath ?? undefined}
           />
         )}
       </div>

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -45,6 +45,7 @@ import { TodoCard } from "./todo-card";
 import { getSessionTodoSnapshots } from "./trace-data";
 import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
 import { getJson } from "@/src/lib/client-fetch";
+import { PROJECT_GIT_CHANGED_EVENT } from "@/components/features/projects/hooks";
 import type {
   ProjectGitStatusSummary,
   ProjectPullRequestSummary,
@@ -470,9 +471,20 @@ function useProjectPullRequest(project: ProjectSummary | null): {
 
     void load(true);
     const interval = window.setInterval(() => void load(false), 15000);
+    const onProjectGitChanged = (event: Event) => {
+      if (
+        event instanceof CustomEvent &&
+        typeof event.detail === "string" &&
+        event.detail === project.id
+      ) {
+        void load(true);
+      }
+    };
+    window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     return () => {
       cancelled = true;
       window.clearInterval(interval);
+      window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     };
   }, [project, refreshKey]);
 

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   CheckCircle2,
   FileText,
+  GitBranch,
   ListTodo,
   Maximize2,
   Minimize2,
@@ -42,15 +43,24 @@ import { LiveTerminalOutput } from "./live-terminal";
 import { ApprovalDetails } from "./approval-details";
 import { TodoCard } from "./todo-card";
 import { getSessionTodoSnapshots } from "./trace-data";
+import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
+import { getJson } from "@/src/lib/client-fetch";
+import type {
+  ProjectGitStatusSummary,
+  ProjectPullRequestSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
 
 export type WorklogEntry = ToolTraceEntry;
-type SidebarTab = "worklog" | "plans" | "todos";
+type SidebarTab = "worklog" | "plans" | "todos" | "pr";
 
 interface WorklogProps {
   messages: AntonUIMessage[];
   onApproval: ChatAddToolApproveResponseFunction;
+  project: ProjectSummary | null;
   className?: string;
   onClose?: () => void;
+  visible?: boolean;
   expanded?: boolean;
   onExpandToggle?: () => void;
 }
@@ -58,14 +68,20 @@ interface WorklogProps {
 export function Worklog({
   messages,
   onApproval,
+  project,
   className,
   onClose,
+  visible = true,
   expanded = false,
   onExpandToggle,
 }: WorklogProps) {
   const [tabs, setTabs] = useState<SidebarTab[]>(["worklog"]);
   const [activeTab, setActiveTab] = useState<SidebarTab | null>("worklog");
   const [menuOpen, setMenuOpen] = useState(false);
+  const [lastAutoPr, setLastAutoPr] = useState<number | null>(null);
+  const prState = useProjectPullRequest(project);
+  const hasGithubProject = project?.provider === "github" && project.status === "ready";
+  const pullRequestNumber = prState.pullRequest?.number ?? null;
 
   const addTab = (tab: SidebarTab) => {
     setTabs((current) => (current.includes(tab) ? current : [...current, tab]));
@@ -84,7 +100,30 @@ export function Worklog({
     setMenuOpen(false);
   };
 
-  const availableTabs = SIDEBAR_TABS.filter((tab) => !tabs.includes(tab.id));
+  useEffect(() => {
+    if (pullRequestNumber === null && !hasGithubProject) {
+      queueMicrotask(() => {
+        setTabs((current) => current.filter((tab) => tab !== "pr"));
+        setActiveTab((current) => (current === "pr" ? "worklog" : current));
+        setLastAutoPr(null);
+      });
+      return;
+    }
+    if (pullRequestNumber === null || !visible || lastAutoPr === pullRequestNumber) {
+      return;
+    }
+    queueMicrotask(() => {
+      setTabs((current) => (current.includes("pr") ? current : [...current, "pr"]));
+      setActiveTab("pr");
+      setLastAutoPr(pullRequestNumber);
+    });
+  }, [hasGithubProject, lastAutoPr, pullRequestNumber, visible]);
+
+  const availableTabs = SIDEBAR_TABS.filter(
+    (tab) =>
+      !tabs.includes(tab.id) &&
+      (tab.id !== "pr" || hasGithubProject || prState.pullRequest !== null),
+  );
 
   return (
     <aside
@@ -98,7 +137,7 @@ export function Worklog({
         <header className="flex h-10 shrink-0 items-center justify-between border-b border-border px-2">
           <div className="flex min-w-0 items-center gap-1">
             {tabs.map((tab) => {
-              const meta = tabMeta(tab);
+              const meta = tabMeta(tab, prState.pullRequest);
               return (
                 <div
                   key={tab}
@@ -150,7 +189,7 @@ export function Worklog({
               {menuOpen && availableTabs.length > 0 && (
                 <div className="absolute right-0 top-full z-50 mt-1 w-36 rounded-md bg-popover p-1 text-xs text-popover-foreground shadow-lg ring-1 ring-border">
                   {availableTabs.map((tab) => {
-                    const meta = tabMeta(tab.id);
+                    const meta = tabMeta(tab.id, prState.pullRequest);
                     return (
                       <button
                         key={tab.id}
@@ -198,6 +237,21 @@ export function Worklog({
           <PlansPanel messages={messages} />
         ) : activeTab === "todos" ? (
           <TodosPanel messages={messages} />
+        ) : activeTab === "pr" && prState.pullRequest ? (
+          <PullRequestPanel
+            pullRequest={prState.pullRequest}
+            gitStatus={prState.gitStatus}
+            loading={prState.loading}
+            error={prState.error}
+            onRefresh={prState.refresh}
+          />
+        ) : activeTab === "pr" && hasGithubProject ? (
+          <PullRequestEmptyPanel
+            gitStatus={prState.gitStatus}
+            loading={prState.loading}
+            error={prState.error}
+            onRefresh={prState.refresh}
+          />
         ) : (
           <EmptyTabsPanel />
         )}
@@ -210,14 +264,20 @@ const SIDEBAR_TABS = [
   { id: "worklog", label: "Worklog", Icon: TerminalSquare },
   { id: "plans", label: "Plans", Icon: FileText },
   { id: "todos", label: "Todos", Icon: ListTodo },
+  { id: "pr", label: "PR", Icon: GitBranch },
 ] as const satisfies readonly {
   id: SidebarTab;
   label: string;
   Icon: typeof TerminalSquare;
 }[];
 
-function tabMeta(tab: SidebarTab) {
-  return SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
+function tabMeta(
+  tab: SidebarTab,
+  pullRequest: ProjectPullRequestSummary | null,
+) {
+  const meta = SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
+  if (tab !== "pr" || !pullRequest) return meta;
+  return { ...meta, label: `PR #${pullRequest.number}` };
 }
 
 function EmptyTabsPanel() {
@@ -344,6 +404,85 @@ function TodosPanel({ messages }: { messages: AntonUIMessage[] }) {
 
 function firstLine(value: string): string {
   return value.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "Markdown plan";
+}
+
+function useProjectPullRequest(project: ProjectSummary | null): {
+  gitStatus: ProjectGitStatusSummary | null;
+  pullRequest: ProjectPullRequestSummary | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+} {
+  const [gitStatus, setGitStatus] = useState<ProjectGitStatusSummary | null>(null);
+  const [pullRequest, setPullRequest] = useState<ProjectPullRequestSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (
+      !project ||
+      project.provider !== "github" ||
+      project.status !== "ready"
+    ) {
+      queueMicrotask(() => {
+        setGitStatus(null);
+        setPullRequest(null);
+        setError(null);
+        setLoading(false);
+      });
+      return;
+    }
+
+    let cancelled = false;
+    const load = async (showLoading: boolean) => {
+      if (showLoading) setLoading(true);
+      try {
+        const statusData = await getJson<{ status: ProjectGitStatusSummary }>(
+          `/api/projects/${project.id}/git/status`,
+        );
+        if (cancelled) return;
+        setGitStatus(statusData.status);
+        if (!statusData.status.branch || statusData.status.isDefaultBranch) {
+          setPullRequest(null);
+          setError(null);
+          return;
+        }
+        const prData = await getJson<{
+          pullRequest: ProjectPullRequestSummary | null;
+        }>(
+          `/api/projects/${project.id}/github/pull-request?branch=${encodeURIComponent(
+            statusData.status.branch,
+          )}`,
+        );
+        if (cancelled) return;
+        setPullRequest(prData.pullRequest);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setPullRequest(null);
+          setError(err instanceof Error ? err.message : "Failed to load PR");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load(true);
+    const interval = window.setInterval(() => void load(false), 15000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [project, refreshKey]);
+
+  return {
+    gitStatus,
+    pullRequest,
+    loading,
+    error,
+    refresh: () => setRefreshKey((current) => current + 1),
+  };
 }
 
 function WorklogRow({

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -641,11 +641,13 @@ function WorklogDetail({
           previous={(entry.output as WriteFileOkOutput).previousContent ?? ""}
           next={pickString(entry.input, "content") ?? ""}
           newFile={(entry.output as WriteFileOkOutput).existed === false}
+          filename={pickString(entry.input, "path")}
         />
       ) : showEditDiff ? (
         <DiffView
           previous={editOutput?.previousContent ?? ""}
           next={editOutput?.nextContent ?? ""}
+          filename={pickString(entry.input, "path")}
         />
       ) : entry.name === "bash" && entry.activity?.status === "running" && entry.activity?.toolCallId ? (
         <LiveTerminalOutput

--- a/components/features/settings/hooks.ts
+++ b/components/features/settings/hooks.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import type {
   GitHubInstallationSummary,
   GitHubRepositorySummary,
+  ProjectGitStatusSummary,
   ProjectSummary,
   WorkspaceSettingsSummary,
 } from "@/src/lib/api-types";
@@ -27,6 +28,9 @@ export function useWorkspaceSettings(
   const [installationFilter, setInstallationFilter] = useState("all");
   const [repositories, setRepositories] = useState<GitHubRepositorySummary[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [projectGitStatuses, setProjectGitStatuses] = useState<
+    Record<string, ProjectGitStatusSummary>
+  >({});
   const [localPathDraft, setLocalPathDraft] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -59,6 +63,25 @@ export function useWorkspaceSettings(
           "",
       );
       setProjects(projectsData.projects);
+      const gitStatuses = await Promise.all(
+        projectsData.projects
+          .filter((project) => project.status === "ready")
+          .map((project) =>
+            getJson<{ status: ProjectGitStatusSummary }>(
+              `/api/projects/${project.id}/git/status`,
+            )
+              .then((data) => [project.id, data.status] as const)
+              .catch(() => null),
+          ),
+      );
+      setProjectGitStatuses(
+        Object.fromEntries(
+          gitStatuses.filter(
+            (entry): entry is readonly [string, ProjectGitStatusSummary] =>
+              entry !== null,
+          ),
+        ),
+      );
       setInstallations(reposData?.installations ?? []);
       setRepositories(reposData?.repositories ?? []);
       setInstallationFilter((current) => {
@@ -205,6 +228,7 @@ export function useWorkspaceSettings(
     repositories,
     filteredRepositories,
     projects,
+    projectGitStatuses,
     readyProjects: projects.filter((project) => project.status === "ready"),
     loading,
     saving,

--- a/components/features/settings/workspace-settings-panel.tsx
+++ b/components/features/settings/workspace-settings-panel.tsx
@@ -56,6 +56,7 @@ export function WorkspaceSettingsPanel({
     repositories,
     filteredRepositories,
     readyProjects,
+    projectGitStatuses,
     loading,
     saving,
     cloningRepoId,
@@ -138,16 +139,19 @@ export function WorkspaceSettingsPanel({
           <EmptyState message="No projects yet." />
         ) : (
           <ul className="grid gap-2">
-            {readyProjects.map((project) => (
-              <li
-                key={project.id}
-                className={cn(
-                  "flex items-start gap-2 rounded-md p-2.5 ring-1 transition-colors",
-                  activeProjectId === project.id
-                    ? "bg-primary/10 ring-primary/50"
-                    : "bg-background/45 ring-border",
-                )}
-              >
+            {readyProjects.map((project) => {
+              const currentBranch =
+                projectGitStatuses[project.id]?.branch ?? project.defaultBranch;
+              return (
+                <li
+                  key={project.id}
+                  className={cn(
+                    "flex items-start gap-2 rounded-md p-2.5 ring-1 transition-colors",
+                    activeProjectId === project.id
+                      ? "bg-primary/10 ring-primary/50"
+                      : "bg-background/45 ring-border",
+                  )}
+                >
                 <button
                   type="button"
                   onClick={() => selectProject(project.id)}
@@ -158,7 +162,7 @@ export function WorkspaceSettingsPanel({
                   </span>
                   <span className="mt-0.5 block text-[11px] text-muted-foreground">
                     {project.provider === "local" ? "Local" : "GitHub"} -{" "}
-                    {project.defaultBranch}
+                    {currentBranch}
                   </span>
                   <span className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">
                     {project.localPath}
@@ -228,7 +232,8 @@ export function WorkspaceSettingsPanel({
                   </AlertDialogContent>
                 </AlertDialog>
               </li>
-            ))}
+              );
+            })}
           </ul>
         )}
       </SettingsCard>

--- a/components/features/settings/workspace-settings-panel.tsx
+++ b/components/features/settings/workspace-settings-panel.tsx
@@ -33,6 +33,7 @@ import {
   SelectViewport,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { BranchSwitcher } from "@/components/features/projects/branch-switcher";
 
 import { useWorkspaceSettings } from "./hooks";
 import { SettingsCard, SettingsPageShell } from "./settings-shell";
@@ -168,6 +169,13 @@ export function WorkspaceSettingsPanel({
                     {project.localPath}
                   </span>
                 </button>
+                <BranchSwitcher
+                  project={project}
+                  currentBranch={currentBranch}
+                  iconOnly
+                  contentAlign="end"
+                  onBranchChanged={() => void refresh()}
+                />
                 <Button
                   type="button"
                   size="icon"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-border outline-none data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverContent, PopoverTrigger };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
     "@openrouter/ai-sdk-provider": "^2.8.0",
+    "@pierre/diffs": "^1.1.22",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "ai": "^6.0.168",
+    "ansi-to-html": "^0.7.2",
     "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -37,7 +39,6 @@
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "ansi-to-html": "^0.7.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^2.8.0
         version: 2.8.0(ai@6.0.168(zod@4.3.6))(zod@4.3.6)
+      '@pierre/diffs':
+        specifier: ^1.1.22
+        version: 1.1.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1155,6 +1158,16 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@pierre/diffs@1.1.22':
+    resolution: {integrity: sha512-1Iv7kdl6OABFCd1n2HQbGUiRHouXPaHoIjcb7Lwg8zeJKY5ph+cESFcGEyIiwW0NCbKGtYS2bTnXmI+Eze5dwg==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@0.0.28':
+    resolution: {integrity: sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==}
+    engines: {vscode: ^1.0.0}
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -1859,6 +1872,30 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -2604,6 +2641,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -3211,6 +3252,9 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -3232,6 +3276,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3657,6 +3704,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@1.8.0:
     resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
@@ -3990,6 +4040,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -4222,6 +4278,15 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4351,6 +4416,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -5662,6 +5730,19 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@pierre/diffs@1.1.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@pierre/theme': 0.0.28
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      shiki: 3.23.0
+
+  '@pierre/theme@0.0.28': {}
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -6420,6 +6501,44 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/transformers@3.23.0':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -7121,6 +7240,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@8.0.3: {}
 
   diff@8.0.4: {}
 
@@ -7881,6 +8002,20 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -7919,6 +8054,8 @@ snapshots:
   hono@4.12.15: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -8281,6 +8418,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru_map@0.4.1: {}
 
   lucide-react@1.8.0(react@19.2.4):
     dependencies:
@@ -8829,6 +8968,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -9153,6 +9300,16 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.9
@@ -9398,6 +9555,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.1:
     dependencies:

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -1,6 +1,11 @@
 import { createSign } from "node:crypto";
 import { z } from "zod";
 
+import type {
+  ProjectPullRequestCheckSummary,
+  ProjectPullRequestSummary,
+} from "@/src/lib/api-types";
+
 const GITHUB_API = "https://api.github.com";
 const API_VERSION = "2022-11-28";
 
@@ -34,7 +39,77 @@ const repositoriesResponseSchema = z.object({
   repositories: z.array(repositorySchema),
 });
 
+const pullRequestSchema = z.object({
+  number: z.number().int(),
+  state: z.enum(["open", "closed"]),
+  title: z.string(),
+  html_url: z.string().url(),
+  merged: z.boolean().default(false),
+  user: accountSchema,
+  head: z.object({
+    ref: z.string(),
+    sha: z.string(),
+  }),
+  base: z.object({
+    ref: z.string(),
+  }),
+  additions: z.number().int().default(0),
+  deletions: z.number().int().default(0),
+  changed_files: z.number().int().default(0),
+  commits: z.number().int().default(0),
+  comments: z.number().int().default(0),
+  review_comments: z.number().int().default(0),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const pullRequestFileSchema = z.object({
+  filename: z.string(),
+  status: z.string(),
+  additions: z.number().int(),
+  deletions: z.number().int(),
+  changes: z.number().int(),
+  patch: z.string().nullable().optional(),
+  previous_filename: z.string().nullable().optional(),
+});
+
+const combinedStatusSchema = z.object({
+  state: z.enum(["error", "failure", "pending", "success"]),
+  statuses: z.array(
+    z.object({
+      state: z.enum(["error", "failure", "pending", "success"]),
+    }).passthrough(),
+  ).default([]),
+});
+
+const checkRunSchema = z.object({
+  name: z.string(),
+  status: z.enum(["queued", "in_progress", "completed", "unknown"]).catch("unknown"),
+  conclusion: z
+    .enum([
+      "success",
+      "failure",
+      "neutral",
+      "cancelled",
+      "skipped",
+      "timed_out",
+      "action_required",
+    ])
+    .nullable()
+    .catch(null),
+  html_url: z.string().url().nullable().optional(),
+});
+
+const checkRunsResponseSchema = z.object({
+  total_count: z.number().int().default(0),
+  check_runs: z.array(checkRunSchema).default([]),
+});
+
 export type GitHubRepository = z.infer<typeof repositorySchema>;
+type GitHubPullRequest = z.infer<typeof pullRequestSchema>;
+type GitHubPullRequestFile = z.infer<typeof pullRequestFileSchema>;
+type GitHubCombinedStatus = z.infer<typeof combinedStatusSchema>;
+type GitHubCheckRun = z.infer<typeof checkRunSchema>;
 
 export function isGitHubConfigured(): boolean {
   return readGitHubAppConfig() !== null;
@@ -71,6 +146,53 @@ export async function findInstallationRepository(input: {
   return repos.find((repo) => repo.id === input.repositoryId);
 }
 
+export async function findPullRequestForBranch(input: {
+  installationId: number;
+  owner: string;
+  repo: string;
+  branch: string;
+}): Promise<ProjectPullRequestSummary | null> {
+  const token = await createInstallationToken(input.installationId);
+  const searchParams = new URLSearchParams({
+    state: "all",
+    head: `${input.owner}:${input.branch}`,
+    sort: "updated",
+    direction: "desc",
+    per_page: "5",
+  });
+  const matches = z.array(pullRequestSchema).parse(
+    await githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/pulls?${searchParams}`,
+      { token: token.token },
+    ),
+  );
+  const match = matches[0];
+  if (!match) return null;
+
+  const [details, files, checks] = await Promise.all([
+    fetchPullRequest({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      number: match.number,
+    }),
+    fetchPullRequestFiles({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      number: match.number,
+    }),
+    fetchPullRequestChecks({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      ref: match.head.sha,
+    }),
+  ]);
+
+  return serializePullRequest(details, files, checks);
+}
+
 export async function createInstallationToken(installationId: number): Promise<{
   token: string;
   expiresAt: Date;
@@ -88,6 +210,138 @@ export async function createInstallationToken(installationId: number): Promise<{
     token: parsed.token,
     expiresAt: new Date(parsed.expires_at),
   };
+}
+
+async function fetchPullRequest(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  number: number;
+}): Promise<GitHubPullRequest> {
+  return pullRequestSchema.parse(
+    await githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/pulls/${input.number}`,
+      { token: input.token },
+    ),
+  );
+}
+
+async function fetchPullRequestFiles(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  number: number;
+}): Promise<GitHubPullRequestFile[]> {
+  return z.array(pullRequestFileSchema).parse(
+    await githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/pulls/${input.number}/files?per_page=100`,
+      { token: input.token },
+    ),
+  );
+}
+
+async function fetchPullRequestChecks(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  ref: string;
+}): Promise<{
+  status: GitHubCombinedStatus;
+  checkRuns: GitHubCheckRun[];
+}> {
+  const [status, checkRuns] = await Promise.all([
+    githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/commits/${encodeURIComponent(input.ref)}/status`,
+      { token: input.token },
+    ).then((json) => combinedStatusSchema.parse(json)),
+    githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/commits/${encodeURIComponent(input.ref)}/check-runs?per_page=100`,
+      { token: input.token },
+    ).then((json) => checkRunsResponseSchema.parse(json)),
+  ]);
+  return { status, checkRuns: checkRuns.check_runs };
+}
+
+function serializePullRequest(
+  pr: GitHubPullRequest,
+  files: GitHubPullRequestFile[],
+  checks: { status: GitHubCombinedStatus; checkRuns: GitHubCheckRun[] },
+): ProjectPullRequestSummary {
+  const checkSummary = summarizeChecks(checks);
+  return {
+    number: pr.number,
+    state: pr.state,
+    merged: pr.merged,
+    title: pr.title,
+    htmlUrl: pr.html_url,
+    authorLogin: pr.user.login,
+    baseBranch: pr.base.ref,
+    headBranch: pr.head.ref,
+    headSha: pr.head.sha,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changedFiles: pr.changed_files,
+    commits: pr.commits,
+    comments: pr.comments,
+    reviewComments: pr.review_comments,
+    files: files.map((file) => ({
+      filename: file.filename,
+      status: file.status,
+      additions: file.additions,
+      deletions: file.deletions,
+      changes: file.changes,
+      patch: file.patch ?? null,
+      previousFilename: file.previous_filename ?? null,
+    })),
+    checks: checkSummary,
+    createdAt: Date.parse(pr.created_at),
+    updatedAt: Date.parse(pr.updated_at),
+  };
+}
+
+function summarizeChecks(input: {
+  status: GitHubCombinedStatus;
+  checkRuns: GitHubCheckRun[];
+}): ProjectPullRequestSummary["checks"] {
+  const statusContexts = input.status.statuses;
+  const runs: ProjectPullRequestCheckSummary[] = input.checkRuns.map((run) => ({
+    name: run.name,
+    status: run.status,
+    conclusion: run.conclusion,
+    htmlUrl: run.html_url ?? null,
+  }));
+  const total = statusContexts.length + runs.length;
+  const failed =
+    statusContexts.filter((status) => ["error", "failure"].includes(status.state)).length +
+    runs.filter((run) =>
+      ["failure", "cancelled", "timed_out", "action_required"].includes(
+        run.conclusion ?? "",
+      ),
+    ).length;
+  const pending =
+    statusContexts.filter((status) => status.state === "pending").length +
+    runs.filter((run) => run.status !== "completed").length;
+  const passed =
+    statusContexts.filter((status) => status.state === "success").length +
+    runs.filter((run) =>
+      ["success", "neutral", "skipped"].includes(run.conclusion ?? ""),
+    ).length;
+  const state =
+    total === 0
+      ? "unknown"
+      : failed > 0 || input.status.state === "failure"
+        ? "failure"
+        : input.status.state === "error"
+          ? "error"
+          : pending > 0 || input.status.state === "pending"
+            ? "pending"
+            : "success";
+
+  return { state, total, passed, failed, pending, runs };
+}
+
+function repoPath(owner: string, repo: string): string {
+  return `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
 }
 
 function createAppJwt(): string {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -43,6 +43,72 @@ export type ProjectSummary = {
   updatedAt: number;
 };
 
+export type ProjectGitStatusSummary = {
+  projectId: string;
+  branch: string | null;
+  defaultBranch: string;
+  isDefaultBranch: boolean;
+  dirtyCount: number;
+  ahead: number | null;
+  behind: number | null;
+  upstream: string | null;
+  remoteUrl: string | null;
+};
+
+export type ProjectPullRequestFileSummary = {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch: string | null;
+  previousFilename: string | null;
+};
+
+export type ProjectPullRequestCheckSummary = {
+  name: string;
+  status: "queued" | "in_progress" | "completed" | "unknown";
+  conclusion:
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "skipped"
+    | "timed_out"
+    | "action_required"
+    | null;
+  htmlUrl: string | null;
+};
+
+export type ProjectPullRequestSummary = {
+  number: number;
+  state: "open" | "closed";
+  merged: boolean;
+  title: string;
+  htmlUrl: string;
+  authorLogin: string;
+  baseBranch: string;
+  headBranch: string;
+  headSha: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  commits: number;
+  comments: number;
+  reviewComments: number;
+  files: ProjectPullRequestFileSummary[];
+  checks: {
+    state: "unknown" | "pending" | "success" | "failure" | "error";
+    total: number;
+    passed: number;
+    failed: number;
+    pending: number;
+    runs: ProjectPullRequestCheckSummary[];
+  };
+  createdAt: number;
+  updatedAt: number;
+};
+
 export type ProjectMemory = {
   id: string;
   content: string;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -55,6 +55,19 @@ export type ProjectGitStatusSummary = {
   remoteUrl: string | null;
 };
 
+export type ProjectBranchSummary = {
+  name: string;
+  kind: "local" | "remote";
+  current: boolean;
+};
+
+export type ProjectBranchesSummary = {
+  projectId: string;
+  currentBranch: string | null;
+  defaultBranch: string;
+  branches: ProjectBranchSummary[];
+};
+
 export type ProjectPullRequestFileSummary = {
   filename: string;
   status: string;


### PR DESCRIPTION
## Summary
- Add live project git status, branch list/switch/create, and current-branch PR lookup APIs.
- Add a right-sidebar PR tab with PR metadata, changed files, patch preview, and lightweight discussion/commits/checks summaries.
- Add a reusable compact branch switcher popover in the composer footer and workspace settings, including search, switch, create+checkout, progress states, and live branch refresh.
- Fetch/prune `origin` when the branch picker opens or the inline refresh button is clicked, so remote branches stay current without a terminal pull.
- Render PR and tool-preview diffs through `@pierre/diffs` via one local compact wrapper while keeping `diff` for patch application utilities.
- Keep the PR diff preview horizontally scrollable inside the diff frame instead of widening the right sidebar.
- Use live git branch status in the composer, workspace settings, and PR sidebar so branch labels stay dynamic.

Closes #88

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passes; existing Turbopack NFT warning remains for the project git branches route import trace)
- `git diff --check`
- `node --input-type=module -e "const mod = await import('@pierre/diffs/react'); console.log(Boolean(mod.PatchDiff), Boolean(mod.MultiFileDiff));"` returned `true true`
- `Invoke-WebRequest -UseBasicParsing http://localhost:3000/` returned `200`
- `GET /api/projects/:id/git/branches?refresh=1` returned current branch `codex/88-pr-sidebar-view` and refreshed remote refs for the Anton GitHub project
- `GET /api/projects/:id/git/branches?refresh=1` returned branch data for a local project without failing when refreshing
- `GET /api/projects/:id/git/status` returned current branch `codex/88-pr-sidebar-view`
- `GET /api/projects/:id/github/pull-request?branch=codex%2F88-pr-sidebar-view` returned PR #89 metadata

## Manual verification
- Confirmed the selected Anton project clone reports live branch status via `/api/projects/:id/git/status`.
- Confirmed the PR tab can resolve the active branch PR and expose PR metadata/files/check summary data.
- Confirmed the branch picker refresh path fetches latest remote refs instead of requiring a separate terminal pull.