### PR TITLE
Polish file tree git status and code viewer spacing

### DIFF
--- a/app/api/projects/[id]/files/route.ts
+++ b/app/api/projects/[id]/files/route.ts
@@ -42,16 +42,19 @@ export async function GET(_req: Request, { params }: Ctx) {
 
   try {
     const root = ensureWorkspaceRootAt(project.localPath);
-    const [result, gitStatus] = await Promise.all([
+    const [result, gitStatusResult] = await Promise.all([
       listProjectFiles(root),
-      listProjectGitStatus(root).catch(() => []),
+      listProjectGitStatus(root),
     ]);
     const summary: ProjectFileTreeSummary = {
       projectId: project.id,
-      gitStatus,
+      gitStatus: gitStatusResult.entries,
       ignoredDirectories: [...IGNORED_DIRECTORIES],
       ...result,
     };
+    if (gitStatusResult.error) {
+      console.error("[project files] git status unavailable:", gitStatusResult.error);
+    }
     return Response.json({ fileTree: summary });
   } catch (err) {
     return Response.json(
@@ -113,15 +116,21 @@ function readDirectoryEntries(directory: string) {
   return fs.readdir(directory, { withFileTypes: true });
 }
 
-async function listProjectGitStatus(root: string): Promise<ProjectFileGitStatusEntry[]> {
-  const output = await gitOutput(root, [
-    "status",
-    "--porcelain=v1",
-    "-z",
-    "--untracked-files=all",
-    "--ignored=matching",
-  ]);
-  return parsePorcelainStatus(output);
+async function listProjectGitStatus(root: string): Promise<{
+  entries: ProjectFileGitStatusEntry[];
+  error: string | null;
+}> {
+  try {
+    const output = await gitOutput(root, [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+    ]);
+    return { entries: parsePorcelainStatus(output), error: null };
+  } catch (err) {
+    return { entries: [], error: errorMessage(err) };
+  }
 }
 
 async function gitOutput(cwd: string, args: string[]): Promise<string> {

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,7 +164,7 @@
     --trees-item-margin-x-override: 2px;
     --trees-item-padding-x-override: 4px;
     --trees-padding-inline-override: 2px;
-    --trees-search-bg-override: var(--secondary);
+    --trees-search-bg-override: color-mix(in oklch, var(--primary) 24%, transparent);
     --trees-search-fg-override: var(--foreground);
     --trees-git-added-color-override: #00d7ff;
     --trees-git-deleted-color-override: #ff4d5f;

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,7 +164,7 @@
     --trees-item-margin-x-override: 2px;
     --trees-item-padding-x-override: 4px;
     --trees-padding-inline-override: 2px;
-    --trees-search-bg-override: color-mix(in oklch, var(--primary) 24%, transparent);
+    --trees-search-bg-override: var(--secondary);
     --trees-search-fg-override: var(--foreground);
     --trees-git-added-color-override: #00d7ff;
     --trees-git-deleted-color-override: #ff4d5f;

--- a/components/features/run-trace/project-file-code-view.tsx
+++ b/components/features/run-trace/project-file-code-view.tsx
@@ -39,7 +39,7 @@ const codeViewerOptions = {
       width: 100%;
       min-width: max-content;
       max-width: none;
-      padding-block: 12px;
+      padding-block: 0;
       overflow: visible;
       background: transparent;
     }
@@ -58,12 +58,16 @@ const codeViewerOptions = {
       left: 0;
     }
     [data-column-number] {
-      padding-right: 14px;
+      min-width: 3.5ch;
+      padding-inline: 0.375rem 0.5rem;
       background-color: var(--project-file-code-surface);
       border-right: 1px solid rgba(255, 255, 255, 0.08);
     }
+    [data-line-number-content] {
+      min-width: 3.5ch;
+    }
     [data-line] {
-      padding-inline: 14px 18px;
+      padding-inline: 0.625rem 1rem;
     }
   `,
 };

--- a/components/features/run-trace/project-files-panel.tsx
+++ b/components/features/run-trace/project-files-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
   FileCode,
   FileJson,
@@ -32,9 +32,14 @@ import { cn } from "@/lib/utils";
 import { ProjectFileCodeView } from "./project-file-code-view";
 
 const fileTreeStyle = {
-  "--trees-search-bg-override":
-    "color-mix(in oklch, var(--primary) 24%, transparent)",
+  "--trees-search-bg-override": "var(--secondary)",
 } as CSSProperties;
+
+function countBadgeGitChanges(
+  gitStatus: readonly Pick<GitStatusEntry, "status">[],
+): number {
+  return gitStatus.filter((entry) => entry.status !== "ignored").length;
+}
 
 const projectFilesHeaderRowClass =
   "flex shrink-0 items-center border-b border-border p-1.5";
@@ -215,15 +220,16 @@ function ProjectFileTree({
     },
   });
   const search = useFileTreeSearch(model);
+  const badgeChangeCount = useMemo(
+    () => countBadgeGitChanges(gitStatus),
+    [gitStatus],
+  );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     model.resetPaths(sortedPaths, { initialExpandedPaths: [] });
     model.closeSearch();
-  }, [model, sortedPaths]);
-
-  useEffect(() => {
     model.setGitStatus(gitStatus);
-  }, [gitStatus, model]);
+  }, [model, sortedPaths, gitStatus]);
 
   useEffect(() => {
     if (!selectedPath) return;
@@ -237,6 +243,9 @@ function ProjectFileTree({
           {search.value
             ? `${search.matchingPaths.length.toLocaleString()} match${search.matchingPaths.length === 1 ? "" : "es"}`
             : project?.localPath || "Project"}
+          {!search.value && badgeChangeCount > 0
+            ? ` · ${badgeChangeCount.toLocaleString()} changed`
+            : ""}
           {truncated ? ` · showing ${paths.length.toLocaleString()}` : ""}
         </div>
         <Button
@@ -254,7 +263,7 @@ function ProjectFileTree({
       <div className="min-h-0 flex-1 overflow-hidden px-1 py-1">
         <FileTree
           model={model}
-          className="anton-file-tree h-full overflow-hidden rounded-md border border-border bg-background/45"
+          className="anton-file-tree h-full overflow-hidden"
           style={fileTreeStyle}
           aria-label="Project file tree"
         />
@@ -428,6 +437,17 @@ function useProjectFileTree(
       return;
     }
     queueMicrotask(() => void loadFileTree("initial"));
+  }, [loadFileTree, options.enabled, projectId]);
+
+  useEffect(() => {
+    if (!options.enabled || !projectId) return;
+    const refreshGitStatus = () => void loadFileTree("refresh");
+    window.addEventListener("focus", refreshGitStatus);
+    const intervalId = window.setInterval(refreshGitStatus, 15_000);
+    return () => {
+      window.removeEventListener("focus", refreshGitStatus);
+      window.clearInterval(intervalId);
+    };
   }, [loadFileTree, options.enabled, projectId]);
 
   return {

--- a/components/features/run-trace/project-files-panel.tsx
+++ b/components/features/run-trace/project-files-panel.tsx
@@ -32,7 +32,8 @@ import { cn } from "@/lib/utils";
 import { ProjectFileCodeView } from "./project-file-code-view";
 
 const fileTreeStyle = {
-  "--trees-search-bg-override": "var(--secondary)",
+  "--trees-search-bg-override":
+    "color-mix(in oklch, var(--primary) 24%, transparent)",
 } as CSSProperties;
 
 const projectFilesHeaderRowClass =
@@ -253,7 +254,7 @@ function ProjectFileTree({
       <div className="min-h-0 flex-1 overflow-hidden px-1 py-1">
         <FileTree
           model={model}
-          className="anton-file-tree h-full overflow-hidden [--trees-search-bg-override:var(--secondary)]"
+          className="anton-file-tree h-full overflow-hidden rounded-md border border-border bg-background/45"
           style={fileTreeStyle}
           aria-label="Project file tree"
         />


### PR DESCRIPTION
Closes #103

## Summary
- Keep file tree chrome flat against the parent panel (no card border/background) with grey search and primary-orange selection highlights
- Fix git status badge sync with `useLayoutEffect`, focus/interval refresh, and clearer server-side error logging
- Fix header "changed" count by dropping `--ignored=matching` and excluding ignored entries from the badge total
- Tighten project file code view gutter spacing and remove extra vertical padding

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Open Files tab on a project with local git changes; confirm badge count matches `git status`
- [ ] Confirm modified/untracked files show Pierre git badges in the tree
- [ ] Confirm search bar stays dark grey and selection uses primary-orange highlight
- [ ] Open a long/wide file; confirm tighter line-number gutter and no top/bottom padding gap
