### PR TITLE
feat: project status panel and agent defaults settings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,11 +128,11 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 ## Phase 6: Developer Experience
 
 - [✔️] Add file tree and file search panel for the active project.
-- [] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
+- [✔️] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
 - [] Add live terminal output streaming for long-running commands.
 - [] Add cancellable background command sessions for dev servers and watchers.
 - [] Add command history with rerun support.
-- [] Add settings for default model, max steps, approval strictness, and workspace root.
+- [✔️] Add settings for default model, max steps, approval strictness, and workspace root.
 - [] Add mobile-friendly workspace and worklog controls.
 - [] Add accessible keyboard navigation for settings, sessions, worklog, approvals, and message actions.
 - [✔️] Split chat UI components into feature-oriented folders.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -30,7 +30,7 @@ import {
   type RunContextStatus,
 } from "@/src/agent/context";
 import { buildWorkspaceContextDigest } from "@/src/agent/workspace-context";
-import { budgetForProfile } from "@/src/agent/run-budget";
+import { budgetForProfile, capRunBudget } from "@/src/agent/run-budget";
 import {
   buildToolApprovalMetadata,
   getNativeToolPermissionMetadata,
@@ -48,6 +48,7 @@ import {
   getMessagePersistenceConflict,
   getProject,
   getSession,
+  getWorkspaceSettings,
   getToolCall,
   MessagePersistenceConflictError,
   saveMessagesIncrementally,
@@ -123,7 +124,11 @@ export async function POST(req: Request) {
   const profile = runProfileForMessages(mode, incomingHistory);
   const needsProject = mode !== "chat";
   const requestBodyBytes = byteLength(JSON.stringify(json ?? {}));
-  const model = parsed.data.model ?? DEFAULT_MODEL;
+  const workspaceSettings = getWorkspaceSettings();
+  const model =
+    parsed.data.model ??
+    workspaceSettings.defaultModel ??
+    DEFAULT_MODEL;
   if (!isSupportedModelId(model)) {
     return Response.json(
       { error: "unsupported model", model },
@@ -199,7 +204,10 @@ export async function POST(req: Request) {
     );
   }
 
-  const budget = budgetForProfile(profile);
+  const budget = capRunBudget(
+    budgetForProfile(profile),
+    workspaceSettings.defaultMaxSteps,
+  );
   const preservation = modelContextPreservation(uiMessages, profile);
   const preparedMessages = prepareMessagesForModel(
     uiMessages,
@@ -290,6 +298,7 @@ export async function POST(req: Request) {
           requestBodyBytes,
           contextBudget: contextBudget.report,
           thinkingEnabled: parsed.data.thinkingEnabled ?? false,
+          maxStepsCap: workspaceSettings.defaultMaxSteps,
           permissionMode: parsed.data.permissionMode as
             | PermissionMode
             | undefined,

--- a/app/api/projects/[id]/git/status/route.ts
+++ b/app/api/projects/[id]/git/status/route.ts
@@ -1,14 +1,9 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
 import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
 import { getProject } from "@/src/db/queries";
-import type { ProjectGitStatusSummary } from "@/src/lib/api-types";
 import { redactText } from "@/src/lib/redaction";
+import { buildProjectGitStatusSummary } from "@/src/workspace/git-status";
 
 export const runtime = "nodejs";
-
-const execFileAsync = promisify(execFile);
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -24,42 +19,7 @@ export async function GET(_req: Request, { params }: Ctx) {
 
   try {
     const root = ensureWorkspaceRootAt(project.localPath);
-    const [branch, status, upstream, remoteUrl, aheadBehind, upstreamAheadBehind] = await Promise.all([
-      gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
-      gitOutput(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
-      gitOutput(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]).catch(
-        () => "",
-      ),
-      gitOutput(root, ["config", "--get", "remote.origin.url"]).catch(() => ""),
-      gitOutput(root, [
-        "rev-list",
-        "--left-right",
-        "--count",
-        `origin/${project.defaultBranch}...HEAD`,
-      ]).catch(() => ""),
-      gitOutput(root, [
-        "rev-list",
-        "--left-right",
-        "--count",
-        "@{upstream}...HEAD",
-      ]).catch(() => ""),
-    ]);
-    const counts = parseAheadBehind(aheadBehind);
-    const upstreamCounts = parseAheadBehind(upstreamAheadBehind);
-    const currentBranch = branch.trim() || null;
-    const summary: ProjectGitStatusSummary = {
-      projectId: project.id,
-      branch: currentBranch,
-      defaultBranch: project.defaultBranch,
-      isDefaultBranch: currentBranch === project.defaultBranch,
-      dirtyCount: status.split("\0").filter(Boolean).length,
-      ahead: counts?.ahead ?? null,
-      behind: counts?.behind ?? null,
-      upstreamAhead: upstreamCounts?.ahead ?? null,
-      upstreamBehind: upstreamCounts?.behind ?? null,
-      upstream: upstream.trim() || null,
-      remoteUrl: remoteUrl.trim() ? redactText(remoteUrl.trim()) : null,
-    };
+    const summary = await buildProjectGitStatusSummary(project, root);
     return Response.json({ status: summary });
   } catch (err) {
     return Response.json(
@@ -67,19 +27,6 @@ export async function GET(_req: Request, { params }: Ctx) {
       { status: 500 },
     );
   }
-}
-
-async function gitOutput(cwd: string, args: string[]): Promise<string> {
-  const result = await execFileAsync("git", args, { cwd });
-  return result.stdout.trim();
-}
-
-function parseAheadBehind(value: string): { ahead: number; behind: number } | null {
-  const [behindRaw, aheadRaw] = value.trim().split(/\s+/, 2);
-  const behind = Number(behindRaw);
-  const ahead = Number(aheadRaw);
-  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null;
-  return { ahead, behind };
 }
 
 function errorMessage(err: unknown): string {

--- a/app/api/projects/[id]/status/route.ts
+++ b/app/api/projects/[id]/status/route.ts
@@ -1,0 +1,70 @@
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { getLastRunForProject, getProject } from "@/src/db/queries";
+import { serializeProject } from "@/src/lib/api-serializers";
+import type { ProjectLastRunSummary, ProjectStatusSummary } from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+import { buildProjectGitStatusSummary, listDirtyFiles } from "@/src/workspace/git-status";
+import { inspectProjectAtPath } from "@/src/workspace/project-inspect";
+import type { Run } from "@/src/db/schema";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  try {
+    const root = ensureWorkspaceRootAt(project.localPath);
+    const [inspect, git, dirtyFiles] = await Promise.all([
+      Promise.resolve(inspectProjectAtPath(root)),
+      buildProjectGitStatusSummary(project, root),
+      listDirtyFiles(root, 50),
+    ]);
+    const lastRun = serializeLastRun(getLastRunForProject(project.id));
+    const status: ProjectStatusSummary = {
+      project: serializeProject(project),
+      packageManager: inspect.packageManager,
+      scripts: inspect.scripts,
+      keyDependencies: inspect.keyDependencies,
+      noteworthyFiles: inspect.noteworthyFiles,
+      git,
+      dirtyFiles,
+      lastRun,
+    };
+    return Response.json({ status });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function serializeLastRun(run: Run | undefined): ProjectLastRunSummary | null {
+  if (!run) return null;
+  return {
+    runId: run.id,
+    sessionId: run.sessionId,
+    status: run.status,
+    model: run.model,
+    startedAt: run.startedAt.getTime(),
+    finishedAt: run.finishedAt?.getTime() ?? null,
+    durationMs: run.durationMs ?? null,
+    stepCount: run.stepCount ?? null,
+    totalTokens: run.totalTokens ?? null,
+    costUsd: run.costUsd ?? null,
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/workspace-settings/route.ts
+++ b/app/api/workspace-settings/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { getWorkspaceSettings } from "@/src/db/queries";
+import { getWorkspaceSettings, updateWorkspaceSettings } from "@/src/db/queries";
+import { isSupportedModelId } from "@/src/lib/models";
 import {
   getLocalWorkspacesRoot,
   setLocalWorkspacesRoot,
@@ -9,8 +10,13 @@ import {
 
 export const runtime = "nodejs";
 
+const permissionModeSchema = z.enum(["default", "auto-review", "full-access"]);
+
 const patchSchema = z.object({
-  localWorkspacesRoot: z.string().trim().min(1).nullable(),
+  localWorkspacesRoot: z.string().trim().min(1).nullable().optional(),
+  defaultModel: z.string().trim().min(1).nullable().optional(),
+  defaultMaxSteps: z.number().int().min(1).max(50).nullable().optional(),
+  defaultPermissionMode: permissionModeSchema.nullable().optional(),
 });
 
 export async function GET() {
@@ -29,8 +35,35 @@ export async function PATCH(req: Request) {
     );
   }
 
+  if (
+    parsed.data.defaultModel !== undefined &&
+    parsed.data.defaultModel !== null &&
+    !isSupportedModelId(parsed.data.defaultModel)
+  ) {
+    return Response.json(
+      { error: "unsupported model", model: parsed.data.defaultModel },
+      { status: 400 },
+    );
+  }
+
   try {
-    await setLocalWorkspacesRoot(parsed.data.localWorkspacesRoot);
+    if ("localWorkspacesRoot" in parsed.data) {
+      await setLocalWorkspacesRoot(parsed.data.localWorkspacesRoot ?? null);
+    }
+    const agentPatch = {
+      ...(parsed.data.defaultModel !== undefined
+        ? { defaultModel: parsed.data.defaultModel }
+        : {}),
+      ...(parsed.data.defaultMaxSteps !== undefined
+        ? { defaultMaxSteps: parsed.data.defaultMaxSteps }
+        : {}),
+      ...(parsed.data.defaultPermissionMode !== undefined
+        ? { defaultPermissionMode: parsed.data.defaultPermissionMode }
+        : {}),
+    };
+    if (Object.keys(agentPatch).length > 0) {
+      updateWorkspaceSettings(agentPatch);
+    }
     return Response.json({ settings: serializeSettings() });
   } catch (err) {
     const status = err instanceof WorkspaceRootError ? 400 : 500;
@@ -46,6 +79,9 @@ function serializeSettings() {
     resolvedLocalWorkspacesRoot: resolved.path,
     source: resolved.source,
     exists: resolved.exists,
+    defaultModel: settings.defaultModel,
+    defaultMaxSteps: settings.defaultMaxSteps,
+    defaultPermissionMode: settings.defaultPermissionMode,
   };
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,10 @@
 import { Chat } from "@/components/features/chat/chat";
 
-export default function Home() {
-  return <Chat key="new-chat" />;
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ chat?: string }>;
+}) {
+  const { chat } = await searchParams;
+  return <Chat key={chat ?? "new-chat"} />;
 }

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -21,6 +21,7 @@ import type { PermissionMode } from "@/src/agent/permissions";
 import type { AntonUIMessage } from "@/src/lib/trace";
 import type { McpPreflightServer, McpServerSummary } from "@/src/lib/api-types";
 import { getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
+import { useWorkspaceAgentDefaults } from "@/components/features/settings/use-workspace-agent-defaults";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -92,6 +93,8 @@ function ChatSession({
   const resumeAttemptedRef = useRef(false);
 
   const [sessionId] = useState<string>(() => sessionIdProp ?? generateChatId());
+  const isDraftSession = sessionIdProp === undefined;
+  const workspaceDefaults = useWorkspaceAgentDefaults();
   const [activeProjectId, setActiveProjectId] = useActiveProjectIdState(
     initialProjectId,
     { listen: initialProjectId === null },
@@ -99,8 +102,8 @@ function ChatSession({
   const initialControls = useMemo(
     () =>
       composerControlStateBySession.get(sessionId) ??
-      readStoredComposerControlState(sessionId),
-    [sessionId],
+      (isDraftSession ? undefined : readStoredComposerControlState(sessionId)),
+    [isDraftSession, sessionId],
   );
   const [worklogOpen, setWorklogOpen] = useState(false);
   const [worklogExpanded, setWorklogExpanded] = useState(false);
@@ -263,23 +266,34 @@ function ChatSession({
   }, [resumeStream, sessionIdProp]);
 
   useEffect(() => {
-    const storedControls = readStoredComposerControlState(sessionId);
-    if (!storedControls) return;
-    let cancelled = false;
+    if (!isDraftSession) {
+      const storedControls = readStoredComposerControlState(sessionId);
+      if (!storedControls) return;
+      let cancelled = false;
+      queueMicrotask(() => {
+        if (cancelled) return;
+        setMode(storedControls.mode);
+        setModel(storedControls.model);
+        setPermissionMode(storedControls.permissionMode);
+        setThinkingEnabled(storedControls.thinkingEnabled);
+        if (storedControls.selectedMcpServerIds) {
+          setSelectedMcpServerIds(storedControls.selectedMcpServerIds);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [isDraftSession, sessionId]);
+
+  useEffect(() => {
+    if (!isDraftSession || !workspaceDefaults) return;
     queueMicrotask(() => {
-      if (cancelled) return;
-      setMode(storedControls.mode);
-      setModel(storedControls.model);
-      setPermissionMode(storedControls.permissionMode);
-      setThinkingEnabled(storedControls.thinkingEnabled);
-      if (storedControls.selectedMcpServerIds) {
-        setSelectedMcpServerIds(storedControls.selectedMcpServerIds);
-      }
+      setModel(workspaceDefaults.model);
+      setPermissionMode(workspaceDefaults.permissionMode);
     });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId]);
+  }, [isDraftSession, workspaceDefaults]);
 
   useEffect(() => {
     let cancelled = false;
@@ -313,21 +327,26 @@ function ChatSession({
   }, [sessionId]);
 
   useEffect(() => {
-    composerControlStateBySession.set(sessionId, {
+    const controls: ComposerControlState = {
       mode,
       model,
       permissionMode,
       thinkingEnabled,
       selectedMcpServerIds,
-    });
-    writeStoredComposerControlState(sessionId, {
-      mode,
-      model,
-      permissionMode,
-      thinkingEnabled,
-      selectedMcpServerIds,
-    });
-  }, [mode, model, permissionMode, selectedMcpServerIds, sessionId, thinkingEnabled]);
+    };
+    composerControlStateBySession.set(sessionId, controls);
+    if (!isDraftSession || persistedRef.current) {
+      writeStoredComposerControlState(sessionId, controls);
+    }
+  }, [
+    isDraftSession,
+    mode,
+    model,
+    permissionMode,
+    selectedMcpServerIds,
+    sessionId,
+    thinkingEnabled,
+  ]);
 
   const selectedEnabledMcpServerIds = useCallback(() => (
     selectedMcpServerIds.filter((id) =>

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -248,8 +248,8 @@ function ModeSelector({
       onValueChange={(next) => onChange(next as ChatMode)}
       disabled={disabled}
     >
-      <SelectTrigger className="h-5 gap-1 border-0 bg-transparent px-1.5 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground">
-        <selected.Icon className="size-3.5" />
+      <SelectTrigger className="h-5 gap-1 border-0 bg-transparent px-1.5 text-[11px] font-medium leading-4 text-muted-foreground hover:bg-accent hover:text-foreground">
+        <selected.Icon className="size-3.5 shrink-0" />
         <SelectValue>{selected.label}</SelectValue>
       </SelectTrigger>
       <SelectContent align="start" className="min-w-40">
@@ -384,10 +384,14 @@ function PermissionsDropdown({
   value: PermissionMode;
   onChange: (mode: PermissionMode) => void;
 }) {
+  const selected =
+    PERMISSION_MODE_ITEMS.find((item) => item.value === value) ??
+    PERMISSION_MODE_ITEMS[1];
   return (
     <Select value={value} onValueChange={(v) => onChange(v as PermissionMode)}>
-      <SelectTrigger className="h-5 gap-1 border-0 bg-transparent px-1.5 text-[11px] font-medium text-primary hover:bg-primary/10">
-        <SelectValue />
+      <SelectTrigger className="h-5 gap-1 border-0 bg-transparent px-1.5 text-[11px] font-medium leading-4 text-primary hover:bg-primary/10">
+        <selected.Icon className="size-3.5 shrink-0" />
+        <SelectValue>{selected.label}</SelectValue>
       </SelectTrigger>
       <SelectContent className="min-w-36">
         <SelectViewport className="p-0.5">

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import type { ProjectGitStatusSummary, ProjectSummary } from "@/src/lib/api-types";
+import type { ProjectGitStatusSummary, ProjectStatusSummary, ProjectSummary } from "@/src/lib/api-types";
 import { getJson } from "@/src/lib/client-fetch";
 
 export const PROJECT_GIT_CHANGED_EVENT = "anton-project-git-change";
@@ -102,4 +102,103 @@ export function useProjectGitStatus(
 
 export function notifyProjectGitChanged(projectId: string): void {
   window.dispatchEvent(new CustomEvent(PROJECT_GIT_CHANGED_EVENT, { detail: projectId }));
+}
+
+const PROJECT_STATUS_POLL_INTERVAL_MS = 120_000;
+
+export function useProjectStatus(projectId: string | null): {
+  status: ProjectStatusSummary | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const [loaded, setLoaded] = useState<{
+    projectId: string;
+    status: ProjectStatusSummary | null;
+    error: string | null;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = async () => {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      const data = await getJson<{ status: ProjectStatusSummary }>(
+        `/api/projects/${projectId}/status`,
+      );
+      setLoaded({ projectId, status: data.status, error: null });
+    } catch (err) {
+      setLoaded({
+        projectId,
+        status: null,
+        error: err instanceof Error ? err.message : "Failed to load project status",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!projectId) {
+      queueMicrotask(() => setLoaded(null));
+      return;
+    }
+
+    let cancelled = false;
+    let pollTimeout: number | null = null;
+    const load = async () => {
+      if (cancelled) return;
+      setLoading(true);
+      try {
+        const data = await getJson<{ status: ProjectStatusSummary }>(
+          `/api/projects/${projectId}/status`,
+        );
+        if (!cancelled) {
+          setLoaded({ projectId, status: data.status, error: null });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setLoaded({
+            projectId,
+            status: null,
+            error:
+              err instanceof Error ? err.message : "Failed to load project status",
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    const schedulePoll = () => {
+      if (cancelled) return;
+      pollTimeout = window.setTimeout(() => {
+        void load().finally(schedulePoll);
+      }, PROJECT_STATUS_POLL_INTERVAL_MS);
+    };
+
+    void load().finally(schedulePoll);
+    const onProjectGitChanged = (event: Event) => {
+      if (
+        event instanceof CustomEvent &&
+        typeof event.detail === "string" &&
+        event.detail === projectId
+      ) {
+        void load();
+      }
+    };
+    window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    return () => {
+      cancelled = true;
+      if (pollTimeout !== null) window.clearTimeout(pollTimeout);
+      window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    };
+  }, [projectId]);
+
+  const isCurrent = loaded?.projectId === projectId;
+  return {
+    status: isCurrent ? loaded?.status ?? null : null,
+    loading,
+    error: isCurrent ? loaded?.error ?? null : null,
+    refresh,
+  };
 }

--- a/components/features/run-trace/project-status-panel.tsx
+++ b/components/features/run-trace/project-status-panel.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type ReactNode } from "react";
+import {
+  Activity,
+  CheckCircle2,
+  Clock,
+  Copy,
+  ExternalLink,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+} from "@/components/shared/feedback-states";
+import { cn } from "@/lib/utils";
+import type { ProjectStatusSummary, ProjectSummary } from "@/src/lib/api-types";
+import { notifyProjectGitChanged, useProjectStatus } from "@/components/features/projects/hooks";
+
+export function ProjectStatusPanel({
+  project,
+}: {
+  project: ProjectSummary | null;
+}) {
+  const { status, loading, error, refresh } = useProjectStatus(
+    project?.status === "ready" ? project.id : null,
+  );
+
+  if (!project) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <EmptyState message="Select a ready project to view status." />
+      </div>
+    );
+  }
+
+  if (project.status !== "ready") {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <EmptyState message={`Project is ${project.status}. Status is unavailable until ready.`} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <section className="border-b border-border px-3 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border">
+              <Activity className="size-3" />
+              Project status
+            </div>
+            <h2 className="mt-2 text-sm font-semibold">{project.fullName}</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Workspace root, git state, scripts, and last agent run.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => {
+              notifyProjectGitChanged(project.id);
+              void refresh();
+            }}
+            disabled={loading}
+            aria-label="Refresh project status"
+            title="Refresh project status"
+          >
+            <RefreshCw className={cn(loading && "animate-spin")} />
+          </Button>
+        </div>
+        {error ? (
+          <div className="mt-3">
+            <ErrorBanner message={error} />
+          </div>
+        ) : null}
+      </section>
+
+      {loading && !status ? (
+        <div className="px-3 py-4">
+          <LoadingState label="Loading project status..." />
+        </div>
+      ) : status ? (
+        <div className="space-y-0">
+          <StatusSection title="Overview">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              <Metric label="Branch" value={status.git.branch ?? "—"} />
+              <Metric label="Dirty" value={status.git.dirtyCount} />
+              <Metric
+                label="Package manager"
+                value={status.packageManager ?? "none"}
+              />
+            </div>
+          </StatusSection>
+
+          <StatusSection title="Root path">
+            <PathRow path={status.project.localPath} />
+          </StatusSection>
+
+          <StatusSection title="Git">
+            <div className="space-y-2 text-xs text-muted-foreground">
+              <div className="flex flex-wrap gap-2">
+                {status.git.upstream ? (
+                  <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px]">
+                    {status.git.upstream}
+                  </span>
+                ) : (
+                  <span>No upstream configured</span>
+                )}
+                {status.git.ahead !== null && status.git.behind !== null ? (
+                  <span>
+                    {status.git.ahead} ahead · {status.git.behind} behind origin
+                  </span>
+                ) : null}
+              </div>
+              {status.dirtyFiles.length > 0 ? (
+                <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md bg-background/35 p-2 font-mono text-[10px] ring-1 ring-border/70">
+                  {status.dirtyFiles.map((file) => (
+                    <li key={file} className="truncate">
+                      {file}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>Working tree clean</p>
+              )}
+            </div>
+          </StatusSection>
+
+          <StatusSection title="Scripts">
+            {status.scripts.length > 0 ? (
+              <div className="flex flex-wrap gap-1.5">
+                {status.scripts.map((script) => (
+                  <span
+                    key={script}
+                    className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                  >
+                    {script}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">No npm scripts detected</p>
+            )}
+          </StatusSection>
+
+          <StatusSection title="Last run">
+            {status.lastRun ? (
+              <LastRunCard lastRun={status.lastRun} />
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No agent runs recorded for this project yet.
+              </p>
+            )}
+          </StatusSection>
+        </div>
+      ) : (
+        <div className="px-3 py-4">
+          <EmptyState message="Project status unavailable." />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border-b border-border px-3 py-3">
+      <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-md bg-background/45 px-2 py-1.5 ring-1 ring-border">
+      <div className="text-[10px] uppercase text-muted-foreground">{label}</div>
+      <div className="truncate font-mono text-xs font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function PathRow({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div className="flex items-start gap-2">
+      <code className="min-w-0 flex-1 break-all rounded-md bg-background/35 px-2 py-1.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border/70">
+        {path}
+      </code>
+      <Button
+        type="button"
+        size="icon-sm"
+        variant="ghost"
+        aria-label="Copy root path"
+        title="Copy root path"
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(path);
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          } catch {
+            setCopied(false);
+          }
+        }}
+      >
+        {copied ? <CheckCircle2 className="size-3.5" /> : <Copy className="size-3.5" />}
+      </Button>
+    </div>
+  );
+}
+
+function LastRunCard({
+  lastRun,
+}: {
+  lastRun: NonNullable<ProjectStatusSummary["lastRun"]>;
+}) {
+  const statusMeta = runStatusMeta(lastRun.status);
+  return (
+    <div className="rounded-md bg-background/35 p-2.5 ring-1 ring-border/70">
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ring-1",
+            statusMeta.className,
+          )}
+        >
+          <statusMeta.Icon className="size-3" />
+          {statusMeta.label}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {lastRun.model}
+        </span>
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Metric
+          label="Duration"
+          value={
+            lastRun.durationMs !== null
+              ? `${Math.round(lastRun.durationMs / 1000)}s`
+              : "—"
+          }
+        />
+        <Metric label="Steps" value={lastRun.stepCount ?? "—"} />
+        <Metric label="Tokens" value={lastRun.totalTokens ?? "—"} />
+        <Metric
+          label="Cost"
+          value={
+            lastRun.costUsd !== null ? `$${lastRun.costUsd.toFixed(4)}` : "—"
+          }
+        />
+      </div>
+      <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground">
+        <Clock className="size-3" />
+        {new Date(lastRun.startedAt).toLocaleString()}
+        <Link
+          href={`/s/${lastRun.sessionId}`}
+          className="ml-auto inline-flex items-center gap-1 text-foreground hover:underline"
+        >
+          Open session
+          <ExternalLink className="size-3" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function runStatusMeta(status: NonNullable<ProjectStatusSummary["lastRun"]>["status"]) {
+  switch (status) {
+    case "completed":
+      return {
+        Icon: CheckCircle2,
+        label: "Completed",
+        className: "text-emerald-400 ring-emerald-400/30 bg-emerald-400/10",
+      };
+    case "running":
+      return {
+        Icon: Clock,
+        label: "Running",
+        className: "text-amber-400 ring-amber-400/30 bg-amber-400/10",
+      };
+    case "aborted":
+      return {
+        Icon: XCircle,
+        label: "Aborted",
+        className: "text-muted-foreground ring-border bg-secondary",
+      };
+    case "error":
+      return {
+        Icon: XCircle,
+        label: "Error",
+        className: "text-destructive ring-destructive/30 bg-destructive/10",
+      };
+  }
+}

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   GitBranch,
   FolderTree,
+  Info,
   ListTodo,
   Loader2,
   Maximize2,
@@ -55,6 +56,7 @@ import { TodoCard } from "./todo-card";
 import { getSessionTodoSnapshots } from "./trace-data";
 import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
 import { ProjectFilesPanel } from "./project-files-panel";
+import { ProjectStatusPanel } from "./project-status-panel";
 import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 import { PROJECT_GIT_CHANGED_EVENT } from "@/components/features/projects/hooks";
 import type {
@@ -66,7 +68,7 @@ import type {
 } from "@/src/lib/api-types";
 
 export type WorklogEntry = ToolTraceEntry;
-type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files";
+type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "status";
 
 interface WorklogProps {
   messages: AntonUIMessage[];
@@ -273,6 +275,8 @@ export function Worklog({
             expanded={expanded}
             onFileOpen={onFileOpen}
           />
+        ) : activeTab === "status" ? (
+          <ProjectStatusPanel project={project} />
         ) : activeTab === "pr" && prState.pullRequest ? (
           <PullRequestPanel
             pullRequest={prState.pullRequest}
@@ -306,6 +310,7 @@ const SIDEBAR_TABS = [
   { id: "todos", label: "Todos", Icon: ListTodo },
   { id: "pr", label: "PR", Icon: GitBranch },
   { id: "files", label: "Files", Icon: FolderTree },
+  { id: "status", label: "Status", Icon: Info },
 ] as const satisfies readonly {
   id: SidebarTab;
   label: string;

--- a/components/features/sessions/session-sidebar.tsx
+++ b/components/features/sessions/session-sidebar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 import {
@@ -15,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { SettingsDialog } from "@/components/features/settings/settings-dialog";
 import { useActiveProjectIdState } from "@/src/lib/client-state/active-project";
 
+import { generateChatId } from "@/components/features/chat/chat-utils";
 import { SessionRow } from "./session-row";
 import { useSessionStore } from "./session-store";
 import { SidebarProvider, useSidebar } from "./sidebar-state";
@@ -56,9 +56,13 @@ export function SessionSidebar() {
           sessions={sessions}
           onCollapse={() => setOpen(false)}
           onOpenSettings={() => setSettingsOpen(true)}
+          onNewChat={() => router.push(`/?chat=${generateChatId()}`)}
         />
       ) : (
-        <CollapsedSidebar onOpenSettings={() => setSettingsOpen(true)} />
+        <CollapsedSidebar
+          onOpenSettings={() => setSettingsOpen(true)}
+          onNewChat={() => router.push(`/?chat=${generateChatId()}`)}
+        />
       )}
       <SettingsDialog
         open={settingsOpen}
@@ -77,6 +81,7 @@ function ExpandedSidebar({
   sessions,
   onCollapse,
   onOpenSettings,
+  onNewChat,
 }: {
   activeId: string | undefined;
   loading: boolean;
@@ -84,6 +89,7 @@ function ExpandedSidebar({
   sessions: ReturnType<typeof useSessionStore>["sessions"];
   onCollapse: () => void;
   onOpenSettings: () => void;
+  onNewChat: () => void;
 }) {
   return (
     <div className="flex h-full w-[300px] shrink-0 flex-col">
@@ -113,10 +119,14 @@ function ExpandedSidebar({
 
       <div className="flex items-center justify-between gap-2 px-2 py-1.5">
         <span className="text-xs font-medium text-muted-foreground">Recent</span>
-        <Button asChild size="icon-sm" variant="ghost" aria-label="New chat">
-          <Link href="/">
-            <Plus />
-          </Link>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label="New chat"
+          onClick={onNewChat}
+        >
+          <Plus />
         </Button>
       </div>
 
@@ -146,8 +156,10 @@ function ExpandedSidebar({
 
 function CollapsedSidebar({
   onOpenSettings,
+  onNewChat,
 }: {
   onOpenSettings: () => void;
+  onNewChat: () => void;
 }) {
   return (
     <div className="flex h-full w-[41px] shrink-0 flex-col">
@@ -164,10 +176,14 @@ function CollapsedSidebar({
         >
           <MessageSquare />
         </Button>
-        <Button asChild size="icon-sm" variant="ghost" aria-label="New chat">
-          <Link href="/">
-            <Plus className="size-3.5" />
-          </Link>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label="New chat"
+          onClick={onNewChat}
+        >
+          <Plus className="size-3.5" />
         </Button>
       </nav>
       <div className="mt-auto flex w-full justify-center border-t border-sidebar-border py-1.5">

--- a/components/features/settings/agent-settings-panel.tsx
+++ b/components/features/settings/agent-settings-panel.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ShieldCheck,
+  ShieldOff,
+  ShieldQuestion,
+  SlidersHorizontal,
+} from "lucide-react";
+
+import { ErrorBanner, LoadingState } from "@/components/shared/feedback-states";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
+import type { PermissionMode } from "@/src/agent/permissions";
+import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
+import {
+  DEFAULT_MODEL_ID,
+  isSupportedModelId,
+  MODEL_CATALOG,
+  type ModelId,
+} from "@/src/lib/models";
+import {
+  errorMessage,
+  getJson,
+  jsonHeaders,
+  requestJson,
+} from "@/src/lib/client-fetch";
+import { notifyWorkspaceAgentDefaultsChanged } from "@/src/lib/client-state/workspace-agent-defaults";
+
+import { SettingsCard, SettingsPageShell } from "./settings-shell";
+
+const COMPACT_SELECT_TRIGGER_CLASS =
+  "h-5 w-44 px-1.5 text-[11px] font-medium text-foreground hover:bg-primary/10";
+const COMPACT_SELECT_CONTENT_CLASS = "min-w-36";
+const COMPACT_SELECT_VIEWPORT_CLASS = "p-0.5";
+const COMPACT_SELECT_ITEM_CLASS = "py-1 pr-7 pl-1.5";
+
+const PERMISSION_MODE_ITEMS = [
+  { value: "default", label: "Ask every time", Icon: ShieldQuestion },
+  { value: "auto-review", label: "Auto-review", Icon: ShieldCheck },
+  { value: "full-access", label: "Full access", Icon: ShieldOff },
+] as const satisfies readonly {
+  value: PermissionMode;
+  label: string;
+  Icon: typeof ShieldCheck;
+}[];
+
+export function AgentSettingsPanel() {
+  const [settings, setSettings] = useState<WorkspaceSettingsSummary | null>(null);
+  const [model, setModel] = useState<ModelId>(DEFAULT_MODEL_ID);
+  const [maxSteps, setMaxSteps] = useState("");
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>("auto-review");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await getJson<{ settings: WorkspaceSettingsSummary }>(
+          "/api/workspace-settings",
+        );
+        if (cancelled) return;
+        setSettings(data.settings);
+        setModel(
+          data.settings.defaultModel &&
+            isSupportedModelId(data.settings.defaultModel)
+            ? data.settings.defaultModel
+            : DEFAULT_MODEL_ID,
+        );
+        setMaxSteps(
+          data.settings.defaultMaxSteps !== null
+            ? String(data.settings.defaultMaxSteps)
+            : "",
+        );
+        setPermissionMode(data.settings.defaultPermissionMode ?? "auto-review");
+        setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(errorMessage(err, "Failed to load agent defaults"));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const parsedMaxSteps = maxSteps.trim() ? Number(maxSteps.trim()) : null;
+      if (
+        parsedMaxSteps !== null &&
+        (!Number.isInteger(parsedMaxSteps) ||
+          parsedMaxSteps < 1 ||
+          parsedMaxSteps > 50)
+      ) {
+        setError("Max steps must be an integer between 1 and 50.");
+        return;
+      }
+      const data = await requestJson<{ settings: WorkspaceSettingsSummary }>(
+        "/api/workspace-settings",
+        {
+          method: "PATCH",
+          headers: jsonHeaders(),
+          body: JSON.stringify({
+            defaultModel: model,
+            defaultMaxSteps: parsedMaxSteps,
+            defaultPermissionMode: permissionMode,
+          }),
+        },
+      );
+      setSettings(data.settings);
+      notifyWorkspaceAgentDefaultsChanged(data.settings);
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to save agent defaults"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsPageShell
+      title="Agent defaults"
+      description="Set the default model, step budget cap, and approval strictness for new chat sessions."
+    >
+      {error ? (
+        <div className="mb-3">
+          <ErrorBanner message={error} />
+        </div>
+      ) : null}
+      {loading ? (
+        <LoadingState label="Loading agent defaults..." />
+      ) : (
+        <div className="space-y-3">
+          <SettingsCard title="Default model" icon={<SlidersHorizontal />}>
+            <div className="max-w-sm">
+              <Select value={model} onValueChange={(value) => setModel(value as ModelId)}>
+                <SelectTrigger className={COMPACT_SELECT_TRIGGER_CLASS}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className={COMPACT_SELECT_CONTENT_CLASS}>
+                  <SelectViewport className={COMPACT_SELECT_VIEWPORT_CLASS}>
+                    {MODEL_CATALOG.map((item) => (
+                      <SelectItem
+                        key={item.id}
+                        value={item.id}
+                        className={COMPACT_SELECT_ITEM_CLASS}
+                      >
+                        <span className="text-xs leading-4">{item.label}</span>
+                      </SelectItem>
+                    ))}
+                  </SelectViewport>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Used when a session has no saved composer override.
+            </p>
+          </SettingsCard>
+
+          <SettingsCard title="Max steps">
+            <div className="max-w-xs space-y-2">
+              <Input
+                type="text"
+                inputMode="numeric"
+                autoComplete="off"
+                value={maxSteps}
+                placeholder="Profile default"
+                onChange={(event) => {
+                  const next = event.target.value.replace(/\D/g, "");
+                  if (next === "" || Number(next) <= 50) {
+                    setMaxSteps(next);
+                  }
+                }}
+                aria-label="Default max steps"
+                className="h-7 px-2 text-[11px] tabular-nums"
+              />
+              <p className="text-xs text-muted-foreground">
+                Caps the agent step budget. Profile-specific limits may still be
+                lower.
+              </p>
+            </div>
+          </SettingsCard>
+
+          <SettingsCard title="Approval strictness">
+            <div className="max-w-sm">
+              <Select
+                value={permissionMode}
+                onValueChange={(value) => setPermissionMode(value as PermissionMode)}
+              >
+                <SelectTrigger className={COMPACT_SELECT_TRIGGER_CLASS}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className={COMPACT_SELECT_CONTENT_CLASS}>
+                  <SelectViewport className={COMPACT_SELECT_VIEWPORT_CLASS}>
+                    {PERMISSION_MODE_ITEMS.map((item) => (
+                      <SelectItem
+                        key={item.value}
+                        value={item.value}
+                        className={COMPACT_SELECT_ITEM_CLASS}
+                      >
+                        <span className="inline-flex items-center gap-1.5 text-xs leading-4">
+                          <item.Icon className="size-3.5" />
+                          {item.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectViewport>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Default permission mode for new sessions. Composer controls still
+              override per session.
+            </p>
+          </SettingsCard>
+
+          <div className="flex items-center gap-2">
+            <Button type="button" onClick={() => void save()} disabled={saving}>
+              {saving ? "Saving..." : "Save defaults"}
+            </Button>
+            {settings ? (
+              <span className="text-xs text-muted-foreground">
+                Workspace root remains in Workspaces settings.
+              </span>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </SettingsPageShell>
+  );
+}

--- a/components/features/settings/settings-dialog.tsx
+++ b/components/features/settings/settings-dialog.tsx
@@ -10,6 +10,7 @@ import {
   SettingsShell,
   type SettingsSection,
 } from "./settings-shell";
+import { AgentSettingsPanel } from "./agent-settings-panel";
 import { McpSettingsPanel } from "./mcp-settings-panel";
 import { WorkspaceSettingsPanel } from "./workspace-settings-panel";
 
@@ -59,6 +60,7 @@ export function SettingsDialog({
           onActiveProjectChange={onActiveProjectChange}
         />
       )}
+      {section === "agent" && <AgentSettingsPanel />}
       {section === "mcp" && <McpSettingsPanel />}
       {section === "memories" && (
         <SettingsPageShell

--- a/components/features/settings/settings-shell.tsx
+++ b/components/features/settings/settings-shell.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
-export type SettingsSection = "workspaces" | "mcp" | "memories" | "skills";
+export type SettingsSection = "workspaces" | "agent" | "mcp" | "memories" | "skills";
 
 export function SettingsShell({
   section,
@@ -58,6 +58,14 @@ export function SettingsShell({
                 onClick={() => onSectionChange("workspaces")}
               >
                 Workspaces
+              </SettingsNavButton>
+            </SettingsGroup>
+            <SettingsGroup title="Agent">
+              <SettingsNavButton
+                active={section === "agent"}
+                onClick={() => onSectionChange("agent")}
+              >
+                Agent defaults
               </SettingsNavButton>
             </SettingsGroup>
             <SettingsGroup title="Project context">
@@ -114,6 +122,7 @@ export function SettingsShell({
           >
             <TabsList>
               <TabsTrigger value="workspaces">Workspaces</TabsTrigger>
+              <TabsTrigger value="agent">Agent</TabsTrigger>
               <TabsTrigger value="mcp">MCP</TabsTrigger>
               <TabsTrigger value="memories">Memories</TabsTrigger>
               <TabsTrigger value="skills">Skills</TabsTrigger>
@@ -220,6 +229,8 @@ function sectionTitle(section: SettingsSection): string {
   switch (section) {
     case "workspaces":
       return "Workspaces";
+    case "agent":
+      return "Agent defaults";
     case "mcp":
       return "MCP";
     case "memories":

--- a/components/features/settings/use-workspace-agent-defaults.ts
+++ b/components/features/settings/use-workspace-agent-defaults.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { WorkspaceAgentDefaults } from "@/src/lib/client-state/workspace-agent-defaults";
+import {
+  fetchWorkspaceAgentDefaults,
+  WORKSPACE_AGENT_DEFAULTS_CHANGED_EVENT,
+  workspaceDefaultsFromSettings,
+} from "@/src/lib/client-state/workspace-agent-defaults";
+import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
+
+export function useWorkspaceAgentDefaults(): WorkspaceAgentDefaults | null {
+  const [defaults, setDefaults] = useState<WorkspaceAgentDefaults | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setDefaults(await fetchWorkspaceAgentDefaults());
+    } catch {
+      setDefaults(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial defaults hydration updates state after async requests settle.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+    const onChanged = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      const settings = event.detail as WorkspaceSettingsSummary | undefined;
+      if (settings) {
+        setDefaults(workspaceDefaultsFromSettings(settings));
+        return;
+      }
+      void refresh();
+    };
+    window.addEventListener(WORKSPACE_AGENT_DEFAULTS_CHANGED_EVENT, onChanged);
+    return () => {
+      window.removeEventListener(WORKSPACE_AGENT_DEFAULTS_CHANGED_EVENT, onChanged);
+    };
+  }, [refresh]);
+
+  return defaults;
+}

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -19,6 +19,7 @@ import {
 import { listMemories } from "@/src/db/queries";
 import {
   budgetForProfile,
+  capRunBudget,
   costBudgetStopCondition,
   tokenBudgetStopCondition,
   type RunBudget,
@@ -354,6 +355,7 @@ export async function runAgent({
   profile = profileForMode(mode),
   enabledMcpServerIds,
   thinkingEnabled = false,
+  maxStepsCap,
   requestBodyBytes,
   contextBudget,
   onStepStart,
@@ -373,6 +375,7 @@ export async function runAgent({
   profile?: AgentRunProfile;
   enabledMcpServerIds?: string[];
   thinkingEnabled?: boolean;
+  maxStepsCap?: number | null;
   requestBodyBytes?: number;
   contextBudget?: ContextBudgetAudit;
   onStepStart?: (event: { stepNumber: number }) => void;
@@ -411,7 +414,7 @@ export async function runAgent({
     tokenAudit: TokenAudit;
   }) => void;
 }) {
-  const budget = budgetForProfile(profile);
+  const budget = capRunBudget(budgetForProfile(profile), maxStepsCap);
   const nativeToolNames = PROFILE_NATIVE_TOOLS[profile];
   const allowMcpTools = profileAllowsMcp(profile);
   const mcpTools = allowMcpTools

--- a/src/agent/run-budget.ts
+++ b/src/agent/run-budget.ts
@@ -107,6 +107,17 @@ export function budgetForProfile(profile: AgentRunProfile): RunBudget {
   };
 }
 
+export function capRunBudget(
+  budget: RunBudget,
+  maxStepsCap: number | null | undefined,
+): RunBudget {
+  if (maxStepsCap === null || maxStepsCap === undefined) return budget;
+  return {
+    ...budget,
+    maxSteps: Math.min(budget.maxSteps, maxStepsCap),
+  };
+}
+
 export function tokenBudgetStopCondition(
   maxTotalTokens: number,
 ): StopCondition<ToolSet> {

--- a/src/agent/tools/inspect-project.ts
+++ b/src/agent/tools/inspect-project.ts
@@ -1,33 +1,11 @@
-import { execFileSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
 import { tool } from "ai";
 import { z } from "zod";
 
-import { buildBashEnvironment } from "../command-policy";
 import {
   ensureWorkspaceRoot,
   ensureWorkspaceRootAt,
 } from "../sandbox";
-import {
-  dependencyNames,
-  detectPackageManager,
-  readPackageJson,
-  scriptNames,
-} from "./package-manager";
-
-const NOTEWORTHY_FILES = [
-  "AGENTS.md",
-  "CLAUDE.md",
-  "README.md",
-  "ROADMAP.md",
-  "package.json",
-  "tsconfig.json",
-  "next.config.ts",
-  "vite.config.ts",
-  "drizzle.config.ts",
-  ".mcp.json",
-] as const;
+import { inspectProjectAtPath } from "@/src/workspace/project-inspect";
 
 export function createInspectProjectTool(workspaceRoot?: string) {
   return tool({
@@ -38,150 +16,13 @@ export function createInspectProjectTool(workspaceRoot?: string) {
       const root = workspaceRoot
         ? ensureWorkspaceRootAt(workspaceRoot)
         : ensureWorkspaceRoot();
-      const packageJson = readPackageJson(root);
-      const git = gitInfo(root);
-
-      if (!packageJson.ok) {
-        return {
-          ok: true as const,
-          packageManager: null,
-          scripts: [],
-          keyDependencies: [],
-          noteworthyFiles: existingNoteworthyFiles(root),
-          git,
-          summary: "No package.json found; inspect files manually before coding.",
-        };
-      }
-
-      const dependencies = dependencyNames(packageJson.value);
-      const keyDependencies = dependencies.filter(isKeyDependency).slice(0, 30);
-      const scripts = scriptNames(packageJson.value);
-      const packageManager = detectPackageManager(root, packageJson.value);
-
+      const result = inspectProjectAtPath(root);
       return {
         ok: true as const,
-        packageManager,
-        scripts,
-        keyDependencies,
-        noteworthyFiles: existingNoteworthyFiles(root),
-        git,
-        summary: [
-          `${packageManager} project`,
-          scripts.length ? `scripts: ${scripts.join(", ")}` : "no scripts",
-          keyDependencies.length
-            ? `key deps: ${keyDependencies.join(", ")}`
-            : "no key deps detected",
-          git.branch ? `git branch: ${git.branch}` : "git branch unavailable",
-          git.dirtyFileCount > 0
-            ? `${git.dirtyFileCount} dirty file${git.dirtyFileCount === 1 ? "" : "s"}`
-            : "working tree clean",
-        ].join("; "),
+        ...result,
       };
     },
   });
 }
 
 export const inspectProjectTool = createInspectProjectTool();
-
-function existingNoteworthyFiles(root: string): string[] {
-  return NOTEWORTHY_FILES.filter((file) => fs.existsSync(path.join(root, file)));
-}
-
-function isKeyDependency(name: string): boolean {
-  return [
-    "@ai-sdk/react",
-    "@openrouter/ai-sdk-provider",
-    "ai",
-    "better-sqlite3",
-    "drizzle-orm",
-    "eslint",
-    "next",
-    "react",
-    "tailwindcss",
-    "typescript",
-    "vite",
-    "zod",
-  ].includes(name);
-}
-
-function gitInfo(root: string): {
-  isRepository: boolean;
-  branch: string | null;
-  dirtyFileCount: number;
-  dirtyFiles: string[];
-  error?: string;
-} {
-  const inside = runGit(root, ["rev-parse", "--is-inside-work-tree"]);
-  if (!inside.ok) {
-    return {
-      isRepository: false,
-      branch: null,
-      dirtyFileCount: 0,
-      dirtyFiles: [],
-      error: inside.error,
-    };
-  }
-  if (inside.stdout.trim() !== "true") {
-    return {
-      isRepository: false,
-      branch: null,
-      dirtyFileCount: 0,
-      dirtyFiles: [],
-    };
-  }
-
-  const branch = runGit(root, ["branch", "--show-current"]);
-  const status = runGit(root, ["status", "--short"]);
-  const dirtyFiles = status.ok
-    ? status.stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .slice(0, 20)
-    : [];
-
-  return {
-    isRepository: true,
-    branch: branch.ok ? branch.stdout.trim() || null : null,
-    dirtyFileCount: status.ok
-      ? status.stdout.split(/\r?\n/).filter((line) => line.trim().length > 0).length
-      : 0,
-    dirtyFiles,
-    ...(status.ok ? {} : { error: status.error }),
-  };
-}
-
-function runGit(
-  cwd: string,
-  args: readonly string[],
-): { ok: true; stdout: string } | { ok: false; stdout: string; error: string } {
-  try {
-    return {
-      ok: true,
-      stdout: execFileSync("git", [...args], {
-        cwd,
-        env: buildBashEnvironment() as NodeJS.ProcessEnv,
-        encoding: "utf8",
-        timeout: 5_000,
-        windowsHide: true,
-      }),
-    };
-  } catch (err) {
-    return {
-      ok: false,
-      stdout: outputText(err, "stdout"),
-      error: outputText(err, "stderr") || errorMessage(err),
-    };
-  }
-}
-
-function outputText(err: unknown, key: "stdout" | "stderr"): string {
-  if (typeof err !== "object" || err === null || !(key in err)) return "";
-  const value = (err as Record<typeof key, unknown>)[key];
-  return typeof value === "string" ? value : "";
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}

--- a/src/db/migrations/0010_spicy_morbius.sql
+++ b/src/db/migrations/0010_spicy_morbius.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `workspace_settings` ADD `default_model` text;--> statement-breakpoint
+ALTER TABLE `workspace_settings` ADD `default_max_steps` integer;--> statement-breakpoint
+ALTER TABLE `workspace_settings` ADD `default_permission_mode` text;

--- a/src/db/migrations/meta/0010_snapshot.json
+++ b/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1309 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1d4dc4f9-b209-4002-9f2f-721a58375012",
+  "prevId": "ff326b9d-d744-4db6-85ea-148fa1eb9b17",
+  "tables": {
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_max_steps": {
+          "name": "default_max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_permission_mode": {
+          "name": "default_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1779019724382,
       "tag": "0009_panoramic_komodo",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1779508584446,
+      "tag": "0010_spicy_morbius",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -155,6 +155,9 @@ export function getWorkspaceSettings(): WorkspaceSettings {
   const row: WorkspaceSettings = {
     id: WORKSPACE_SETTINGS_ID,
     localWorkspacesRoot: null,
+    defaultModel: null,
+    defaultMaxSteps: null,
+    defaultPermissionMode: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -163,18 +166,49 @@ export function getWorkspaceSettings(): WorkspaceSettings {
 }
 
 export function updateWorkspaceSettings(input: {
-  localWorkspacesRoot: string | null;
+  localWorkspacesRoot?: string | null;
+  defaultModel?: string | null;
+  defaultMaxSteps?: number | null;
+  defaultPermissionMode?: "default" | "auto-review" | "full-access" | null;
 }): WorkspaceSettings {
   getWorkspaceSettings();
+  const update: Partial<WorkspaceSettings> = { updatedAt: new Date() };
+  if ("localWorkspacesRoot" in input) {
+    update.localWorkspacesRoot = input.localWorkspacesRoot ?? null;
+  }
+  if ("defaultModel" in input) {
+    update.defaultModel = input.defaultModel ?? null;
+  }
+  if ("defaultMaxSteps" in input) {
+    update.defaultMaxSteps = input.defaultMaxSteps ?? null;
+  }
+  if ("defaultPermissionMode" in input) {
+    update.defaultPermissionMode = input.defaultPermissionMode ?? null;
+  }
   db
     .update(workspaceSettings)
-    .set({
-      localWorkspacesRoot: input.localWorkspacesRoot,
-      updatedAt: new Date(),
-    })
+    .set(update)
     .where(eq(workspaceSettings.id, WORKSPACE_SETTINGS_ID))
     .run();
   return getWorkspaceSettings();
+}
+
+export function getLastRunForProject(projectId: string): Run | undefined {
+  const projectSessions = db
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(eq(sessions.projectId, projectId))
+    .all();
+  const sessionIds = projectSessions.map((session) => session.id);
+  if (sessionIds.length === 0) return undefined;
+
+  return db
+    .select()
+    .from(runs)
+    .where(inArray(runs.sessionId, sessionIds))
+    .orderBy(desc(runs.startedAt))
+    .limit(1)
+    .get();
 }
 
 export function listGithubInstallations(): GithubInstallation[] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,6 +11,11 @@ import {
 export const workspaceSettings = sqliteTable("workspace_settings", {
   id: text("id").primaryKey(),
   localWorkspacesRoot: text("local_workspaces_root"),
+  defaultModel: text("default_model"),
+  defaultMaxSteps: integer("default_max_steps"),
+  defaultPermissionMode: text("default_permission_mode", {
+    enum: ["default", "auto-review", "full-access"],
+  }),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .default(sql`(unixepoch('now') * 1000)`),

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -3,6 +3,9 @@ export type WorkspaceSettingsSummary = {
   resolvedLocalWorkspacesRoot: string | null;
   source: "database" | "env" | "default";
   exists: boolean;
+  defaultModel: string | null;
+  defaultMaxSteps: number | null;
+  defaultPermissionMode: "default" | "auto-review" | "full-access" | null;
 };
 
 export type GitHubRepositorySummary = {
@@ -55,6 +58,30 @@ export type ProjectGitStatusSummary = {
   upstreamBehind: number | null;
   upstream: string | null;
   remoteUrl: string | null;
+};
+
+export type ProjectStatusSummary = {
+  project: ProjectSummary;
+  packageManager: "npm" | "pnpm" | "yarn" | "bun" | null;
+  scripts: string[];
+  keyDependencies: string[];
+  noteworthyFiles: string[];
+  git: ProjectGitStatusSummary;
+  dirtyFiles: string[];
+  lastRun: ProjectLastRunSummary | null;
+};
+
+export type ProjectLastRunSummary = {
+  runId: string;
+  sessionId: string;
+  status: "running" | "completed" | "error" | "aborted";
+  model: string;
+  startedAt: number;
+  finishedAt: number | null;
+  durationMs: number | null;
+  stepCount: number | null;
+  totalTokens: number | null;
+  costUsd: number | null;
 };
 
 export type ProjectBranchSummary = {

--- a/src/lib/client-state/workspace-agent-defaults.ts
+++ b/src/lib/client-state/workspace-agent-defaults.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import type { PermissionMode } from "@/src/agent/permissions";
+import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
+import {
+  DEFAULT_MODEL_ID,
+  isSupportedModelId,
+  type ModelId,
+} from "@/src/lib/models";
+import { getJson } from "@/src/lib/client-fetch";
+
+export const WORKSPACE_AGENT_DEFAULTS_CHANGED_EVENT =
+  "anton-workspace-agent-defaults-change";
+
+export type WorkspaceAgentDefaults = {
+  model: ModelId;
+  permissionMode: PermissionMode;
+  maxSteps: number | null;
+};
+
+export function workspaceDefaultsFromSettings(
+  settings: WorkspaceSettingsSummary,
+): WorkspaceAgentDefaults {
+  return {
+    model:
+      settings.defaultModel && isSupportedModelId(settings.defaultModel)
+        ? settings.defaultModel
+        : DEFAULT_MODEL_ID,
+    permissionMode: settings.defaultPermissionMode ?? "auto-review",
+    maxSteps: settings.defaultMaxSteps,
+  };
+}
+
+export async function fetchWorkspaceAgentDefaults(): Promise<WorkspaceAgentDefaults> {
+  const data = await getJson<{ settings: WorkspaceSettingsSummary }>(
+    "/api/workspace-settings",
+  );
+  return workspaceDefaultsFromSettings(data.settings);
+}
+
+export function notifyWorkspaceAgentDefaultsChanged(
+  settings: WorkspaceSettingsSummary,
+): void {
+  window.dispatchEvent(
+    new CustomEvent(WORKSPACE_AGENT_DEFAULTS_CHANGED_EVENT, {
+      detail: settings,
+    }),
+  );
+}

--- a/src/workspace/git-status.ts
+++ b/src/workspace/git-status.ts
@@ -1,0 +1,87 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { ProjectGitStatusSummary } from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+import { parseDirtyFilesFromPorcelain } from "@/src/workspace/project-inspect";
+
+const execFileAsync = promisify(execFile);
+
+export type ProjectGitStatusInput = {
+  id: string;
+  defaultBranch: string;
+};
+
+export async function buildProjectGitStatusSummary(
+  project: ProjectGitStatusInput,
+  root: string,
+): Promise<ProjectGitStatusSummary> {
+  const [branch, status, upstream, remoteUrl, aheadBehind, upstreamAheadBehind] =
+    await Promise.all([
+      gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
+      gitOutput(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+      gitOutput(root, [
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+      ]).catch(() => ""),
+      gitOutput(root, ["config", "--get", "remote.origin.url"]).catch(() => ""),
+      gitOutput(root, [
+        "rev-list",
+        "--left-right",
+        "--count",
+        `origin/${project.defaultBranch}...HEAD`,
+      ]).catch(() => ""),
+      gitOutput(root, [
+        "rev-list",
+        "--left-right",
+        "--count",
+        "@{upstream}...HEAD",
+      ]).catch(() => ""),
+    ]);
+  const counts = parseAheadBehind(aheadBehind);
+  const upstreamCounts = parseAheadBehind(upstreamAheadBehind);
+  const currentBranch = branch.trim() || null;
+  const dirtyFiles = parseDirtyFilesFromPorcelain(status);
+
+  return {
+    projectId: project.id,
+    branch: currentBranch,
+    defaultBranch: project.defaultBranch,
+    isDefaultBranch: currentBranch === project.defaultBranch,
+    dirtyCount: dirtyFiles.length,
+    ahead: counts?.ahead ?? null,
+    behind: counts?.behind ?? null,
+    upstreamAhead: upstreamCounts?.ahead ?? null,
+    upstreamBehind: upstreamCounts?.behind ?? null,
+    upstream: upstream.trim() || null,
+    remoteUrl: remoteUrl.trim() ? redactText(remoteUrl.trim()) : null,
+  };
+}
+
+export async function listDirtyFiles(
+  root: string,
+  limit = 50,
+): Promise<string[]> {
+  const status = await gitOutput(root, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+  ]);
+  return parseDirtyFilesFromPorcelain(status).slice(0, limit);
+}
+
+async function gitOutput(cwd: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, { cwd });
+  return result.stdout.trim();
+}
+
+function parseAheadBehind(value: string): { ahead: number; behind: number } | null {
+  const [behindRaw, aheadRaw] = value.trim().split(/\s+/, 2);
+  const behind = Number(behindRaw);
+  const ahead = Number(aheadRaw);
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return null;
+  return { ahead, behind };
+}

--- a/src/workspace/project-inspect.ts
+++ b/src/workspace/project-inspect.ts
@@ -1,0 +1,204 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildBashEnvironment } from "@/src/agent/command-policy";
+import {
+  dependencyNames,
+  detectPackageManager,
+  readPackageJson,
+  scriptNames,
+} from "@/src/agent/tools/package-manager";
+
+const NOTEWORTHY_FILES = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "README.md",
+  "ROADMAP.md",
+  "package.json",
+  "tsconfig.json",
+  "next.config.ts",
+  "vite.config.ts",
+  "drizzle.config.ts",
+  ".mcp.json",
+] as const;
+
+const MAX_DIRTY_FILES = 50;
+
+export type ProjectInspectGitInfo = {
+  isRepository: boolean;
+  branch: string | null;
+  dirtyFileCount: number;
+  dirtyFiles: string[];
+  error?: string;
+};
+
+export type ProjectInspectResult = {
+  packageManager: "npm" | "pnpm" | "yarn" | "bun" | null;
+  scripts: string[];
+  keyDependencies: string[];
+  noteworthyFiles: string[];
+  git: ProjectInspectGitInfo;
+  summary: string;
+};
+
+export function inspectProjectAtPath(root: string): ProjectInspectResult {
+  const packageJson = readPackageJson(root);
+  const git = gitInfo(root);
+
+  if (!packageJson.ok) {
+    return {
+      packageManager: null,
+      scripts: [],
+      keyDependencies: [],
+      noteworthyFiles: existingNoteworthyFiles(root),
+      git,
+      summary: "No package.json found; inspect files manually before coding.",
+    };
+  }
+
+  const dependencies = dependencyNames(packageJson.value);
+  const keyDependencies = dependencies.filter(isKeyDependency).slice(0, 30);
+  const scripts = scriptNames(packageJson.value);
+  const packageManager = detectPackageManager(root, packageJson.value);
+
+  return {
+    packageManager,
+    scripts,
+    keyDependencies,
+    noteworthyFiles: existingNoteworthyFiles(root),
+    git,
+    summary: [
+      `${packageManager} project`,
+      scripts.length ? `scripts: ${scripts.join(", ")}` : "no scripts",
+      keyDependencies.length
+        ? `key deps: ${keyDependencies.join(", ")}`
+        : "no key deps detected",
+      git.branch ? `git branch: ${git.branch}` : "git branch unavailable",
+      git.dirtyFileCount > 0
+        ? `${git.dirtyFileCount} dirty file${git.dirtyFileCount === 1 ? "" : "s"}`
+        : "working tree clean",
+    ].join("; "),
+  };
+}
+
+function existingNoteworthyFiles(root: string): string[] {
+  return NOTEWORTHY_FILES.filter((file) => fs.existsSync(path.join(root, file)));
+}
+
+function isKeyDependency(name: string): boolean {
+  return [
+    "@ai-sdk/react",
+    "@openrouter/ai-sdk-provider",
+    "ai",
+    "better-sqlite3",
+    "drizzle-orm",
+    "eslint",
+    "next",
+    "react",
+    "tailwindcss",
+    "typescript",
+    "vite",
+    "zod",
+  ].includes(name);
+}
+
+function gitInfo(root: string): ProjectInspectGitInfo {
+  const inside = runGit(root, ["rev-parse", "--is-inside-work-tree"]);
+  if (!inside.ok) {
+    return {
+      isRepository: false,
+      branch: null,
+      dirtyFileCount: 0,
+      dirtyFiles: [],
+      error: inside.error,
+    };
+  }
+  if (inside.stdout.trim() !== "true") {
+    return {
+      isRepository: false,
+      branch: null,
+      dirtyFileCount: 0,
+      dirtyFiles: [],
+    };
+  }
+
+  const branch = runGit(root, ["branch", "--show-current"]);
+  const status = runGit(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  const dirtyFiles = status.ok
+    ? parseDirtyFilesFromPorcelain(status.stdout).slice(0, MAX_DIRTY_FILES)
+    : [];
+
+  return {
+    isRepository: true,
+    branch: branch.ok ? branch.stdout.trim() || null : null,
+    dirtyFileCount: status.ok
+      ? parseDirtyFilesFromPorcelain(status.stdout).length
+      : 0,
+    dirtyFiles,
+    ...(status.ok ? {} : { error: status.error }),
+  };
+}
+
+export function parseDirtyFilesFromPorcelain(output: string): string[] {
+  if (!output.trim()) return [];
+  const entries = output.split("\0").filter(Boolean);
+  const paths: string[] = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index] ?? "";
+    if (entry.length < 3) {
+      const trimmed = entry.trim();
+      if (trimmed) paths.push(trimmed);
+      continue;
+    }
+    const marker = entry.slice(0, 2);
+    const rest = entry.slice(3).trim();
+    if (marker === "R " || marker === "C ") {
+      const renamedPath = entries[index + 1]?.trim();
+      if (renamedPath) {
+        paths.push(renamedPath);
+        index += 1;
+      } else if (rest) {
+        paths.push(rest);
+      }
+      continue;
+    }
+    if (rest) paths.push(rest);
+  }
+  return paths;
+}
+
+function runGit(
+  cwd: string,
+  args: readonly string[],
+): { ok: true; stdout: string } | { ok: false; stdout: string; error: string } {
+  try {
+    return {
+      ok: true,
+      stdout: execFileSync("git", [...args], {
+        cwd,
+        env: buildBashEnvironment() as NodeJS.ProcessEnv,
+        encoding: "utf8",
+        timeout: 5_000,
+        windowsHide: true,
+      }),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      stdout: outputText(err, "stdout"),
+      error: outputText(err, "stderr") || errorMessage(err),
+    };
+  }
+}
+
+function outputText(err: unknown, key: "stdout" | "stderr"): string {
+  if (typeof err !== "object" || err === null || !(key in err)) return "";
+  const value = (err as Record<typeof key, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}


### PR DESCRIPTION
Closes #100

## Summary
- Add a **Status** worklog tab backed by `GET /api/projects/[id]/status`, showing root path, git state, package manager, scripts, and last agent run for the active project.
- Add **Agent defaults** in Settings (default model, max steps cap, approval strictness) persisted in `workspace_settings` with migration `0010_spicy_morbius`.
- Wire saved defaults into new draft chats (no premature localStorage overrides), cap run step budgets server-side, and refresh composer controls when settings change.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Run `pnpm db:migrate` locally, then open Settings → Agent defaults, save model/steps/approval
- [ ] Click **New chat** and confirm composer picks up saved defaults
- [ ] Open worklog **Status** tab on a ready project and verify path, git, scripts, and last run
- [ ] Confirm permission dropdown aligns with other composer toolbar controls