### PR TITLE
[codex] Add issue branches and PR creation

### DIFF
--- a/app/api/projects/[id]/git/diff/route.ts
+++ b/app/api/projects/[id]/git/diff/route.ts
@@ -1,0 +1,146 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { getProject } from "@/src/db/queries";
+import type {
+  ProjectLocalDiffSummary,
+  ProjectPullRequestFileSummary,
+} from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+const MAX_GIT_OUTPUT_BYTES = 1024 * 1024;
+
+type Ctx = { params: Promise<{ id: string }> };
+
+type DirtyEntry = {
+  filename: string;
+  status: string;
+  previousFilename: string | null;
+  untracked: boolean;
+};
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  try {
+    const root = ensureWorkspaceRootAt(project.localPath);
+    const summary: ProjectLocalDiffSummary = {
+      projectId: project.id,
+      files: await localDiffFiles(root),
+    };
+    return Response.json({ diff: summary });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+async function localDiffFiles(root: string): Promise<ProjectPullRequestFileSummary[]> {
+  const status = await gitOutput(root, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+  ]);
+  const entries = parsePorcelainStatus(status);
+  return Promise.all(entries.map((entry) => localDiffFile(root, entry)));
+}
+
+async function localDiffFile(
+  root: string,
+  entry: DirtyEntry,
+): Promise<ProjectPullRequestFileSummary> {
+  const patch = entry.untracked
+    ? null
+    : await gitOutput(root, [
+        "diff",
+        "--no-ext-diff",
+        "--find-renames",
+        "HEAD",
+        "--",
+        entry.filename,
+      ]);
+  const counts = patch ? countPatchChanges(patch) : { additions: 0, deletions: 0 };
+  return {
+    filename: entry.filename,
+    status: entry.status,
+    additions: counts.additions,
+    deletions: counts.deletions,
+    changes: counts.additions + counts.deletions,
+    patch,
+    previousFilename: entry.previousFilename,
+  };
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    maxBuffer: MAX_GIT_OUTPUT_BYTES,
+  });
+  return result.stdout;
+}
+
+function parsePorcelainStatus(raw: string): DirtyEntry[] {
+  const records = raw.split("\0").filter((record) => record.length > 0);
+  const entries: DirtyEntry[] = [];
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index] ?? "";
+    if (record.length < 4) continue;
+    const code = record.slice(0, 2);
+    const filename = record.slice(3);
+    if (!filename) continue;
+
+    const status = statusFromPorcelain(code);
+    const renamed = code.includes("R") || code.includes("C");
+    let previousFilename: string | null = null;
+    if (renamed) {
+      previousFilename = records[index + 1] ?? null;
+      index += previousFilename ? 1 : 0;
+    }
+
+    entries.push({
+      filename,
+      status,
+      previousFilename,
+      untracked: code === "??",
+    });
+  }
+  return entries;
+}
+
+function statusFromPorcelain(code: string): string {
+  if (code === "??") return "added";
+  if (code.includes("R")) return "renamed";
+  if (code.includes("D")) return "removed";
+  if (code.includes("A")) return "added";
+  return "modified";
+}
+
+function countPatchChanges(patch: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of patch.split(/\r?\n/)) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) additions += 1;
+    if (line.startsWith("-")) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/git/status/route.ts
+++ b/app/api/projects/[id]/git/status/route.ts
@@ -24,7 +24,7 @@ export async function GET(_req: Request, { params }: Ctx) {
 
   try {
     const root = ensureWorkspaceRootAt(project.localPath);
-    const [branch, status, upstream, remoteUrl, aheadBehind] = await Promise.all([
+    const [branch, status, upstream, remoteUrl, aheadBehind, upstreamAheadBehind] = await Promise.all([
       gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
       gitOutput(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
       gitOutput(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).catch(
@@ -37,8 +37,15 @@ export async function GET(_req: Request, { params }: Ctx) {
         "--count",
         `origin/${project.defaultBranch}...HEAD`,
       ]).catch(() => ""),
+      gitOutput(root, [
+        "rev-list",
+        "--left-right",
+        "--count",
+        "@{upstream}...HEAD",
+      ]).catch(() => ""),
     ]);
     const counts = parseAheadBehind(aheadBehind);
+    const upstreamCounts = parseAheadBehind(upstreamAheadBehind);
     const currentBranch = branch.trim() || null;
     const summary: ProjectGitStatusSummary = {
       projectId: project.id,
@@ -48,6 +55,8 @@ export async function GET(_req: Request, { params }: Ctx) {
       dirtyCount: status.split("\0").filter(Boolean).length,
       ahead: counts?.ahead ?? null,
       behind: counts?.behind ?? null,
+      upstreamAhead: upstreamCounts?.ahead ?? null,
+      upstreamBehind: upstreamCounts?.behind ?? null,
       upstream: upstream.trim() || null,
       remoteUrl: remoteUrl.trim() ? redactText(remoteUrl.trim()) : null,
     };

--- a/app/api/projects/[id]/github/issues/route.ts
+++ b/app/api/projects/[id]/github/issues/route.ts
@@ -1,0 +1,41 @@
+import { getProject } from "@/src/db/queries";
+import { listOpenIssuesForRepository } from "@/src/github/app";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (
+    project.provider !== "github" ||
+    project.githubInstallationId === null ||
+    project.status !== "ready"
+  ) {
+    return Response.json({ issues: [] });
+  }
+
+  try {
+    const issues = await listOpenIssuesForRepository({
+      installationId: project.githubInstallationId,
+      owner: project.owner,
+      repo: project.name,
+    });
+    return Response.json({ issues });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 502 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/github/pull-request/route.ts
+++ b/app/api/projects/[id]/github/pull-request/route.ts
@@ -1,15 +1,26 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { z } from "zod";
 
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
 import { getProject } from "@/src/db/queries";
-import { findPullRequestForBranch } from "@/src/github/app";
+import { createPullRequestForBranch, findPullRequestForBranch } from "@/src/github/app";
 import { redactText } from "@/src/lib/redaction";
 
 export const runtime = "nodejs";
 
 type Ctx = { params: Promise<{ id: string }> };
 
+const execFileAsync = promisify(execFile);
+
 const querySchema = z.object({
   branch: z.string().trim().min(1),
+});
+
+const createSchema = z.object({
+  branch: z.string().trim().min(1),
+  title: z.string().trim().min(1).optional(),
+  body: z.string().trim().optional(),
 });
 
 export async function GET(req: Request, { params }: Ctx) {
@@ -54,6 +65,135 @@ export async function GET(req: Request, { params }: Ctx) {
       { status: 502 },
     );
   }
+}
+
+export async function POST(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (
+    project.provider !== "github" ||
+    project.githubInstallationId === null ||
+    project.status !== "ready"
+  ) {
+    return Response.json({ error: "project is not a ready GitHub repository" }, { status: 400 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+  if (parsed.data.branch === project.defaultBranch) {
+    return Response.json(
+      { error: "cannot create a pull request from the default branch" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const status = await localBranchStatus(ensureWorkspaceRootAt(project.localPath));
+    if (status.branch !== parsed.data.branch) {
+      return Response.json(
+        { error: "pull request branch must match the current local branch" },
+        { status: 409 },
+      );
+    }
+    if (status.dirtyCount > 0) {
+      return Response.json(
+        { error: "commit or discard local changes before creating a pull request" },
+        { status: 409 },
+      );
+    }
+    if (!status.upstream?.startsWith("origin/")) {
+      return Response.json(
+        { error: "push this branch to origin before creating a pull request" },
+        { status: 409 },
+      );
+    }
+    if (status.upstreamAhead !== 0) {
+      return Response.json(
+        { error: "push local commits before creating a pull request" },
+        { status: 409 },
+      );
+    }
+    const pullRequest = await createPullRequestForBranch({
+      installationId: project.githubInstallationId,
+      owner: project.owner,
+      repo: project.name,
+      branch: parsed.data.branch,
+      baseBranch: project.defaultBranch,
+      title: parsed.data.title ?? titleFromBranch(parsed.data.branch),
+      body: parsed.data.body ?? bodyFromBranch(parsed.data.branch),
+    });
+    return Response.json({ pullRequest });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 502 },
+    );
+  }
+}
+
+function titleFromBranch(branch: string): string {
+  return branch
+    .replace(/^codex\//, "")
+    .replace(/^\d+-/, "")
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ") || branch;
+}
+
+function bodyFromBranch(branch: string): string | null {
+  const issueNumber = /^codex\/(\d+)(?:-|$)/.exec(branch)?.[1];
+  return issueNumber ? `Closes #${issueNumber}` : null;
+}
+
+async function localBranchStatus(root: string): Promise<{
+  branch: string | null;
+  dirtyCount: number;
+  upstream: string | null;
+  upstreamAhead: number | null;
+}> {
+  const [branch, status, upstream, upstreamAheadBehind] = await Promise.all([
+    gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
+    gitOutput(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+    gitOutput(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).catch(
+      () => "",
+    ),
+    gitOutput(root, [
+      "rev-list",
+      "--left-right",
+      "--count",
+      "@{upstream}...HEAD",
+    ]).catch(() => ""),
+  ]);
+  const upstreamCounts = parseAheadBehind(upstreamAheadBehind);
+  return {
+    branch: branch.trim() || null,
+    dirtyCount: status.split("\0").filter(Boolean).length,
+    upstream: upstream.trim() || null,
+    upstreamAhead: upstreamCounts?.ahead ?? null,
+  };
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+function parseAheadBehind(value: string): { ahead: number; behind: number } | null {
+  const [behindRaw, aheadRaw] = value.trim().split(/\s+/, 2);
+  const behind = Number(behindRaw);
+  const ahead = Number(aheadRaw);
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null;
+  return { ahead, behind };
 }
 
 function errorMessage(err: unknown): string {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -55,6 +55,16 @@ export function Chat(props: ChatProps) {
   return <ChatSession key={props.sessionId ?? "new-chat"} {...props} />;
 }
 
+type ComposerControlState = {
+  mode: ChatMode;
+  model: ModelId;
+  permissionMode: PermissionMode;
+  thinkingEnabled: boolean;
+  selectedMcpServerIds?: string[];
+};
+
+const composerControlStateBySession = new Map<string, ComposerControlState>();
+
 function ChatSession({
   sessionId: sessionIdProp,
   initialMessages,
@@ -89,14 +99,23 @@ function ChatSession({
     sessionIdProp !== undefined &&
       (initialMessages?.filter(hasVisibleMessageParts).length ?? 0) === 0,
   );
+  const cachedControls = composerControlStateBySession.get(sessionId);
   const [model, setModel] = useState<ModelId>(
-    (initialModel ?? DEFAULT_MODEL_ID) as ModelId,
+    cachedControls?.model ?? ((initialModel ?? DEFAULT_MODEL_ID) as ModelId),
   );
-  const [permissionMode, setPermissionMode] = useState<PermissionMode>("auto-review");
-  const [mode, setMode] = useState<ChatMode>(DEFAULT_CHAT_MODE);
-  const [thinkingEnabled, setThinkingEnabled] = useState(false);
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>(
+    cachedControls?.permissionMode ?? "auto-review",
+  );
+  const [mode, setMode] = useState<ChatMode>(
+    cachedControls?.mode ?? DEFAULT_CHAT_MODE,
+  );
+  const [thinkingEnabled, setThinkingEnabled] = useState(
+    cachedControls?.thinkingEnabled ?? false,
+  );
   const [mcpServers, setMcpServers] = useState<McpServerSummary[]>([]);
-  const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<string[]>([]);
+  const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<string[]>(
+    cachedControls?.selectedMcpServerIds ?? [],
+  );
   const [pendingMcpSend, setPendingMcpSend] = useState<{
     text: string;
     mode: ChatMode;
@@ -206,6 +225,12 @@ function ChatSession({
         setMcpServers(data.servers);
         setSelectedMcpServerIds((current) => {
           if (current.length > 0) return current;
+          const cachedIds = composerControlStateBySession.get(sessionId)?.selectedMcpServerIds;
+          if (cachedIds !== undefined) {
+            return cachedIds.filter((id) =>
+              data.servers.some((server) => server.id === id && server.enabled),
+            );
+          }
           return data.servers
             .filter((server) => server.enabled)
             .map((server) => server.id);
@@ -218,7 +243,17 @@ function ChatSession({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [sessionId]);
+
+  useEffect(() => {
+    composerControlStateBySession.set(sessionId, {
+      mode,
+      model,
+      permissionMode,
+      thinkingEnabled,
+      selectedMcpServerIds,
+    });
+  }, [mode, model, permissionMode, selectedMcpServerIds, sessionId, thinkingEnabled]);
 
   const sendWithMcp = async (
     text: string,

--- a/components/features/projects/branch-switcher.tsx
+++ b/components/features/projects/branch-switcher.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import {
   Check,
   ChevronDown,
+  CircleDot,
   GitBranch,
   Loader2,
   Plus,
@@ -23,6 +24,7 @@ import { cn } from "@/lib/utils";
 import type {
   ProjectBranchesSummary,
   ProjectBranchSummary,
+  ProjectIssueSummary,
   ProjectSummary,
 } from "@/src/lib/api-types";
 import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
@@ -51,12 +53,14 @@ export function BranchSwitcher({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [branches, setBranches] = useState<ProjectBranchesSummary | null>(null);
+  const [issues, setIssues] = useState<ProjectIssueSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [switching, setSwitching] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [createMode, setCreateMode] = useState(false);
   const [newBranch, setNewBranch] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [issueError, setIssueError] = useState<string | null>(null);
   const displayedBranch = currentBranch ?? project?.defaultBranch ?? null;
 
   const filteredBranches = useMemo(() => {
@@ -66,16 +70,43 @@ export function BranchSwitcher({
     return items.filter((branch) => branch.name.toLowerCase().includes(needle));
   }, [branches, query]);
 
+  const filteredIssues = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return issues;
+    return issues.filter((issue) =>
+      [
+        `#${issue.number}`,
+        issue.title,
+        issue.suggestedBranchName,
+      ].some((value) => value.toLowerCase().includes(needle)),
+    );
+  }, [issues, query]);
+
   const loadBranches = useCallback(async ({ refresh = false } = {}) => {
     if (!project) return;
     setLoading(true);
     try {
       const queryString = refresh ? "?refresh=1" : "";
-      const data = await getJson<{ branches: ProjectBranchesSummary }>(
+      const branchData = await getJson<{ branches: ProjectBranchesSummary }>(
         `/api/projects/${project.id}/git/branches${queryString}`,
       );
-      setBranches(data.branches);
+      setBranches(branchData.branches);
       setError(null);
+      if (project.provider === "github" && project.status === "ready") {
+        try {
+          const issueData = await getJson<{ issues: ProjectIssueSummary[] }>(
+            `/api/projects/${project.id}/github/issues`,
+          );
+          setIssues(issueData.issues);
+          setIssueError(null);
+        } catch (err) {
+          setIssues([]);
+          setIssueError(errorMessage(err, "Failed to load issues"));
+        }
+      } else {
+        setIssues([]);
+        setIssueError(null);
+      }
     } catch (err) {
       setError(errorMessage(err, "Failed to load branches"));
     } finally {
@@ -126,6 +157,27 @@ export function BranchSwitcher({
     const trimmed = newBranch.trim();
     if (!trimmed) return;
     void mutateBranch({ action: "create", branch: trimmed }, trimmed);
+  };
+
+  const selectIssue = (issue: ProjectIssueSummary) => {
+    const local = branches?.branches.find(
+      (branch) => branch.name === issue.suggestedBranchName,
+    );
+    if (local) {
+      selectBranch(local);
+      return;
+    }
+    const remote = branches?.branches.find(
+      (branch) => branch.name === `origin/${issue.suggestedBranchName}`,
+    );
+    if (remote) {
+      selectBranch(remote);
+      return;
+    }
+    void mutateBranch(
+      { action: "create", branch: issue.suggestedBranchName },
+      issue.suggestedBranchName,
+    );
   };
 
   return (
@@ -203,7 +255,7 @@ export function BranchSwitcher({
             </button>
           </div>
         </div>
-        <div className="max-h-52 overflow-y-auto p-0.5">
+        <div className="max-h-72 overflow-y-auto p-0.5">
           <div className="px-1.5 py-1 text-[10px] font-medium uppercase text-muted-foreground">
             Branches
           </div>
@@ -251,6 +303,49 @@ export function BranchSwitcher({
               ))}
             </ul>
           )}
+          {project?.provider === "github" ? (
+            <>
+              <div className="mt-1 border-t border-border px-1.5 py-1 text-[10px] font-medium uppercase text-muted-foreground">
+                Issues
+              </div>
+              {issueError ? (
+                <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
+                  {issueError}
+                </div>
+              ) : filteredIssues.length === 0 ? (
+                <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                  {loading ? "Loading issues..." : "No open issues found."}
+                </div>
+              ) : (
+                <ul className="grid gap-0.5">
+                  {filteredIssues.map((issue) => (
+                    <li key={issue.number}>
+                      <button
+                        type="button"
+                        onClick={() => selectIssue(issue)}
+                        disabled={switching !== null}
+                        className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
+                      >
+                        {switching === issue.suggestedBranchName ? (
+                          <Loader2 className="mt-0.5 size-3 animate-spin text-primary" />
+                        ) : (
+                          <CircleDot className="mt-0.5 size-3 text-emerald-400" />
+                        )}
+                        <span className="min-w-0">
+                          <span className="block truncate font-medium">
+                            #{issue.number} {issue.title}
+                          </span>
+                          <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                            {issue.suggestedBranchName}
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : null}
         </div>
         <div className="border-t border-border p-0.5">
           {createMode ? (

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -178,6 +178,7 @@ export function PullRequestPanel({
 
 export function PullRequestEmptyPanel({
   gitStatus,
+  localFiles,
   loading,
   creating,
   error,
@@ -185,6 +186,7 @@ export function PullRequestEmptyPanel({
   onCreatePullRequest,
 }: {
   gitStatus: ProjectGitStatusSummary | null;
+  localFiles: ProjectPullRequestFileSummary[];
   loading: boolean;
   creating: boolean;
   error: string | null;
@@ -192,6 +194,16 @@ export function PullRequestEmptyPanel({
   onCreatePullRequest: () => void;
 }) {
   const createReady = canCreatePullRequest(gitStatus);
+  const canShowCreateAction = Boolean(gitStatus?.branch && !gitStatus.isDefaultBranch);
+  const createBlocker =
+    gitStatus && canShowCreateAction && !createReady
+      ? pullRequestCreateBlocker(gitStatus)
+      : null;
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const selected =
+    localFiles.find((file) => file.filename === selectedFile) ??
+    localFiles[0] ??
+    null;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <section className="border-b border-border px-3 py-3">
@@ -224,13 +236,14 @@ export function PullRequestEmptyPanel({
             <Metric label="Dirty" value={gitStatus.dirtyCount} />
           </div>
         ) : null}
-        {createReady ? (
+        {canShowCreateAction ? (
           <Button
             type="button"
             size="sm"
             className="mt-3"
             onClick={onCreatePullRequest}
-            disabled={loading || creating}
+            disabled={!createReady || loading || creating}
+            title={createBlocker ?? "Create pull request"}
           >
             {creating ? (
               <RefreshCw className="animate-spin" />
@@ -239,9 +252,10 @@ export function PullRequestEmptyPanel({
             )}
             Create PR
           </Button>
-        ) : gitStatus?.branch && !gitStatus.isDefaultBranch ? (
+        ) : null}
+        {createBlocker ? (
           <p className="mt-3 text-[11px] text-muted-foreground">
-            {pullRequestCreateBlocker(gitStatus)}
+            {createBlocker}
           </p>
         ) : null}
         {error ? (
@@ -250,6 +264,18 @@ export function PullRequestEmptyPanel({
           </div>
         ) : null}
       </section>
+      {localFiles.length > 0 ? (
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <div className="border-b border-border px-3 py-2 text-[11px] font-medium text-muted-foreground">
+            Local changes
+          </div>
+          <ChangesView
+            files={localFiles}
+            selected={selected}
+            onSelect={setSelectedFile}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -179,14 +179,19 @@ export function PullRequestPanel({
 export function PullRequestEmptyPanel({
   gitStatus,
   loading,
+  creating,
   error,
   onRefresh,
+  onCreatePullRequest,
 }: {
   gitStatus: ProjectGitStatusSummary | null;
   loading: boolean;
+  creating: boolean;
   error: string | null;
   onRefresh: () => void;
+  onCreatePullRequest: () => void;
 }) {
+  const createReady = canCreatePullRequest(gitStatus);
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <section className="border-b border-border px-3 py-3">
@@ -219,6 +224,26 @@ export function PullRequestEmptyPanel({
             <Metric label="Dirty" value={gitStatus.dirtyCount} />
           </div>
         ) : null}
+        {createReady ? (
+          <Button
+            type="button"
+            size="sm"
+            className="mt-3"
+            onClick={onCreatePullRequest}
+            disabled={loading || creating}
+          >
+            {creating ? (
+              <RefreshCw className="animate-spin" />
+            ) : (
+              <GitPullRequest />
+            )}
+            Create PR
+          </Button>
+        ) : gitStatus?.branch && !gitStatus.isDefaultBranch ? (
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            {pullRequestCreateBlocker(gitStatus)}
+          </p>
+        ) : null}
         {error ? (
           <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
             {error}
@@ -227,6 +252,31 @@ export function PullRequestEmptyPanel({
       </section>
     </div>
   );
+}
+
+function canCreatePullRequest(gitStatus: ProjectGitStatusSummary | null): boolean {
+  return Boolean(
+    gitStatus?.branch &&
+      !gitStatus.isDefaultBranch &&
+      gitStatus.upstream?.startsWith("origin/") &&
+      gitStatus.upstreamAhead === 0 &&
+      gitStatus.dirtyCount === 0,
+  );
+}
+
+function pullRequestCreateBlocker(
+  gitStatus: ProjectGitStatusSummary,
+): string {
+  if (gitStatus.dirtyCount > 0) {
+    return "Commit or discard local changes before creating a PR.";
+  }
+  if (!gitStatus.upstream?.startsWith("origin/")) {
+    return "Push this branch to origin before creating a PR.";
+  }
+  if (gitStatus.upstreamAhead !== null && gitStatus.upstreamAhead > 0) {
+    return "Push local commits before creating a PR.";
+  }
+  return "Create a PR after the branch is available on origin.";
 }
 
 function emptyPullRequestMessage(gitStatus: ProjectGitStatusSummary | null): string {

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -44,7 +44,7 @@ import { ApprovalDetails } from "./approval-details";
 import { TodoCard } from "./todo-card";
 import { getSessionTodoSnapshots } from "./trace-data";
 import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
-import { getJson } from "@/src/lib/client-fetch";
+import { getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 import { PROJECT_GIT_CHANGED_EVENT } from "@/components/features/projects/hooks";
 import type {
   ProjectGitStatusSummary,
@@ -250,8 +250,10 @@ export function Worklog({
           <PullRequestEmptyPanel
             gitStatus={prState.gitStatus}
             loading={prState.loading}
+            creating={prState.creating}
             error={prState.error}
             onRefresh={prState.refresh}
+            onCreatePullRequest={prState.createPullRequest}
           />
         ) : (
           <EmptyTabsPanel />
@@ -411,12 +413,15 @@ function useProjectPullRequest(project: ProjectSummary | null): {
   gitStatus: ProjectGitStatusSummary | null;
   pullRequest: ProjectPullRequestSummary | null;
   loading: boolean;
+  creating: boolean;
   error: string | null;
   refresh: () => void;
+  createPullRequest: () => void;
 } {
   const [gitStatus, setGitStatus] = useState<ProjectGitStatusSummary | null>(null);
   const [pullRequest, setPullRequest] = useState<ProjectPullRequestSummary | null>(null);
   const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -431,6 +436,7 @@ function useProjectPullRequest(project: ProjectSummary | null): {
         setPullRequest(null);
         setError(null);
         setLoading(false);
+        setCreating(false);
       });
       return;
     }
@@ -492,8 +498,29 @@ function useProjectPullRequest(project: ProjectSummary | null): {
     gitStatus,
     pullRequest,
     loading,
+    creating,
     error,
     refresh: () => setRefreshKey((current) => current + 1),
+    createPullRequest: () => {
+      if (!project || !gitStatus?.branch || creating) return;
+      setCreating(true);
+      requestJson<{ pullRequest: ProjectPullRequestSummary }>(
+        `/api/projects/${project.id}/github/pull-request`,
+        {
+          method: "POST",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ branch: gitStatus.branch }),
+        },
+      )
+        .then((data) => {
+          setPullRequest(data.pullRequest);
+          setError(null);
+        })
+        .catch((err: unknown) => {
+          setError(err instanceof Error ? err.message : "Failed to create PR");
+        })
+        .finally(() => setCreating(false));
+    },
   };
 }
 

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -48,6 +48,7 @@ import { getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 import { PROJECT_GIT_CHANGED_EVENT } from "@/components/features/projects/hooks";
 import type {
   ProjectGitStatusSummary,
+  ProjectLocalDiffSummary,
   ProjectPullRequestSummary,
   ProjectSummary,
 } from "@/src/lib/api-types";
@@ -249,6 +250,7 @@ export function Worklog({
         ) : activeTab === "pr" && hasGithubProject ? (
           <PullRequestEmptyPanel
             gitStatus={prState.gitStatus}
+            localFiles={prState.localDiff?.files ?? []}
             loading={prState.loading}
             creating={prState.creating}
             error={prState.error}
@@ -411,6 +413,7 @@ function firstLine(value: string): string {
 
 function useProjectPullRequest(project: ProjectSummary | null): {
   gitStatus: ProjectGitStatusSummary | null;
+  localDiff: ProjectLocalDiffSummary | null;
   pullRequest: ProjectPullRequestSummary | null;
   loading: boolean;
   creating: boolean;
@@ -419,6 +422,7 @@ function useProjectPullRequest(project: ProjectSummary | null): {
   createPullRequest: () => void;
 } {
   const [gitStatus, setGitStatus] = useState<ProjectGitStatusSummary | null>(null);
+  const [localDiff, setLocalDiff] = useState<ProjectLocalDiffSummary | null>(null);
   const [pullRequest, setPullRequest] = useState<ProjectPullRequestSummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -433,6 +437,7 @@ function useProjectPullRequest(project: ProjectSummary | null): {
     ) {
       queueMicrotask(() => {
         setGitStatus(null);
+        setLocalDiff(null);
         setPullRequest(null);
         setError(null);
         setLoading(false);
@@ -450,9 +455,26 @@ function useProjectPullRequest(project: ProjectSummary | null): {
         );
         if (cancelled) return;
         setGitStatus(statusData.status);
+        let localDiffError: string | null = null;
+        if (statusData.status.dirtyCount > 0) {
+          try {
+            const diffData = await getJson<{ diff: ProjectLocalDiffSummary }>(
+              `/api/projects/${project.id}/git/diff`,
+            );
+            if (cancelled) return;
+            setLocalDiff(diffData.diff);
+          } catch (err) {
+            if (cancelled) return;
+            setLocalDiff(null);
+            localDiffError =
+              err instanceof Error ? err.message : "Failed to load local diff";
+          }
+        } else {
+          setLocalDiff(null);
+        }
         if (!statusData.status.branch || statusData.status.isDefaultBranch) {
           setPullRequest(null);
-          setError(null);
+          setError(localDiffError);
           return;
         }
         const prData = await getJson<{
@@ -464,9 +486,10 @@ function useProjectPullRequest(project: ProjectSummary | null): {
         );
         if (cancelled) return;
         setPullRequest(prData.pullRequest);
-        setError(null);
+        setError(localDiffError);
       } catch (err) {
         if (!cancelled) {
+          setLocalDiff(null);
           setPullRequest(null);
           setError(err instanceof Error ? err.message : "Failed to load PR");
         }
@@ -496,6 +519,7 @@ function useProjectPullRequest(project: ProjectSummary | null): {
 
   return {
     gitStatus,
+    localDiff,
     pullRequest,
     loading,
     creating,

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -185,6 +185,7 @@ function systemPrompt(
     "Use `bash` by default for shell-native work when that tool is available: package scripts, build/lint/typecheck/test commands, git commands, file listing/searching, and simple file operations such as rm/mv/cp/mkdir.",
     "Prefer one `bash` command over many single-file tool calls for glob-based operations such as deleting `MIGRATION*` files, listing files, or inspecting command output.",
     "Use structured read/edit tools for exact file content inspection, guarded patches, or when a tool's typed output is materially safer than shell output.",
+    "Do not use `delegate_task` for current package versions, network lookups, shell output, or any task that requires command execution; use `bash` directly when command access is available.",
     "For existing-file edits, read the file first, then use `edit_file` with the returned `sha256` as `expectedHash`.",
     "- Mutating file tools refuse lockfiles, migrations, generated output, binary files, and large files unless `allowGuarded: true` is intentionally set.",
     "Do not write test cases, add test files, or introduce test scripts. Verify changes with typecheck, lint, build, and focused manual checks as appropriate.",

--- a/src/agent/tools/edit-utils.ts
+++ b/src/agent/tools/edit-utils.ts
@@ -49,9 +49,10 @@ export function exactHunkPatchAlreadyApplied({
 }): boolean {
   const blocks = exactHunkBlocks(source, patch);
   if (!blocks) return false;
-  return (
-    !blocks.normalizedSource.includes(blocks.oldBlock) &&
-    blocks.normalizedSource.includes(blocks.newBlock)
+  return blocks.blocks.every(
+    (block) =>
+      !blocks.normalizedSource.includes(block.oldBlock) &&
+      blocks.normalizedSource.includes(block.newBlock),
   );
 }
 
@@ -61,19 +62,20 @@ function applyExactHunkPatch(
 ): string | undefined {
   const blocks = exactHunkBlocks(source, patch);
   if (!blocks) return undefined;
-  if (!blocks.oldBlock) return undefined;
-
-  const first = blocks.normalizedSource.indexOf(blocks.oldBlock);
-  if (first === -1) return undefined;
-  if (blocks.normalizedSource.indexOf(blocks.oldBlock, first + blocks.oldBlock.length) !== -1) {
-    return undefined;
+  let next = blocks.normalizedSource;
+  for (const block of blocks.blocks) {
+    if (!block.oldBlock) return undefined;
+    const first = next.indexOf(block.oldBlock);
+    if (first === -1) return undefined;
+    if (next.indexOf(block.oldBlock, first + block.oldBlock.length) !== -1) {
+      return undefined;
+    }
+    next =
+      next.slice(0, first) +
+      block.newBlock +
+      next.slice(first + block.oldBlock.length);
   }
-
-  return (
-    blocks.normalizedSource.slice(0, first) +
-    blocks.newBlock +
-    blocks.normalizedSource.slice(first + blocks.oldBlock.length)
-  ).replace(/\n/g, blocks.newline);
+  return next.replace(/\n/g, blocks.newline);
 }
 
 function exactHunkBlocks(
@@ -82,21 +84,36 @@ function exactHunkBlocks(
 ):
   | {
       normalizedSource: string;
-      oldBlock: string;
-      newBlock: string;
+      blocks: { oldBlock: string; newBlock: string }[];
       newline: string;
     }
   | undefined {
   const rawLines = patch.replace(/\r\n/g, "\n").split("\n");
-  const hunkStart = rawLines.findIndex((line) => line.startsWith("@@"));
-  if (hunkStart === -1) return undefined;
+  const hunkStarts = rawLines.flatMap((line, index) =>
+    line.startsWith("@@") ? [index] : [],
+  );
+  if (hunkStarts.length === 0) return undefined;
 
-  const hunkLines = rawLines
-    .slice(hunkStart + 1)
-    .filter((line) => line.length > 0 && !line.startsWith("\\ No newline"));
+  const blocks: { oldBlock: string; newBlock: string }[] = [];
+  for (const [index, hunkStart] of hunkStarts.entries()) {
+    const nextHunkStart = hunkStarts[index + 1] ?? rawLines.length;
+    const hunkLines = rawLines
+      .slice(hunkStart + 1, nextHunkStart)
+      .filter((line) => line.length > 0 && !line.startsWith("\\ No newline"));
+    const block = exactHunkBlock(hunkLines);
+    if (!block) return undefined;
+    blocks.push(block);
+  }
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const normalizedSource = source.replace(/\r\n/g, "\n");
+  return { normalizedSource, blocks, newline };
+}
+
+function exactHunkBlock(
+  hunkLines: string[],
+): { oldBlock: string; newBlock: string } | undefined {
   if (hunkLines.length === 0) return undefined;
   if (hunkLines.some((line) => !/^[-+ ]/.test(line))) return undefined;
-
   const oldLines: string[] = [];
   const newLines: string[] = [];
   let removed = 0;
@@ -117,11 +134,9 @@ function exactHunkBlocks(
   }
 
   if (removed === 0 && added === 0) return undefined;
-  const newline = source.includes("\r\n") ? "\r\n" : "\n";
-  const normalizedSource = source.replace(/\r\n/g, "\n");
   const oldBlock = oldLines.join("\n");
   const newBlock = newLines.join("\n");
-  return { normalizedSource, oldBlock, newBlock, newline };
+  return { oldBlock, newBlock };
 }
 
 function parseSingleFilePatch(

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -2,6 +2,7 @@ import { createSign } from "node:crypto";
 import { z } from "zod";
 
 import type {
+  ProjectIssueSummary,
   ProjectPullRequestCheckSummary,
   ProjectPullRequestSummary,
 } from "@/src/lib/api-types";
@@ -63,6 +64,16 @@ const pullRequestSchema = z.object({
   updated_at: z.string(),
 });
 
+const issueSchema = z.object({
+  number: z.number().int(),
+  state: z.literal("open"),
+  title: z.string(),
+  html_url: z.string().url(),
+  user: accountSchema,
+  updated_at: z.string(),
+  pull_request: z.unknown().optional(),
+});
+
 const pullRequestFileSchema = z.object({
   filename: z.string(),
   status: z.string(),
@@ -107,6 +118,7 @@ const checkRunsResponseSchema = z.object({
 
 export type GitHubRepository = z.infer<typeof repositorySchema>;
 type GitHubPullRequest = z.infer<typeof pullRequestSchema>;
+type GitHubIssue = z.infer<typeof issueSchema>;
 type GitHubPullRequestFile = z.infer<typeof pullRequestFileSchema>;
 type GitHubCombinedStatus = z.infer<typeof combinedStatusSchema>;
 type GitHubCheckRun = z.infer<typeof checkRunSchema>;
@@ -190,6 +202,75 @@ export async function findPullRequestForBranch(input: {
     }),
   ]);
 
+  return serializePullRequest(details, files, checks);
+}
+
+export async function listOpenIssuesForRepository(input: {
+  installationId: number;
+  owner: string;
+  repo: string;
+}): Promise<ProjectIssueSummary[]> {
+  const token = await createInstallationToken(input.installationId);
+  const searchParams = new URLSearchParams({
+    state: "open",
+    sort: "updated",
+    direction: "desc",
+    per_page: "50",
+  });
+  const issues = z.array(issueSchema).parse(
+    await githubFetch(
+      `/repos/${repoPath(input.owner, input.repo)}/issues?${searchParams}`,
+      { token: token.token },
+    ),
+  );
+  return issues
+    .filter((issue) => issue.pull_request === undefined)
+    .map(serializeIssue);
+}
+
+export async function createPullRequestForBranch(input: {
+  installationId: number;
+  owner: string;
+  repo: string;
+  branch: string;
+  baseBranch: string;
+  title: string;
+  body: string | null;
+}): Promise<ProjectPullRequestSummary> {
+  const token = await createInstallationToken(input.installationId);
+  const created = pullRequestSchema.parse(
+    await githubFetch(`/repos/${repoPath(input.owner, input.repo)}/pulls`, {
+      method: "POST",
+      token: token.token,
+      body: {
+        title: input.title,
+        head: input.branch,
+        base: input.baseBranch,
+        body: input.body ?? undefined,
+        maintainer_can_modify: true,
+      },
+    }),
+  );
+  const [details, files, checks] = await Promise.all([
+    fetchPullRequest({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      number: created.number,
+    }),
+    fetchPullRequestFiles({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      number: created.number,
+    }),
+    fetchPullRequestChecks({
+      token: token.token,
+      owner: input.owner,
+      repo: input.repo,
+      ref: created.head.sha,
+    }),
+  ]);
   return serializePullRequest(details, files, checks);
 }
 
@@ -299,6 +380,28 @@ function serializePullRequest(
   };
 }
 
+function serializeIssue(issue: GitHubIssue): ProjectIssueSummary {
+  return {
+    number: issue.number,
+    state: issue.state,
+    title: issue.title,
+    htmlUrl: issue.html_url,
+    authorLogin: issue.user.login,
+    suggestedBranchName: issueBranchName(issue),
+    updatedAt: Date.parse(issue.updated_at),
+  };
+}
+
+function issueBranchName(issue: Pick<GitHubIssue, "number" | "title">): string {
+  const slug = issue.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+    .replace(/-+$/g, "");
+  return `codex/${issue.number}${slug ? `-${slug}` : ""}`;
+}
+
 function summarizeChecks(input: {
   status: GitHubCombinedStatus;
   checkRuns: GitHubCheckRun[];
@@ -362,16 +465,18 @@ function createAppJwt(): string {
 
 async function githubFetch(
   path: string,
-  options: { method?: string; token: string },
+  options: { method?: string; token: string; body?: unknown },
 ): Promise<unknown> {
   const res = await fetch(`${GITHUB_API}${path}`, {
     method: options.method ?? "GET",
     headers: {
       accept: "application/vnd.github+json",
       authorization: `Bearer ${options.token}`,
+      ...(options.body === undefined ? {} : { "content-type": "application/json" }),
       "x-github-api-version": API_VERSION,
       "user-agent": "anton-local-agent",
     },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
   });
   const json = await res.json().catch(() => null);
   if (!res.ok) {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -90,6 +90,11 @@ export type ProjectPullRequestFileSummary = {
   previousFilename: string | null;
 };
 
+export type ProjectLocalDiffSummary = {
+  projectId: string;
+  files: ProjectPullRequestFileSummary[];
+};
+
 export type ProjectPullRequestCheckSummary = {
   name: string;
   status: "queued" | "in_progress" | "completed" | "unknown";

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -51,6 +51,8 @@ export type ProjectGitStatusSummary = {
   dirtyCount: number;
   ahead: number | null;
   behind: number | null;
+  upstreamAhead: number | null;
+  upstreamBehind: number | null;
   upstream: string | null;
   remoteUrl: string | null;
 };
@@ -66,6 +68,16 @@ export type ProjectBranchesSummary = {
   currentBranch: string | null;
   defaultBranch: string;
   branches: ProjectBranchSummary[];
+};
+
+export type ProjectIssueSummary = {
+  number: number;
+  title: string;
+  state: "open";
+  htmlUrl: string;
+  authorLogin: string;
+  suggestedBranchName: string;
+  updatedAt: number;
 };
 
 export type ProjectPullRequestFileSummary = {

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -257,13 +257,11 @@ export function getAssistantTextDisplay(
   const lastToolIndex = message.parts.findLastIndex(isToolUIPart);
   const progressText: string[] = [];
   const finalText: string[] = [];
-  const allText: string[] = [];
 
   for (const [index, part] of message.parts.entries()) {
     if (part.type !== "text") continue;
     const text = part.text.trim();
     if (!text) continue;
-    allText.push(text);
     if (options.progressOnly || (lastToolIndex !== -1 && index < lastToolIndex)) {
       progressText.push(text);
     } else {
@@ -273,9 +271,7 @@ export function getAssistantTextDisplay(
 
   return {
     progressText: progressText.join("\n\n"),
-    finalText: options.progressOnly
-      ? finalText.join("\n\n")
-      : allText.join("\n\n"),
+    finalText: finalText.join("\n\n"),
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds GitHub issue listing for ready GitHub-backed projects and shows open issues in the branch switcher.
- Creates issue-derived branches using `codex/<issue>-<slug>` names from the issue picker.
- Adds a project-scoped PR creation endpoint and an empty-state Create PR action for clean pushed non-default branches.

Closes #90

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passes with existing Turbopack NFT warning from `next.config.ts` -> `src/agent/sandbox.ts` import trace)

## Visual Verification
- Not manually browser-verified in this session; implementation was checked by typecheck, lint, and production build.
