### PR TITLE
Add run cost budgets and active stream resume

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,8 +106,8 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add repo map, recent diff summary, and selected file summaries for richer context selection.
 - [✔️] Add model selection validation on the server; reject unsupported or disabled model IDs.
 - [✔️] Add enforceable per-run token and step budgets.
-- [] Add enforceable dollar-cost budgets after reliable model pricing metadata is available.
-- [] Add resumable runs after tool approval, refresh, or network interruption.
+- [✔️] Add enforceable dollar-cost budgets after reliable model pricing metadata is available.
+- [✔️] Add resumable runs after tool approval, refresh, or network interruption.
 - [✔️] Add better system prompts for coding workflow: inspect, plan, edit, verify, summarize.
 - [✔️] Add final response structure that reports changed files, verification, and unresolved risks.
 

--- a/app/api/chat/resume/route.ts
+++ b/app/api/chat/resume/route.ts
@@ -1,0 +1,21 @@
+import { createUIMessageStreamResponse } from "ai";
+
+import { subscribeActiveChatStream } from "@/src/lib/chat-stream-registry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get("sessionId")?.trim();
+  if (!sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const stream = subscribeActiveChatStream(sessionId);
+  if (!stream) {
+    return new Response(null, { status: 204 });
+  }
+
+  return createUIMessageStreamResponse({ stream });
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -114,9 +114,13 @@ export async function POST(req: Request) {
   }
 
   const { sessionId } = parsed.data;
-  const mode = parsed.data.mode ?? DEFAULT_CHAT_MODE;
   const uiMessages = parsed.data.messages as AntonUIMessage[];
-  const profile = runProfileForMessages(mode, uiMessages);
+  const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
+  const approvalContinuation = isToolApprovalContinuation(incomingHistory);
+  const mode = approvalContinuation
+    ? "agent"
+    : parsed.data.mode ?? DEFAULT_CHAT_MODE;
+  const profile = runProfileForMessages(mode, incomingHistory);
   const needsProject = mode !== "chat";
   const requestBodyBytes = byteLength(JSON.stringify(json ?? {}));
   const model = parsed.data.model ?? DEFAULT_MODEL;
@@ -152,8 +156,6 @@ export async function POST(req: Request) {
       projectId,
     });
   } else {
-    const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
-    const approvalContinuation = isToolApprovalContinuation(incomingHistory);
     const conflict = getMessagePersistenceConflict(sessionId, incomingHistory, {
       mutableTailCount: approvalContinuation ? 1 : 0,
       allowExtraAssistantTail: approvalContinuation,
@@ -189,6 +191,12 @@ export async function POST(req: Request) {
     if (existing.model !== model) {
       touchSession(sessionId, model);
     }
+  }
+  if (incomingHistory.length > 0) {
+    saveMessagesIncrementally<AntonUIMessage>(
+      sessionId,
+      redactValue(incomingHistory) as AntonUIMessage[],
+    );
   }
 
   const budget = budgetForProfile(profile);
@@ -1373,10 +1381,10 @@ function runProfileForMessages(
   mode: ChatMode,
   messages: AntonUIMessage[],
 ): AgentRunProfile {
+  if (isToolApprovalContinuation(messages)) return "approval-continuation";
   if (mode === "chat") return "pure-chat";
   if (mode === "ask") return "ask";
   if (mode === "plan") return "plan";
-  if (isToolApprovalContinuation(messages)) return "approval-continuation";
   const latestText = latestUserText(messages).trim().toLowerCase();
   if (latestText === "implement plan") return "accepted-plan-simple";
   if (

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -59,6 +59,7 @@ import {
   upsertToolCall,
   upsertRunEvent,
 } from "@/src/db/queries";
+import { registerActiveChatStream } from "@/src/lib/chat-stream-registry";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
 import { isSupportedModelId } from "@/src/lib/models";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
@@ -311,11 +312,14 @@ export async function POST(req: Request) {
             stepProviderMetadata,
             maxSteps,
             maxTotalTokens,
+            maxCostUsd,
             maxStepLimitReached,
             tokenBudgetReached,
+            costBudgetReached,
             tokenAudit,
           }) => {
-            const budgetLimitReached = maxStepLimitReached || tokenBudgetReached;
+            const budgetLimitReached =
+              maxStepLimitReached || tokenBudgetReached || costBudgetReached;
             contextTerminalStatus = budgetLimitReached ? "error" : "completed";
             trace.finalize(
               budgetLimitReached ? "error" : "completed",
@@ -325,8 +329,10 @@ export async function POST(req: Request) {
               {
                 maxSteps,
                 maxTotalTokens,
+                maxCostUsd,
                 maxStepLimitReached,
                 tokenBudgetReached,
+                costBudgetReached,
                 tokenAudit,
                 stepProviderMetadata,
               },
@@ -391,7 +397,9 @@ export async function POST(req: Request) {
     },
   });
 
-  return createUIMessageStreamResponse({ stream });
+  return createUIMessageStreamResponse({
+    stream: registerActiveChatStream(sessionId, stream),
+  });
 }
 
 function finalAssistantText(messages: AntonUIMessage[]): string | undefined {
@@ -880,8 +888,10 @@ function createTraceWriter({
     limits: {
       maxSteps?: number;
       maxTotalTokens?: number;
+      maxCostUsd?: number;
       maxStepLimitReached?: boolean;
       tokenBudgetReached?: boolean;
+      costBudgetReached?: boolean;
       tokenAudit?: TokenAudit;
       stepProviderMetadata?: ProviderMetadata[];
     } = {},
@@ -908,11 +918,18 @@ function createTraceWriter({
       limits.tokenAudit,
       tokenUsage,
       limits.stepProviderMetadata,
+      {
+        maxCostUsd: limits.maxCostUsd,
+        observedCostUsd: costUsd,
+        reached: limits.costBudgetReached === true,
+      },
     );
     const storedFinishReason = limits.maxStepLimitReached
       ? "max_step_limit"
       : limits.tokenBudgetReached
         ? "token_budget_limit"
+      : limits.costBudgetReached
+        ? "cost_budget_limit"
       : finishReason;
     writeRun(status, {
       finishedAt,
@@ -926,6 +943,8 @@ function createTraceWriter({
       finishReason: storedFinishReason,
       maxSteps: limits.maxSteps,
       maxStepLimitReached: limits.maxStepLimitReached,
+      maxCostUsd: limits.maxCostUsd,
+      costBudgetReached: limits.costBudgetReached,
     });
     if (limits.maxStepLimitReached) {
       startEvent({
@@ -952,6 +971,21 @@ function createTraceWriter({
           finishReason,
           stepCount,
           maxTotalTokens: limits.maxTotalTokens,
+        },
+      });
+    }
+    if (limits.costBudgetReached) {
+      startEvent({
+        id: `${runId}:cost-budget:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Cost budget reached",
+        summary: `Stopped after reaching the per-run cost budget of $${formatCostLimit(limits.maxCostUsd)}.`,
+        details: {
+          finishReason,
+          stepCount,
+          maxCostUsd: limits.maxCostUsd,
+          costUsd,
         },
       });
     }
@@ -1297,17 +1331,42 @@ function runCostMetadata(
   tokenAudit: TokenAudit | undefined,
   tokenUsage: TokenUsageMetrics | undefined,
   stepProviderMetadata: ProviderMetadata[] | undefined,
+  costBudget: {
+    maxCostUsd: number | undefined;
+    observedCostUsd: number | undefined;
+    reached: boolean;
+  },
 ): Record<string, unknown> | null {
   const providerCostMetadata = openRouterCostMetadata(
     providerMetadata,
     stepProviderMetadata,
   );
-  if (!tokenAudit && !tokenUsage) return providerCostMetadata;
+  const costBudgetMetadata = {
+    maxCostUsd: costBudget.maxCostUsd,
+    observedCostUsd: costBudget.observedCostUsd,
+    reached: costBudget.reached,
+    enforcement:
+      costBudget.observedCostUsd === undefined
+        ? "skipped_missing_provider_cost"
+        : "enforced_provider_cost",
+  };
+  if (!tokenAudit && !tokenUsage && !providerCostMetadata) {
+    return redactValue({ costBudget: costBudgetMetadata }) as Record<
+      string,
+      unknown
+    >;
+  }
   return redactValue({
     ...(providerCostMetadata ?? {}),
     ...(tokenUsage ? { tokenUsage } : {}),
     ...(tokenAudit ? { tokenAudit } : {}),
+    costBudget: costBudgetMetadata,
   }) as Record<string, unknown>;
+}
+
+function formatCostLimit(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "unknown";
+  return value.toFixed(value >= 1 ? 2 : 4);
 }
 
 function runProfileForMessages(

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
+  type ChatAddToolApproveResponseFunction,
+  type ChatRequestOptions,
 } from "ai";
 import { PanelLeftOpen, PanelRightClose, PanelRightOpen } from "lucide-react";
 
-import { DEFAULT_MODEL_ID, type ModelId } from "@/src/lib/models";
-import { DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
+import {
+  DEFAULT_MODEL_ID,
+  isSupportedModelId,
+  type ModelId,
+} from "@/src/lib/models";
+import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import type { PermissionMode } from "@/src/agent/permissions";
 import type { AntonUIMessage } from "@/src/lib/trace";
 import type { McpPreflightServer, McpServerSummary } from "@/src/lib/api-types";
@@ -64,6 +70,8 @@ type ComposerControlState = {
 };
 
 const composerControlStateBySession = new Map<string, ComposerControlState>();
+const COMPOSER_CONTROLS_STORAGE_PREFIX = "anton:composer-controls:";
+const PERMISSION_MODES = ["default", "auto-review", "full-access"] as const;
 
 function ChatSession({
   sessionId: sessionIdProp,
@@ -88,6 +96,12 @@ function ChatSession({
     initialProjectId,
     { listen: initialProjectId === null },
   );
+  const initialControls = useMemo(
+    () =>
+      composerControlStateBySession.get(sessionId) ??
+      readStoredComposerControlState(sessionId),
+    [sessionId],
+  );
   const [worklogOpen, setWorklogOpen] = useState(false);
   const [worklogExpanded, setWorklogExpanded] = useState(false);
   const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
@@ -100,22 +114,21 @@ function ChatSession({
     sessionIdProp !== undefined &&
       (initialMessages?.filter(hasVisibleMessageParts).length ?? 0) === 0,
   );
-  const cachedControls = composerControlStateBySession.get(sessionId);
   const [model, setModel] = useState<ModelId>(
-    cachedControls?.model ?? ((initialModel ?? DEFAULT_MODEL_ID) as ModelId),
+    initialControls?.model ?? ((initialModel ?? DEFAULT_MODEL_ID) as ModelId),
   );
   const [permissionMode, setPermissionMode] = useState<PermissionMode>(
-    cachedControls?.permissionMode ?? "auto-review",
+    initialControls?.permissionMode ?? "auto-review",
   );
   const [mode, setMode] = useState<ChatMode>(
-    cachedControls?.mode ?? DEFAULT_CHAT_MODE,
+    initialControls?.mode ?? DEFAULT_CHAT_MODE,
   );
   const [thinkingEnabled, setThinkingEnabled] = useState(
-    cachedControls?.thinkingEnabled ?? false,
+    initialControls?.thinkingEnabled ?? false,
   );
   const [mcpServers, setMcpServers] = useState<McpServerSummary[]>([]);
   const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<string[]>(
-    cachedControls?.selectedMcpServerIds ?? [],
+    initialControls?.selectedMcpServerIds ?? [],
   );
   const [pendingMcpSend, setPendingMcpSend] = useState<{
     text: string;
@@ -176,6 +189,37 @@ function ChatSession({
       void refresh();
     },
   });
+  const previousStatusRef = useRef(status);
+
+  const restorePersistedMessages = useCallback(async (
+    options: { isCancelled?: () => boolean } = {},
+  ) => {
+    if (!sessionIdProp) return;
+    const res = await fetch(`/api/sessions/${sessionIdProp}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) return;
+    const data = (await res.json()) as { messages?: AntonUIMessage[] };
+    if (options.isCancelled?.()) return;
+    const persistedMessages = data.messages?.filter(hasVisibleMessageParts);
+    if (persistedMessages && persistedMessages.length > 0) {
+      setMessages(data.messages ?? persistedMessages);
+      lastNonEmptyMessagesRef.current = persistedMessages;
+      setMessageDisplayOverride(null);
+    }
+  }, [sessionIdProp, setMessages]);
+
+  useEffect(() => {
+    const previousStatus = previousStatusRef.current;
+    previousStatusRef.current = status;
+    if (
+      sessionIdProp &&
+      status === "ready" &&
+      (previousStatus === "submitted" || previousStatus === "streaming")
+    ) {
+      void restorePersistedMessages().catch(() => undefined);
+    }
+  }, [restorePersistedMessages, sessionIdProp, status]);
 
   useEffect(() => {
     const visibleMessages = messages.filter(hasVisibleMessageParts);
@@ -195,18 +239,10 @@ function ChatSession({
     if (!sessionIdProp || messages.length > 0) return;
 
     let cancelled = false;
-    const restorePersistedMessages = async () => {
+    const restoreInitialPersistedMessages = async () => {
       setRestoringPersistedMessages(true);
       try {
-        const res = await fetch(`/api/sessions/${sessionIdProp}`, {
-          cache: "no-store",
-        });
-        if (!res.ok) return;
-        const data = (await res.json()) as { messages?: AntonUIMessage[] };
-        const persistedMessages = data.messages?.filter(hasVisibleMessageParts);
-        if (!cancelled && persistedMessages && persistedMessages.length > 0) {
-          setMessages(data.messages ?? persistedMessages);
-        }
+        await restorePersistedMessages({ isCancelled: () => cancelled });
       } catch {
         // Keep the current local state; the route refresh still has server truth.
       } finally {
@@ -214,17 +250,36 @@ function ChatSession({
       }
     };
 
-    void restorePersistedMessages();
+    void restoreInitialPersistedMessages();
     return () => {
       cancelled = true;
     };
-  }, [messages.length, sessionIdProp, setMessages]);
+  }, [messages.length, restorePersistedMessages, sessionIdProp]);
 
   useEffect(() => {
     if (resumeAttemptedRef.current || !sessionIdProp) return;
     resumeAttemptedRef.current = true;
     void resumeStream();
   }, [resumeStream, sessionIdProp]);
+
+  useEffect(() => {
+    const storedControls = readStoredComposerControlState(sessionId);
+    if (!storedControls) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setMode(storedControls.mode);
+      setModel(storedControls.model);
+      setPermissionMode(storedControls.permissionMode);
+      setThinkingEnabled(storedControls.thinkingEnabled);
+      if (storedControls.selectedMcpServerIds) {
+        setSelectedMcpServerIds(storedControls.selectedMcpServerIds);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -265,7 +320,54 @@ function ChatSession({
       thinkingEnabled,
       selectedMcpServerIds,
     });
+    writeStoredComposerControlState(sessionId, {
+      mode,
+      model,
+      permissionMode,
+      thinkingEnabled,
+      selectedMcpServerIds,
+    });
   }, [mode, model, permissionMode, selectedMcpServerIds, sessionId, thinkingEnabled]);
+
+  const selectedEnabledMcpServerIds = useCallback(() => (
+    selectedMcpServerIds.filter((id) =>
+      mcpServers.some((server) => server.id === id && server.enabled),
+    )
+  ), [mcpServers, selectedMcpServerIds]);
+
+  const requestBodyForMode = useCallback(
+    (requestedMode: ChatMode): ChatRequestOptions["body"] => ({
+      projectId: effectiveProjectId,
+      model,
+      mode: requestedMode,
+      thinkingEnabled,
+      permissionMode,
+      enabledMcpServerIds:
+        requestedMode === "agent" ? selectedEnabledMcpServerIds() : [],
+    }),
+    [
+      effectiveProjectId,
+      model,
+      permissionMode,
+      selectedEnabledMcpServerIds,
+      thinkingEnabled,
+    ],
+  );
+
+  const approveTool = useCallback<ChatAddToolApproveResponseFunction>(
+    (response) =>
+      addToolApprovalResponse({
+        ...response,
+        options: {
+          ...response.options,
+          body: {
+            ...requestBodyForMode(mode),
+            ...asRecord(response.options?.body),
+          },
+        },
+      }),
+    [addToolApprovalResponse, mode, requestBodyForMode],
+  );
 
   const sendWithMcp = async (
     text: string,
@@ -274,9 +376,7 @@ function ChatSession({
     if (requestedMode !== "chat" && !effectiveProjectId) return false;
     const includeMcp = requestedMode === "agent" && !isAcceptedPlanRequest(text);
     const selectedIds = includeMcp
-      ? selectedMcpServerIds.filter((id) =>
-          mcpServers.some((server) => server.id === id && server.enabled),
-        )
+      ? selectedEnabledMcpServerIds()
       : [];
     if (selectedIds.length > 0) {
       const preflight = await requestJson<{
@@ -300,11 +400,7 @@ function ChatSession({
       { text },
       {
         body: {
-          projectId: effectiveProjectId,
-          model,
-          mode: requestedMode,
-          thinkingEnabled,
-          permissionMode,
+          ...requestBodyForMode(requestedMode),
           enabledMcpServerIds: selectedIds,
         },
       },
@@ -403,7 +499,7 @@ function ChatSession({
             status={status}
             recovering={recoveringMessages}
             streamingResponseMode={streaming ? streamingResponseMode : null}
-            onApproval={addToolApprovalResponse}
+            onApproval={approveTool}
             onAcceptPlan={() => {
               void sendWithMcp("Implement plan", "agent");
             }}
@@ -444,7 +540,7 @@ function ChatSession({
 
         <Worklog
           messages={displayMessages}
-          onApproval={addToolApprovalResponse}
+          onApproval={approveTool}
           project={project}
           visible={worklogOpen}
           expanded={worklogExpanded}
@@ -470,7 +566,7 @@ function ChatSession({
           >
             <Worklog
               messages={displayMessages}
-              onApproval={addToolApprovalResponse}
+              onApproval={approveTool}
               project={project}
               visible
               className="ml-auto h-full w-[min(420px,100%)] border-l"
@@ -497,6 +593,82 @@ function ChatSession({
 
 function isAcceptedPlanRequest(text: string): boolean {
   return text.trim().toLowerCase() === "implement plan";
+}
+
+function composerControlsStorageKey(sessionId: string): string {
+  return `${COMPOSER_CONTROLS_STORAGE_PREFIX}${sessionId}`;
+}
+
+function readStoredComposerControlState(
+  sessionId: string,
+): ComposerControlState | undefined {
+  if (typeof window === "undefined") return undefined;
+  const raw = window.localStorage.getItem(composerControlsStorageKey(sessionId));
+  if (!raw) return undefined;
+  const parsed = parseJsonRecord(raw);
+  if (!parsed) return undefined;
+  const mode = readChatMode(parsed.mode);
+  const model = readModelId(parsed.model);
+  const permissionMode = readPermissionMode(parsed.permissionMode);
+  if (!mode || !model || !permissionMode) return undefined;
+  return {
+    mode,
+    model,
+    permissionMode,
+    thinkingEnabled: parsed.thinkingEnabled === true,
+    selectedMcpServerIds: readStringArray(parsed.selectedMcpServerIds),
+  };
+}
+
+function writeStoredComposerControlState(
+  sessionId: string,
+  controls: ComposerControlState,
+): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    composerControlsStorageKey(sessionId),
+    JSON.stringify(controls),
+  );
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return asRecord(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function readChatMode(value: unknown): ChatMode | undefined {
+  return typeof value === "string" && CHAT_MODES.includes(value as ChatMode)
+    ? value as ChatMode
+    : undefined;
+}
+
+function readModelId(value: unknown): ModelId | undefined {
+  return typeof value === "string" && isSupportedModelId(value)
+    ? value
+    : undefined;
+}
+
+function readPermissionMode(value: unknown): PermissionMode | undefined {
+  return typeof value === "string" &&
+    PERMISSION_MODES.includes(value as PermissionMode)
+    ? value as PermissionMode
+    : undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
 }
 
 function McpTrustDialog({

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -81,6 +81,7 @@ function ChatSession({
     initialMessages?.filter(hasVisibleMessageParts) ?? [],
   );
   const restoreMessagesRef = useRef<AntonUIMessage[] | null>(null);
+  const resumeAttemptedRef = useRef(false);
 
   const [sessionId] = useState<string>(() => sessionIdProp ?? generateChatId());
   const [activeProjectId, setActiveProjectId] = useActiveProjectIdState(
@@ -135,6 +136,9 @@ function ChatSession({
         body: () => ({
           sessionId,
         }),
+        prepareReconnectToStreamRequest: ({ id }) => ({
+          api: `/api/chat/resume?sessionId=${encodeURIComponent(id)}`,
+        }),
       }),
     [sessionId],
   );
@@ -146,8 +150,10 @@ function ChatSession({
     stop,
     error,
     setMessages,
+    resumeStream,
     addToolApprovalResponse,
   } = useChat<AntonUIMessage>({
+    id: sessionId,
     transport,
     messages: initialMessages,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
@@ -213,6 +219,12 @@ function ChatSession({
       cancelled = true;
     };
   }, [messages.length, sessionIdProp, setMessages]);
+
+  useEffect(() => {
+    if (resumeAttemptedRef.current || !sessionIdProp) return;
+    resumeAttemptedRef.current = true;
+    void resumeStream();
+  }, [resumeStream, sessionIdProp]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -12,10 +12,14 @@ import {
   openrouter,
   DEFAULT_MODEL,
 } from "@/src/lib/providers";
-import { buildTokenUsageMetrics } from "@/src/lib/token-usage";
+import {
+  buildTokenUsageMetrics,
+  openRouterCostFromMetadata,
+} from "@/src/lib/token-usage";
 import { listMemories } from "@/src/db/queries";
 import {
   budgetForProfile,
+  costBudgetStopCondition,
   tokenBudgetStopCondition,
   type RunBudget,
 } from "./run-budget";
@@ -82,6 +86,7 @@ type RunBudgetAudit = Pick<
   | "maxInputTokens"
   | "maxInputBytes"
   | "maxTotalTokens"
+  | "maxCostUsd"
   | "priorRunContextChars"
   | "workspaceContextChars"
 >;
@@ -399,8 +404,10 @@ export async function runAgent({
     stepCount: number;
     maxSteps: number;
     maxTotalTokens: number;
+    maxCostUsd: number;
     maxStepLimitReached: boolean;
     tokenBudgetReached: boolean;
+    costBudgetReached: boolean;
     tokenAudit: TokenAudit;
   }) => void;
 }) {
@@ -462,6 +469,7 @@ export async function runAgent({
       maxInputTokens: budget.maxInputTokens,
       maxInputBytes: budget.maxInputBytes,
       maxTotalTokens: budget.maxTotalTokens,
+      maxCostUsd: budget.maxCostUsd,
       priorRunContextChars: budget.priorRunContextChars,
       workspaceContextChars: budget.workspaceContextChars,
     },
@@ -478,6 +486,7 @@ export async function runAgent({
     stopWhen: [
       stepCountIs(budget.maxSteps),
       tokenBudgetStopCondition(budget.maxTotalTokens),
+      costBudgetStopCondition(budget.maxCostUsd),
     ],
     providerOptions: {
       openrouter: openRouterProviderOptions(profile, thinkingEnabled),
@@ -582,11 +591,15 @@ export async function runAgent({
         stepCount: observedStepCount,
         maxSteps: budget.maxSteps,
         maxTotalTokens: budget.maxTotalTokens,
+        maxCostUsd: budget.maxCostUsd,
         maxStepLimitReached:
           observedStepCount >= budget.maxSteps && finishReason === "tool-calls",
         tokenBudgetReached:
           finiteNumber(totalUsage.totalTokens) !== undefined &&
           (totalUsage.totalTokens ?? 0) >= budget.maxTotalTokens,
+        costBudgetReached:
+          (openRouterCostFromMetadata(undefined, stepProviderMetadata) ?? 0) >=
+          budget.maxCostUsd,
         tokenAudit,
       });
       await closeMcpTools();

--- a/src/agent/run-budget.ts
+++ b/src/agent/run-budget.ts
@@ -1,5 +1,6 @@
 import type { StopCondition, ToolSet } from "ai";
 
+import { openRouterCostFromMetadata } from "@/src/lib/token-usage";
 import type { AgentRunProfile } from "./loop";
 
 export type RunBudget = {
@@ -9,6 +10,7 @@ export type RunBudget = {
   maxInputTokens: number;
   maxInputBytes: number;
   maxTotalTokens: number;
+  maxCostUsd: number;
   priorRunContextChars: number;
   workspaceContextChars: number;
   latestUserMaxBytes: number;
@@ -22,6 +24,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 4_096,
     maxInputTokens: 24_000,
     maxTotalTokens: 32_000,
+    maxCostUsd: 0.02,
     priorRunContextChars: 0,
     workspaceContextChars: 0,
   },
@@ -30,6 +33,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 4_096,
     maxInputTokens: 32_000,
     maxTotalTokens: 48_000,
+    maxCostUsd: 0.05,
     priorRunContextChars: 4_000,
     workspaceContextChars: 4_000,
   },
@@ -38,6 +42,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 4_096,
     maxInputTokens: 48_000,
     maxTotalTokens: 64_000,
+    maxCostUsd: 0.08,
     priorRunContextChars: 5_000,
     workspaceContextChars: 5_000,
   },
@@ -46,6 +51,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 4_096,
     maxInputTokens: 32_000,
     maxTotalTokens: 48_000,
+    maxCostUsd: 0.08,
     priorRunContextChars: 3_000,
     workspaceContextChars: 3_000,
   },
@@ -54,6 +60,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
+    maxCostUsd: 0.25,
     priorRunContextChars: 6_000,
     workspaceContextChars: 6_000,
   },
@@ -62,6 +69,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 4_096,
     maxInputTokens: 24_000,
     maxTotalTokens: 40_000,
+    maxCostUsd: 0.05,
     priorRunContextChars: 2_500,
     workspaceContextChars: 2_500,
   },
@@ -70,6 +78,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
+    maxCostUsd: 0.25,
     priorRunContextChars: 6_000,
     workspaceContextChars: 6_000,
   },
@@ -78,6 +87,7 @@ const RUN_BUDGETS = {
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
+    maxCostUsd: 0.25,
     priorRunContextChars: 4_000,
     workspaceContextChars: 4_000,
   },
@@ -102,6 +112,20 @@ export function tokenBudgetStopCondition(
 ): StopCondition<ToolSet> {
   return ({ steps }) => {
     return totalStepTokens(steps) >= maxTotalTokens;
+  };
+}
+
+export function costBudgetStopCondition(
+  maxCostUsd: number,
+): StopCondition<ToolSet> {
+  return ({ steps }) => {
+    const costUsd = openRouterCostFromMetadata(
+      undefined,
+      steps
+        .map((step) => step.providerMetadata)
+        .filter((metadata) => metadata !== undefined),
+    );
+    return costUsd !== undefined && costUsd >= maxCostUsd;
   };
 }
 

--- a/src/lib/chat-stream-registry.ts
+++ b/src/lib/chat-stream-registry.ts
@@ -1,0 +1,120 @@
+import type { UIMessageChunk } from "ai";
+
+const CLEANUP_AFTER_MS = 60_000;
+const MAX_REPLAY_CHUNKS = 10_000;
+
+type ActiveChatStream = {
+  chunks: UIMessageChunk[];
+  subscribers: Set<ReadableStreamDefaultController<UIMessageChunk>>;
+  finished: boolean;
+  error: unknown;
+  cleanupTimer: ReturnType<typeof setTimeout> | null;
+};
+
+const globalForChatStreams = globalThis as typeof globalThis & {
+  __antonActiveChatStreams?: Map<string, ActiveChatStream>;
+};
+
+const activeChatStreams =
+  globalForChatStreams.__antonActiveChatStreams ?? new Map<string, ActiveChatStream>();
+
+globalForChatStreams.__antonActiveChatStreams = activeChatStreams;
+
+export function registerActiveChatStream(
+  sessionId: string,
+  source: ReadableStream<UIMessageChunk>,
+): ReadableStream<UIMessageChunk> {
+  const previous = activeChatStreams.get(sessionId);
+  previous?.subscribers.forEach((subscriber) => {
+    subscriber.close();
+  });
+  previous?.subscribers.clear();
+  if (previous?.cleanupTimer) clearTimeout(previous.cleanupTimer);
+
+  const active: ActiveChatStream = {
+    chunks: [],
+    subscribers: new Set(),
+    finished: false,
+    error: undefined,
+    cleanupTimer: null,
+  };
+  activeChatStreams.set(sessionId, active);
+  void pumpActiveStream(sessionId, active, source);
+
+  const subscription = subscribeActiveChatStream(sessionId);
+  if (!subscription) {
+    throw new Error("failed to subscribe to active chat stream");
+  }
+  return subscription;
+}
+
+export function subscribeActiveChatStream(
+  sessionId: string,
+): ReadableStream<UIMessageChunk> | null {
+  const active = activeChatStreams.get(sessionId);
+  if (!active || active.finished) return null;
+  let subscribedController:
+    | ReadableStreamDefaultController<UIMessageChunk>
+    | undefined;
+
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of active.chunks) {
+        controller.enqueue(chunk);
+      }
+      if (active.error !== undefined) {
+        controller.error(active.error);
+        return;
+      }
+      if (active.finished) {
+        controller.close();
+        return;
+      }
+      subscribedController = controller;
+      active.subscribers.add(controller);
+    },
+    cancel() {
+      if (subscribedController) {
+        active.subscribers.delete(subscribedController);
+      }
+    },
+  });
+}
+
+async function pumpActiveStream(
+  sessionId: string,
+  active: ActiveChatStream,
+  source: ReadableStream<UIMessageChunk>,
+): Promise<void> {
+  try {
+    const reader = source.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      active.chunks.push(value);
+      if (active.chunks.length > MAX_REPLAY_CHUNKS) {
+        active.chunks.shift();
+      }
+      for (const subscriber of active.subscribers) {
+        subscriber.enqueue(value);
+      }
+    }
+    active.finished = true;
+    for (const subscriber of active.subscribers) {
+      subscriber.close();
+    }
+  } catch (error) {
+    active.error = error;
+    active.finished = true;
+    for (const subscriber of active.subscribers) {
+      subscriber.error(error);
+    }
+  } finally {
+    active.subscribers.clear();
+    active.cleanupTimer = setTimeout(() => {
+      if (activeChatStreams.get(sessionId) === active) {
+        activeChatStreams.delete(sessionId);
+      }
+    }, CLEANUP_AFTER_MS);
+  }
+}

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -41,6 +41,8 @@ export type AntonMessageMetadata = {
   finishReason?: string;
   maxSteps?: number;
   maxStepLimitReached?: boolean;
+  maxCostUsd?: number;
+  costBudgetReached?: boolean;
 };
 
 export type AntonRunData = {
@@ -59,6 +61,8 @@ export type AntonRunData = {
   finishReason?: string;
   maxSteps?: number;
   maxStepLimitReached?: boolean;
+  maxCostUsd?: number;
+  costBudgetReached?: boolean;
 };
 
 export type AntonRunMetricSnapshot = {
@@ -75,6 +79,8 @@ export type AntonRunMetricSnapshot = {
   costMetadata?: unknown;
   stepCount?: number | null;
   finishReason?: string | null;
+  maxCostUsd?: number | null;
+  costBudgetReached?: boolean | null;
 };
 
 export type AntonActivitySnapshot = {
@@ -736,7 +742,7 @@ function hydrateMetricRecord<T>(
     next ??= { ...record };
     next[key] = metric;
   }
-  for (const key of ["durationMs", "stepCount"] as const) {
+  for (const key of ["durationMs", "stepCount", "maxCostUsd"] as const) {
     const metric = run[key];
     if (typeof metric !== "number" || !Number.isFinite(metric)) continue;
     if (record[key] === metric) continue;
@@ -768,6 +774,10 @@ function hydrateMetricRecord<T>(
   if (run.finishReason === "max_step_limit" && record.maxStepLimitReached !== true) {
     next ??= { ...record };
     next.maxStepLimitReached = true;
+  }
+  if (run.finishReason === "cost_budget_limit" && record.costBudgetReached !== true) {
+    next ??= { ...record };
+    next.costBudgetReached = true;
   }
 
   return (next ?? value) as T;
@@ -835,9 +845,31 @@ function runDataFromSnapshot(run: AntonRunMetricSnapshot): AntonRunData {
     ...(isRecord(run.costMetadata) ? { costMetadata: run.costMetadata } : {}),
     ...(typeof run.stepCount === "number" ? { stepCount: run.stepCount } : {}),
     ...(typeof run.finishReason === "string" ? { finishReason: run.finishReason } : {}),
+    ...costBudgetDataFromMetadata(run.costMetadata),
     ...(run.finishReason === "max_step_limit"
       ? { maxStepLimitReached: true }
       : {}),
+    ...(run.finishReason === "cost_budget_limit"
+      ? { costBudgetReached: true }
+      : {}),
+  };
+}
+
+function costBudgetDataFromMetadata(
+  costMetadata: unknown,
+): Pick<AntonRunData, "maxCostUsd" | "costBudgetReached"> {
+  if (!isRecord(costMetadata)) return {};
+  const costBudget = isRecord(costMetadata.costBudget)
+    ? costMetadata.costBudget
+    : undefined;
+  if (!costBudget) return {};
+  const maxCostUsd = costBudget.maxCostUsd;
+  const reached = costBudget.reached;
+  return {
+    ...(typeof maxCostUsd === "number" && Number.isFinite(maxCostUsd)
+      ? { maxCostUsd }
+      : {}),
+    ...(typeof reached === "boolean" ? { costBudgetReached: reached } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds profile-level per-run dollar-cost budgets enforced from OpenRouter provider cost metadata at step boundaries.
- Persists cost-budget metadata and emits a `Cost budget reached` run event with `cost_budget_limit` finish reason.
- Adds an in-memory active chat stream registry plus `/api/chat/resume` reconnect route, and wires the client to resume persisted sessions through AI SDK v6 reconnect support.
- Marks the related Phase 4 roadmap items complete.

Refs #95

## Verification
- `pnpm typecheck`
- `pnpm lint`
- Runtime smoke: `GET /` on the existing local dev server returned `200`.
- Runtime smoke: `GET /api/chat/resume?sessionId=nonexistent-smoke` returned `204` for no active stream.

## Manual verification note
The full active-agent reload/network reconnect scenario was not exercised end-to-end in this session because it requires running an interactive provider-backed agent turn. The implementation follows the AI SDK v6 reconnect contract and the local no-active-stream path was smoke-tested.
