### PR TITLE
Polish trace workspace file viewer and tab chrome

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -160,10 +160,10 @@
     --trees-focus-ring-color-override: var(--ring);
     --trees-font-family-override: var(--font-geist-mono);
     --trees-font-size-override: 11px;
-    --trees-gap-override: 1px;
-    --trees-item-margin-x-override: 4px;
-    --trees-item-padding-x-override: 6px;
-    --trees-padding-inline-override: 4px;
+    --trees-gap-override: 0px;
+    --trees-item-margin-x-override: 2px;
+    --trees-item-padding-x-override: 4px;
+    --trees-padding-inline-override: 2px;
     --trees-search-bg-override: var(--secondary);
     --trees-search-fg-override: var(--foreground);
     --trees-git-added-color-override: #00d7ff;
@@ -175,10 +175,18 @@
     --trees-selected-bg-override: color-mix(in oklch, var(--primary) 18%, transparent);
     --trees-selected-fg-override: var(--foreground);
   }
-  .project-file-code-view pierre-diffs {
+  .project-file-code-view {
+    --project-file-code-surface: color-mix(in oklch, var(--background) 25%, var(--card));
+  }
+  .project-file-code-view::-webkit-scrollbar-corner {
+    background: var(--project-file-code-surface);
+  }
+  .project-file-code-view diffs-container {
     display: block;
-    height: 100%;
+    width: 100%;
+    min-width: max-content;
     min-height: 0;
+    background: transparent;
   }
   ::-webkit-scrollbar-thumb:hover {
     background: color-mix(in oklch, var(--foreground) 24%, transparent);

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -123,7 +123,7 @@ export function Composer({
         e.preventDefault();
         submit();
       }}
-      className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background/95 px-3 pb-2 pt-1 sm:px-4"
+      className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background px-3 pb-2 pt-1 sm:px-4"
     >
       <div className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-3xl">
         <div className="rounded-lg bg-card p-2 ring-1 ring-border">

--- a/components/features/run-trace/project-file-code-view.tsx
+++ b/components/features/run-trace/project-file-code-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
-import { File as PierreFile } from "@pierre/diffs";
+import { useMemo } from "react";
+import { File } from "@pierre/diffs/react";
 import type { FileContents } from "@pierre/diffs";
 
 import { cn } from "@/lib/utils";
@@ -20,23 +20,47 @@ const codeViewerOptions = {
   themeType: "dark" as const,
   unsafeCSS: `
     :host {
-      --diffs-dark-bg: hsl(var(--background)/0.25);
+      display: block;
+      width: 100%;
+      min-width: max-content;
+      max-width: none;
+      --project-file-code-surface: color-mix(in oklch, var(--background) 25%, var(--card));
+      --diffs-bg: var(--project-file-code-surface);
+      --diffs-dark-bg: var(--project-file-code-surface);
       --diffs-dark: #ededed;
       --diffs-font-size: 11px;
       --diffs-line-height: 19px;
       --diffs-font-family: var(--font-geist-mono), "SF Mono", Monaco, Consolas, "Liberation Mono", monospace;
       --diffs-fg-number-override: rgba(255, 255, 255, 0.34);
+      --diffs-gap-block: 0;
+      --diffs-gap-inline: 0;
     }
-    pre {
-      min-height: 100%;
+    [data-code] {
+      width: 100%;
+      min-width: max-content;
+      max-width: none;
+      padding-block: 12px;
+      overflow: visible;
+      background: transparent;
+    }
+    [data-code]::-webkit-scrollbar {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+    [data-gutter] {
+      z-index: 5;
+      background-color: var(--project-file-code-surface);
+      box-shadow: 1px 0 0 var(--border);
+    }
+    [data-overflow="scroll"] [data-gutter] {
+      position: sticky;
+      left: 0;
     }
     [data-column-number] {
       padding-right: 14px;
-      background: transparent;
+      background-color: var(--project-file-code-surface);
       border-right: 1px solid rgba(255, 255, 255, 0.08);
-    }
-    [data-code] {
-      padding-block: 12px;
     }
     [data-line] {
       padding-inline: 14px 18px;
@@ -49,8 +73,6 @@ export function ProjectFileCodeView({
   content,
   className,
 }: ProjectFileCodeViewProps) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const rendererRef = useRef<PierreFile | null>(null);
   const file = useMemo<FileContents>(
     () => ({
       cacheKey: `${path}:${content.length}`,
@@ -60,25 +82,18 @@ export function ProjectFileCodeView({
     [content, path],
   );
 
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-    rendererRef.current ??= new PierreFile(codeViewerOptions);
-    rendererRef.current.render({ containerWrapper: container, file });
-  }, [file]);
-
-  useEffect(
-    () => () => {
-      rendererRef.current?.cleanUp();
-      rendererRef.current = null;
-    },
-    [],
-  );
-
   return (
     <div
-      ref={containerRef}
-      className={cn("project-file-code-view min-h-0 flex-1 overflow-auto bg-background/25", className)}
-    />
+      className={cn(
+        "project-file-code-view anton-diff-scrollbar min-h-0 flex-1 overflow-auto bg-[var(--project-file-code-surface)]",
+        className,
+      )}
+    >
+      <File
+        file={file}
+        options={codeViewerOptions}
+        className="block min-w-0 w-full max-w-none"
+      />
+    </div>
   );
 }

--- a/components/features/run-trace/project-files-panel.tsx
+++ b/components/features/run-trace/project-files-panel.tsx
@@ -35,6 +35,9 @@ const fileTreeStyle = {
   "--trees-search-bg-override": "var(--secondary)",
 } as CSSProperties;
 
+const projectFilesHeaderRowClass =
+  "flex shrink-0 items-center border-b border-border p-1.5";
+
 type ProjectFileTreeState = {
   fileTree: ProjectFileTreeSummary | null;
   loading: boolean;
@@ -228,8 +231,8 @@ function ProjectFileTree({
 
   return (
     <div className={cn("flex min-h-0 min-w-0 flex-col", className)}>
-      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border px-3">
-        <div className="min-w-0 truncate font-mono text-[10px] text-muted-foreground">
+      <div className={cn(projectFilesHeaderRowClass, "justify-between gap-2")}>
+        <div className="min-w-0 ml-1 truncate font-mono text-[11px] text-muted-foreground">
           {search.value
             ? `${search.matchingPaths.length.toLocaleString()} match${search.matchingPaths.length === 1 ? "" : "es"}`
             : project?.localPath || "Project"}
@@ -247,7 +250,7 @@ function ProjectFileTree({
           {refreshing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
         </Button>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden px-2 py-2">
+      <div className="min-h-0 flex-1 overflow-hidden px-1 py-1">
         <FileTree
           model={model}
           className="anton-file-tree h-full overflow-hidden [--trees-search-bg-override:var(--secondary)]"
@@ -295,59 +298,56 @@ function ProjectFileViewer({
 }) {
   return (
     <div className="flex min-h-0 min-w-0 flex-col bg-background/25">
-      <div className="border-b border-border px-2">
-        <div
-          className="flex h-10 min-w-0 items-center gap-1 overflow-x-auto py-1 scrollbar-hide"
-          style={{
-            scrollbarWidth: 'none',
-            msOverflowStyle: 'none',
-          }}
-          onWheel={(e) => {
-            if (e.deltaY !== 0) {
-              e.currentTarget.scrollLeft += e.deltaY;
-              e.preventDefault();
-            }
-          }}
-        >
-          {files.map((file) => (
-            <div
-              key={file.path}
-              className={cn(
-                "inline-flex h-7 min-w-28 max-w-56 shrink-0 items-center rounded text-xs font-semibold transition-colors",
-                activePath === file.path
-                  ? "bg-secondary text-foreground"
-                  : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
-              )}
-              role="group"
-              aria-label={`${baseName(file.path)} tab`}
-              title={file.path}
+      <div
+        className={cn(
+          projectFilesHeaderRowClass,
+          "min-w-0 gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide",
+        )}
+        onWheel={(e) => {
+          if (e.deltaY !== 0) {
+            e.currentTarget.scrollLeft += e.deltaY;
+            e.preventDefault();
+          }
+        }}
+      >
+        {files.map((file) => (
+          <div
+            key={file.path}
+            className={cn(
+              "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center rounded text-[11px] font-normal transition-colors",
+              activePath === file.path
+                ? "bg-secondary text-foreground"
+                : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
+            )}
+            role="group"
+            aria-label={`${baseName(file.path)} tab`}
+            title={file.path}
+          >
+            <button
+              type="button"
+              onClick={() => onClose(file.path)}
+              className="group/close relative ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              aria-label={`Close ${file.path}`}
+              title={`Close ${baseName(file.path)}`}
             >
-              <button
-                type="button"
-                onClick={() => onClose(file.path)}
-                className="group/close relative ml-1 inline-flex size-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-label={`Close ${file.path}`}
-                title={`Close ${baseName(file.path)}`}
-              >
-                <FileIcon path={file.path} className="size-3.5 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
-                <X className="absolute size-3.5 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
-              </button>
-              <button
-                type="button"
-                onClick={() => onSelect(file.path)}
-                className="min-w-0 rounded py-1 pl-0.5 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-pressed={activePath === file.path}
-              >
-                <span className="block truncate">{baseName(file.path)}</span>
-              </button>
-            </div>
-          ))}
-        </div>
+              <FileIcon path={file.path} className="size-3 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
+              <X className="absolute size-3 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
+            </button>
+            <button
+              type="button"
+              onClick={() => onSelect(file.path)}
+              className="min-w-0 rounded pl-0 pr-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              aria-pressed={activePath === file.path}
+            >
+              <span className="block truncate">{baseName(file.path)}</span>
+            </button>
+          </div>
+        ))}
       </div>
       {activeFile ? (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="flex h-10 shrink-0 items-center justify-between gap-3 border-b border-border px-3">
-            <div className="min-w-0 flex items-center gap-1 font-mono text-[12px] text-muted-foreground">
+          <div className={cn(projectFilesHeaderRowClass, "justify-between gap-2.5")}>
+            <div className="min-w-0 ml-1 flex items-center gap-1 font-mono text-xs text-muted-foreground">
               {activeFile.path.split("/").filter(Boolean).map((segment, index, array) => (
                 <span key={index} className="flex items-center gap-1">
                   <span className="truncate hover:text-foreground transition-colors">{segment}</span>
@@ -356,7 +356,7 @@ function ProjectFileViewer({
               ))}
             </div>
             {activeFile.sizeBytes !== null ? (
-              <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+              <span className="shrink-0 mr-1 font-mono text-[11px] text-muted-foreground">
                 {formatBytes(activeFile.sizeBytes)}
               </span>
             ) : null}

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -65,6 +65,18 @@ import type {
   ProjectSummary,
 } from "@/src/lib/api-types";
 
+const traceWorkspaceHeaderRowClass =
+  "flex shrink-0 items-center border-b border-border p-1.5";
+
+const traceWorkspaceTabClass =
+  "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center rounded text-[11px] font-normal transition-colors";
+
+const traceWorkspaceTabCloseButtonClass =
+  "group/close relative ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+const traceWorkspaceTabLabelButtonClass =
+  "min-w-0 rounded pl-0 pr-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
 export type WorklogEntry = ToolTraceEntry;
 type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files";
 
@@ -153,15 +165,15 @@ export function Worklog({
       aria-label="Trace workspace"
     >
       <div className="flex h-full min-w-0 w-full shrink-0 flex-col xl:min-w-[420px]">
-        <header className="flex h-10 shrink-0 items-center justify-between border-b border-border px-2">
-          <div className="flex min-w-0 items-center gap-1">
+        <header className={cn(traceWorkspaceHeaderRowClass, "justify-between gap-1")}>
+          <div className="flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide">
             {tabs.map((tab) => {
               const meta = tabMeta(tab, prState.pullRequest);
               return (
                 <div
                   key={tab}
                   className={cn(
-                    "inline-flex h-7 min-w-0 items-center rounded text-xs font-semibold transition-colors",
+                    traceWorkspaceTabClass,
                     activeTab === tab
                       ? "bg-secondary text-foreground"
                       : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
@@ -172,12 +184,12 @@ export function Worklog({
                   <button
                     type="button"
                     onClick={() => closeTab(tab)}
-                    className="group/close relative ml-1 inline-flex size-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    className={traceWorkspaceTabCloseButtonClass}
                     aria-label={`Close ${meta.label} tab`}
                     title={`Close ${meta.label}`}
                   >
-                    <meta.Icon className="size-3.5 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
-                    <X className="absolute size-3.5 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
+                    <meta.Icon className="size-3 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
+                    <X className="absolute size-3 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
                   </button>
                   {tab === "pr" ? (
                     <PullRequestTabSelector
@@ -191,7 +203,7 @@ export function Worklog({
                     <button
                       type="button"
                       onClick={() => setActiveTab(tab)}
-                      className="min-w-0 rounded py-1 pl-0.5 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      className={traceWorkspaceTabLabelButtonClass}
                       aria-pressed={activeTab === tab}
                     >
                       <span className="block truncate">{meta.label}</span>
@@ -397,7 +409,7 @@ function PullRequestTabSelector({
         <button
           type="button"
           onClick={onActivate}
-          className="min-w-0 rounded py-1 pl-0.5 pr-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className={traceWorkspaceTabLabelButtonClass}
           aria-pressed={active}
           aria-label={pullRequest ? `Select pull request, current ${label}` : "Select pull request"}
         >


### PR DESCRIPTION
Closes #101

## Summary
- Align file tree header, file tabs, and metadata row with shared `p-1.5` header chrome and tighter tree spacing
- Fix `ProjectFileCodeView` background, gutter masking on horizontal scroll, viewport-level scrolling, and scrollbar corner styling
- Match Worklog sidebar tabs to file viewer tab styling
- Use solid `bg-background` on the composer to match the message list

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Open trace workspace Files tab; verify tab/header alignment and compact spacing
- [ ] Open a wide/long file; confirm horizontal scroll stays at viewport bottom and gutter masks line numbers
- [ ] Compare Worklog header tabs with file tabs for visual parity
- [ ] Confirm composer background matches message list
