### PR TITLE
feat: complete GitHub workflow follow-up

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,11 +118,11 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Support multiple installations and account filtering in the UI.
 - [✔️] Add project removal/archive behavior without deleting local files by default.
 - [✔️] Add branch creation with default `codex/` prefix for agent work.
-- [] Add PR creation flow after successful local changes.
-- [] Add issue selection and branch naming from GitHub issues.
+- [✔️] Add PR creation flow after successful local changes.
+- [✔️] Add issue selection and branch naming from GitHub issues.
 - [✔️] Add right-sidebar PR view for active GitHub project branches.
 - [✔️] Add GitHub check/CI status display for pushed branches and PRs.
-- [] Add retry/debug workflow for failing GitHub Actions logs.
+- [✔️] Add retry/debug workflow for failing GitHub Actions logs.
 - [✔️] Store GitHub token expiry metadata and refresh tokens only when needed.
 
 ## Phase 6: Developer Experience

--- a/app/api/projects/[id]/github/actions/jobs/[jobId]/logs/route.ts
+++ b/app/api/projects/[id]/github/actions/jobs/[jobId]/logs/route.ts
@@ -1,0 +1,51 @@
+import { getProject } from "@/src/db/queries";
+import { getWorkflowJobLogs } from "@/src/github/app";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string; jobId: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id, jobId } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (
+    project.provider !== "github" ||
+    project.githubInstallationId === null ||
+    project.status !== "ready"
+  ) {
+    return Response.json({ error: "project is not a ready GitHub repository" }, { status: 400 });
+  }
+
+  const numericJobId = Number(jobId);
+  if (!Number.isSafeInteger(numericJobId) || numericJobId <= 0) {
+    return Response.json({ error: "invalid workflow job ID" }, { status: 400 });
+  }
+
+  try {
+    const logs = await getWorkflowJobLogs({
+      installationId: project.githubInstallationId,
+      owner: project.owner,
+      repo: project.name,
+      jobId: numericJobId,
+    });
+    return new Response(redactText(logs), {
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 502 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/github/actions/jobs/[jobId]/rerun/route.ts
+++ b/app/api/projects/[id]/github/actions/jobs/[jobId]/rerun/route.ts
@@ -1,13 +1,13 @@
 import { getProject } from "@/src/db/queries";
-import { getCheckRunLogs } from "@/src/github/app";
+import { rerunWorkflowJob } from "@/src/github/app";
 import { redactText } from "@/src/lib/redaction";
 
 export const runtime = "nodejs";
 
-type Ctx = { params: Promise<{ id: string; checkRunId: string }> };
+type Ctx = { params: Promise<{ id: string; jobId: string }> };
 
-export async function GET(_req: Request, { params }: Ctx) {
-  const { id, checkRunId } = await params;
+export async function POST(_req: Request, { params }: Ctx) {
+  const { id, jobId } = await params;
   const project = getProject(id);
   if (!project) {
     return Response.json({ error: "project not found" }, { status: 404 });
@@ -20,23 +20,19 @@ export async function GET(_req: Request, { params }: Ctx) {
     return Response.json({ error: "project is not a ready GitHub repository" }, { status: 400 });
   }
 
-  const numericCheckRunId = Number(checkRunId);
-  if (Number.isNaN(numericCheckRunId)) {
-    return Response.json({ error: "invalid check run ID" }, { status: 400 });
+  const numericJobId = Number(jobId);
+  if (!Number.isSafeInteger(numericJobId) || numericJobId <= 0) {
+    return Response.json({ error: "invalid workflow job ID" }, { status: 400 });
   }
 
   try {
-    const logs = await getCheckRunLogs({
+    await rerunWorkflowJob({
       installationId: project.githubInstallationId,
       owner: project.owner,
       repo: project.name,
-      checkRunId: numericCheckRunId,
+      jobId: numericJobId,
     });
-    return new Response(logs, {
-      headers: {
-        "content-type": "text/plain; charset=utf-8",
-      },
-    });
+    return Response.json({ ok: true });
   } catch (err) {
     return Response.json(
       { error: redactText(errorMessage(err)) },

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -6,6 +6,7 @@ import type { ProjectGitStatusSummary, ProjectSummary } from "@/src/lib/api-type
 import { getJson } from "@/src/lib/client-fetch";
 
 export const PROJECT_GIT_CHANGED_EVENT = "anton-project-git-change";
+const PROJECT_GIT_STATUS_POLL_INTERVAL_MS = 120_000;
 
 export function useProjectSummary(projectId: string | null): ProjectSummary | null {
   const [loadedProject, setLoadedProject] = useState<{
@@ -47,7 +48,11 @@ export function useProjectGitStatus(
     }
 
     let cancelled = false;
+    let loading = false;
+    let pollTimeout: number | null = null;
     const loadStatus = async () => {
+      if (loading) return;
+      loading = true;
       try {
         const data = await getJson<{ status: ProjectGitStatusSummary }>(
           `/api/projects/${projectId}/git/status`,
@@ -57,12 +62,22 @@ export function useProjectGitStatus(
         }
       } catch {
         if (!cancelled) {
-          setLoadedStatus({ projectId, status: null });
+          setLoadedStatus((current) =>
+            current?.projectId === projectId ? current : { projectId, status: null },
+          );
         }
+      } finally {
+        loading = false;
       }
     };
-    void loadStatus();
-    const interval = window.setInterval(() => void loadStatus(), 15000);
+    const schedulePoll = () => {
+      if (cancelled) return;
+      pollTimeout = window.setTimeout(() => {
+        void loadStatus().finally(schedulePoll);
+      }, PROJECT_GIT_STATUS_POLL_INTERVAL_MS);
+    };
+
+    void loadStatus().finally(schedulePoll);
     const onProjectGitChanged = (event: Event) => {
       if (
         event instanceof CustomEvent &&
@@ -75,7 +90,9 @@ export function useProjectGitStatus(
     window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      if (pollTimeout !== null) {
+        window.clearTimeout(pollTimeout);
+      }
       window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     };
   }, [projectId]);

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   MessageSquare,
   RefreshCw,
+  RotateCcw,
   XCircle,
 } from "lucide-react";
 
@@ -156,6 +157,7 @@ export function PullRequestPanel({
           <ChecksView
             pullRequest={pullRequest}
             projectId={projectId}
+            onRefresh={onRefresh}
           />
         </TabsContent>
       </Tabs>
@@ -429,9 +431,11 @@ function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
 function ChecksView({
   pullRequest,
   projectId,
+  onRefresh,
 }: {
   pullRequest: ProjectPullRequestSummary;
   projectId: string | null;
+  onRefresh: () => void;
 }) {
   const meta = checkStateMeta(pullRequest.checks.state);
   if (pullRequest.checks.total === 0) {
@@ -458,6 +462,7 @@ function ChecksView({
             <CheckRunRow
               run={run}
               projectId={projectId}
+              onRefresh={onRefresh}
             />
           </li>
         ))}
@@ -469,21 +474,27 @@ function ChecksView({
 function CheckRunRow({
   run,
   projectId,
+  onRefresh,
 }: {
   run: ProjectPullRequestCheckSummary;
   projectId: string | null;
+  onRefresh: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [logs, setLogs] = useState<string | null>(null);
   const [loadingLogs, setLoadingLogs] = useState(false);
+  const [rerunning, setRerunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const jobId = run.workflowJobId;
+  const canLoadLogs = Boolean(projectId && jobId);
+  const canRerun = Boolean(projectId && jobId && run.canRerun);
 
   const fetchLogs = async () => {
-    if (!projectId || !run.id) return;
+    if (!projectId || !jobId) return;
     setLoadingLogs(true);
     setError(null);
     try {
-      const res = await fetch(`/api/projects/${projectId}/github/check-runs/${run.id}/logs`);
+      const res = await fetch(`/api/projects/${projectId}/github/actions/jobs/${jobId}/logs`);
       if (!res.ok) {
         throw new Error(await responseError(res, "Failed to load logs"));
       }
@@ -496,7 +507,30 @@ function CheckRunRow({
     }
   };
 
+  const rerunJob = async () => {
+    if (!projectId || !jobId || !run.canRerun) return;
+    setRerunning(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/github/actions/jobs/${jobId}/rerun`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        throw new Error(await responseError(res, "Failed to rerun job"));
+      }
+      setLogs(null);
+      onRefresh();
+    } catch (err) {
+      setExpanded(true);
+      setError(err instanceof Error ? err.message : "Failed to rerun job");
+    } finally {
+      setRerunning(false);
+    }
+  };
+
   const toggleExpand = () => {
+    if (!canLoadLogs) return;
     const next = !expanded;
     setExpanded(next);
     if (next && !logs) {
@@ -512,14 +546,22 @@ function CheckRunRow({
         <button
           type="button"
           onClick={toggleExpand}
+          disabled={!canLoadLogs}
           className="grid min-w-0 flex-1 grid-cols-[0.875rem_1fr] items-center gap-2 text-left"
+          title={canLoadLogs ? "View logs" : "No workflow job logs available for this check"}
         >
           <runMeta.Icon className={cn("size-3.5 shrink-0", runMeta.className)} />
-          <span className="min-w-0 truncate font-medium">{run.name}</span>
+          <span className="min-w-0">
+            <span className="block truncate font-medium">{run.name}</span>
+            <span className="block truncate font-mono text-[10px] text-muted-foreground">
+              {run.conclusion ?? run.status}
+              {jobId ? ` | job ${jobId}` : " | GitHub check"}
+            </span>
+          </span>
         </button>
 
         <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
-          {run.htmlUrl ? (
+          {run.htmlUrl ?? run.detailsUrl ? (
             <Button
               type="button"
               size="icon-xs"
@@ -527,12 +569,28 @@ function CheckRunRow({
               asChild
               title="Open check on GitHub"
             >
-              <a href={run.htmlUrl} target="_blank" rel="noreferrer">
+              <a href={run.htmlUrl ?? run.detailsUrl ?? ""} target="_blank" rel="noreferrer">
                 <ExternalLink className="size-3" />
               </a>
             </Button>
           ) : null}
-          {projectId && run.id ? (
+          {canRerun ? (
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              onClick={rerunJob}
+              disabled={rerunning}
+              title="Rerun failed job"
+            >
+              {rerunning ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RotateCcw className="size-3" />
+              )}
+            </Button>
+          ) : null}
+          {canLoadLogs ? (
             <Button
               type="button"
               size="icon-xs"

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -91,7 +91,10 @@ export function Worklog({
   const [activeTab, setActiveTab] = useState<SidebarTab | null>("worklog");
   const [menuOpen, setMenuOpen] = useState(false);
   const [lastAutoPr, setLastAutoPr] = useState<number | null>(null);
-  const prState = useProjectPullRequest(project);
+  const prState = useProjectPullRequest(project, {
+    enabled: visible,
+    poll: visible && activeTab === "pr",
+  });
   const hasGithubProject = project?.provider === "github" && project.status === "ready";
   const pullRequestNumber = prState.pullRequest?.number ?? null;
 
@@ -628,7 +631,10 @@ function firstLine(value: string): string {
   return value.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? "Markdown plan";
 }
 
-function useProjectPullRequest(project: ProjectSummary | null): {
+function useProjectPullRequest(
+  project: ProjectSummary | null,
+  options: { enabled: boolean; poll: boolean },
+): {
   gitStatus: ProjectGitStatusSummary | null;
   localDiff: ProjectLocalDiffSummary | null;
   pullRequest: ProjectPullRequestSummary | null;
@@ -657,6 +663,7 @@ function useProjectPullRequest(project: ProjectSummary | null): {
 
   useEffect(() => {
     if (
+      !options.enabled ||
       !project ||
       project.provider !== "github" ||
       project.status !== "ready"
@@ -673,7 +680,11 @@ function useProjectPullRequest(project: ProjectSummary | null): {
     }
 
     let cancelled = false;
+    let loadingRequest = false;
+    let pollTimeout: number | null = null;
     const load = async (showLoading: boolean) => {
+      if (loadingRequest) return;
+      loadingRequest = true;
       if (showLoading) setLoading(true);
       try {
         const statusData = await getJson<{ status: ProjectGitStatusSummary }>(
@@ -699,11 +710,18 @@ function useProjectPullRequest(project: ProjectSummary | null): {
           setLocalDiff(null);
         }
         if (selectedPullRequestNumber !== null) {
-          const prData = await getJson<{
-            pullRequest: ProjectPullRequestSummary;
-          }>(
-            `/api/projects/${project.id}/github/pull-request?number=${selectedPullRequestNumber}`,
-          );
+          let prData: { pullRequest: ProjectPullRequestSummary };
+          try {
+            prData = await getJson<{
+              pullRequest: ProjectPullRequestSummary;
+            }>(
+              `/api/projects/${project.id}/github/pull-request?number=${selectedPullRequestNumber}`,
+            );
+          } catch (err) {
+            if (cancelled) return;
+            setError(errorMessage(err, "Failed to load PR"));
+            return;
+          }
           if (cancelled) return;
           setPullRequest(prData.pullRequest);
           setError(localDiffError);
@@ -714,29 +732,40 @@ function useProjectPullRequest(project: ProjectSummary | null): {
           setError(localDiffError);
           return;
         }
-        const prData = await getJson<{
-          pullRequest: ProjectPullRequestSummary | null;
-        }>(
-          `/api/projects/${project.id}/github/pull-request?branch=${encodeURIComponent(
-            statusData.status.branch,
-          )}`,
-        );
+        let prData: { pullRequest: ProjectPullRequestSummary | null };
+        try {
+          prData = await getJson<{
+            pullRequest: ProjectPullRequestSummary | null;
+          }>(
+            `/api/projects/${project.id}/github/pull-request?branch=${encodeURIComponent(
+              statusData.status.branch,
+            )}`,
+          );
+        } catch (err) {
+          if (cancelled) return;
+          setError(errorMessage(err, "Failed to load PR"));
+          return;
+        }
         if (cancelled) return;
         setPullRequest(prData.pullRequest);
         setError(localDiffError);
       } catch (err) {
         if (!cancelled) {
-          setLocalDiff(null);
-          setPullRequest(null);
-          setError(err instanceof Error ? err.message : "Failed to load PR");
+          setError(errorMessage(err, "Failed to load PR"));
         }
       } finally {
+        loadingRequest = false;
         if (!cancelled) setLoading(false);
       }
     };
+    const schedulePoll = () => {
+      if (cancelled || !options.poll) return;
+      pollTimeout = window.setTimeout(() => {
+        void load(false).finally(schedulePoll);
+      }, 15000);
+    };
 
-    void load(true);
-    const interval = window.setInterval(() => void load(false), 15000);
+    void load(true).finally(schedulePoll);
     const onProjectGitChanged = (event: Event) => {
       if (
         event instanceof CustomEvent &&
@@ -749,10 +778,12 @@ function useProjectPullRequest(project: ProjectSummary | null): {
     window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      if (pollTimeout !== null) {
+        window.clearTimeout(pollTimeout);
+      }
       window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     };
-  }, [project, refreshKey, selectedPullRequestNumber]);
+  }, [options.enabled, options.poll, project, refreshKey, selectedPullRequestNumber]);
 
   return {
     gitStatus,

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   Check,
@@ -299,6 +299,8 @@ const SIDEBAR_TABS = [
   label: string;
   Icon: typeof TerminalSquare;
 }[];
+
+const PR_POLL_INTERVAL_MS = 120_000;
 
 function tabMeta(
   tab: SidebarTab,
@@ -652,6 +654,7 @@ function useProjectPullRequest(
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const latestPullRequestRef = useRef<ProjectPullRequestSummary | null>(null);
   const [selectedPullRequest, setSelectedPullRequest] = useState<{
     projectId: string;
     number: number;
@@ -660,6 +663,13 @@ function useProjectPullRequest(
     selectedPullRequest !== null && selectedPullRequest.projectId === project?.id
       ? selectedPullRequest.number
       : null;
+  const setCurrentPullRequest = useCallback(
+    (nextPullRequest: ProjectPullRequestSummary | null) => {
+      latestPullRequestRef.current = nextPullRequest;
+      setPullRequest(nextPullRequest);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (
@@ -671,7 +681,7 @@ function useProjectPullRequest(
       queueMicrotask(() => {
         setGitStatus(null);
         setLocalDiff(null);
-        setPullRequest(null);
+        setCurrentPullRequest(null);
         setError(null);
         setLoading(false);
         setCreating(false);
@@ -723,12 +733,12 @@ function useProjectPullRequest(
             return;
           }
           if (cancelled) return;
-          setPullRequest(prData.pullRequest);
+          setCurrentPullRequest(prData.pullRequest);
           setError(localDiffError);
           return;
         }
         if (!statusData.status.branch || statusData.status.isDefaultBranch) {
-          setPullRequest(null);
+          setCurrentPullRequest(null);
           setError(localDiffError);
           return;
         }
@@ -747,7 +757,7 @@ function useProjectPullRequest(
           return;
         }
         if (cancelled) return;
-        setPullRequest(prData.pullRequest);
+        setCurrentPullRequest(prData.pullRequest);
         setError(localDiffError);
       } catch (err) {
         if (!cancelled) {
@@ -760,9 +770,11 @@ function useProjectPullRequest(
     };
     const schedulePoll = () => {
       if (cancelled || !options.poll) return;
+      const currentPullRequest = latestPullRequestRef.current;
+      if (currentPullRequest === null || currentPullRequest.merged) return;
       pollTimeout = window.setTimeout(() => {
         void load(false).finally(schedulePoll);
-      }, 15000);
+      }, PR_POLL_INTERVAL_MS);
     };
 
     void load(true).finally(schedulePoll);
@@ -783,7 +795,14 @@ function useProjectPullRequest(
       }
       window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
     };
-  }, [options.enabled, options.poll, project, refreshKey, selectedPullRequestNumber]);
+  }, [
+    options.enabled,
+    options.poll,
+    project,
+    refreshKey,
+    selectedPullRequestNumber,
+    setCurrentPullRequest,
+  ]);
 
   return {
     gitStatus,
@@ -814,7 +833,7 @@ function useProjectPullRequest(
             projectId: project.id,
             number: data.pullRequest.number,
           });
-          setPullRequest(data.pullRequest);
+          setCurrentPullRequest(data.pullRequest);
           setError(null);
         })
         .catch((err: unknown) => {

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -154,6 +154,7 @@ const checkRunSchema = z.object({
     .nullable()
     .catch(null),
   html_url: z.string().url().nullable().optional(),
+  details_url: z.string().url().nullable().optional(),
 });
 
 const checkRunsResponseSchema = z.object({
@@ -449,14 +450,14 @@ export async function createInstallationToken(installationId: number): Promise<{
   return result;
 }
 
-export async function getCheckRunLogs(input: {
+export async function getWorkflowJobLogs(input: {
   installationId: number;
   owner: string;
   repo: string;
-  checkRunId: number;
+  jobId: number;
 }): Promise<string> {
   const token = await createInstallationToken(input.installationId);
-  const url = `${GITHUB_API}/repos/${repoPath(input.owner, input.repo)}/actions/jobs/${input.checkRunId}/logs`;
+  const url = `${GITHUB_API}/repos/${repoPath(input.owner, input.repo)}/actions/jobs/${input.jobId}/logs`;
 
   const res = await fetch(url, {
     redirect: "manual",
@@ -482,9 +483,25 @@ export async function getCheckRunLogs(input: {
   }
 
   if (!res.ok) {
-    throw new GitHubAppError(`Failed to fetch check run logs (${res.status})`);
+    throw new GitHubAppError(`Failed to fetch workflow job logs (${res.status})`);
   }
   return res.text();
+}
+
+export async function rerunWorkflowJob(input: {
+  installationId: number;
+  owner: string;
+  repo: string;
+  jobId: number;
+}): Promise<void> {
+  const token = await createInstallationToken(input.installationId);
+  await githubFetch(
+    `/repos/${repoPath(input.owner, input.repo)}/actions/jobs/${input.jobId}/rerun`,
+    {
+      method: "POST",
+      token: token.token,
+    },
+  );
 }
 
 async function fetchPullRequest(input: {
@@ -719,10 +736,13 @@ function summarizeChecks(input: {
   const statusContexts = input.status.statuses;
   const runs: ProjectPullRequestCheckSummary[] = input.checkRuns.map((run) => ({
     id: run.id,
+    workflowJobId: workflowJobIdFromCheckRun(run),
     name: run.name,
     status: run.status,
     conclusion: run.conclusion,
     htmlUrl: run.html_url ?? null,
+    detailsUrl: run.details_url ?? null,
+    canRerun: canRerunCheckRun(run),
   }));
   const total = statusContexts.length + runs.length;
   const failed =
@@ -752,6 +772,24 @@ function summarizeChecks(input: {
             : "success";
 
   return { state, total, passed, failed, pending, runs };
+}
+
+function workflowJobIdFromCheckRun(run: GitHubCheckRun): number | null {
+  for (const value of [run.details_url, run.html_url]) {
+    if (!value) continue;
+    const match = /\/actions\/runs\/\d+\/job\/(\d+)(?:\b|$)/.exec(value);
+    if (!match) continue;
+    const id = Number(match[1]);
+    if (Number.isSafeInteger(id) && id > 0) {
+      return id;
+    }
+  }
+  return null;
+}
+
+function canRerunCheckRun(run: GitHubCheckRun): boolean {
+  if (workflowJobIdFromCheckRun(run) === null) return false;
+  return ["failure", "cancelled", "timed_out"].includes(run.conclusion ?? "");
 }
 
 function repoPath(owner: string, repo: string): string {

--- a/src/github/link.ts
+++ b/src/github/link.ts
@@ -6,8 +6,18 @@ import { projects } from "@/src/db/schema";
 import { listInstallationRepositories } from "./app";
 
 export function parseGitHubUrl(url: string): { owner: string; name: string } | null {
-  const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)(?:\.git)?/);
-  if (!match) return null;
+  const trimmed = url.trim();
+  const httpsMatch = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(
+    trimmed,
+  );
+  const sshMatch = /^(?:ssh:\/\/git@github\.com\/|git@github\.com:)([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(
+    trimmed,
+  );
+  const match = httpsMatch ?? sshMatch;
+  if (!match) {
+    return null;
+  }
+
   return {
     owner: match[1],
     name: match[2],

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -97,6 +97,7 @@ export type ProjectLocalDiffSummary = {
 
 export type ProjectPullRequestCheckSummary = {
   id: number | null;
+  workflowJobId: number | null;
   name: string;
   status: "queued" | "in_progress" | "completed" | "unknown";
   conclusion:
@@ -109,6 +110,8 @@ export type ProjectPullRequestCheckSummary = {
     | "action_required"
     | null;
   htmlUrl: string | null;
+  detailsUrl: string | null;
+  canRerun: boolean;
 };
 
 export type ProjectPullRequestDiscussionItem = {


### PR DESCRIPTION
## Summary
- harden local GitHub repository URL parsing for HTTPS/SSH clone URLs with dotted repo names
- replace check-run log lookup with workflow-job log and rerun routes that validate job ids and redact logs
- expose workflow job metadata in PR check summaries and gate PR sidebar log/rerun controls on that metadata
- stabilize PR sidebar refresh behavior so transient PR API failures keep the last loaded data visible
- reduce automatic PR/status polling to a 2-minute, non-overlapping cadence; PR polling only runs while the PR tab is open and the loaded PR is unmerged
- update Phase 5 roadmap items completed by #90/#92 and this follow-up

## Linked issue
- Closes #93

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- URL parsing smoke check for HTTPS and SSH clone URLs with dotted repo names

## Manual verification notes
- Issue-derived branch selection and create-PR empty-state behavior were preserved from #90/#92 and rechecked in code paths.
- PR/status polling was reviewed in the client hooks: manual refresh remains available, background polling is serialized, and merged/no-PR states do not schedule PR polling.
- Live failed GitHub Actions log/rerun interaction was not exercised against a real failed job in this local environment; controls now render only when a workflow job id is available and rerun eligibility is reported by the server.
