### PR TITLE
Background command sessions and trace workspace UX

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,7 +135,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add file tree and file search panel for the active project.
 - [✔️] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
 - [] Add live terminal output streaming for long-running commands.
-- [] Add cancellable background command sessions for dev servers and watchers.
+- [✔️] Add cancellable background command sessions for dev servers and watchers.
 - [] Add command history with rerun support.
 - [✔️] Add settings for default model, max steps, approval strictness, and workspace root.
 - [] Add mobile-friendly workspace and worklog controls.

--- a/app/api/projects/[id]/commands/[commandId]/restart/route.ts
+++ b/app/api/projects/[id]/commands/[commandId]/restart/route.ts
@@ -1,0 +1,47 @@
+import { getProject } from "@/src/db/queries";
+import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
+import { redactText } from "@/src/lib/redaction";
+import { restartProjectBackgroundCommand } from "@/src/workspace/background-commands";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string; commandId: string }> };
+
+export async function POST(_req: Request, { params }: Ctx) {
+  const { id, commandId } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  try {
+    const result = await restartProjectBackgroundCommand(
+      project.id,
+      commandId,
+      project.localPath,
+    );
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 },
+      );
+    }
+    return Response.json({
+      session: serializeBackgroundCommandSession(result.session),
+      streamToken: result.streamToken,
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/commands/[commandId]/route.ts
+++ b/app/api/projects/[id]/commands/[commandId]/route.ts
@@ -1,0 +1,34 @@
+import { getProject } from "@/src/db/queries";
+import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
+import { redactText } from "@/src/lib/redaction";
+import { getProjectBackgroundCommand } from "@/src/workspace/background-commands";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string; commandId: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id, commandId } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+
+  try {
+    const session = getProjectBackgroundCommand(project.id, commandId);
+    if (!session) {
+      return Response.json({ error: "command session not found" }, { status: 404 });
+    }
+    return Response.json({ session: serializeBackgroundCommandSession(session) });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/commands/[commandId]/stop/route.ts
+++ b/app/api/projects/[id]/commands/[commandId]/stop/route.ts
@@ -1,0 +1,39 @@
+import { getProject } from "@/src/db/queries";
+import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
+import { redactText } from "@/src/lib/redaction";
+import { stopProjectBackgroundCommand } from "@/src/workspace/background-commands";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string; commandId: string }> };
+
+export async function POST(_req: Request, { params }: Ctx) {
+  const { id, commandId } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await stopProjectBackgroundCommand(project.id, commandId);
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 },
+      );
+    }
+    return Response.json({
+      session: serializeBackgroundCommandSession(result.session),
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/commands/[commandId]/stream/route.ts
+++ b/app/api/projects/[id]/commands/[commandId]/stream/route.ts
@@ -1,0 +1,135 @@
+import {
+  backgroundCommandStream,
+  type BackgroundCommandStreamEvent,
+} from "@/src/lib/background-command-stream";
+import { getProjectBackgroundCommand } from "@/src/workspace/background-commands";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+type Ctx = { params: Promise<{ id: string; commandId: string }> };
+
+export async function GET(req: Request, { params }: Ctx) {
+  const { id, commandId } = await params;
+  const { searchParams } = new URL(req.url);
+  const token = searchParams.get("token");
+
+  if (!token || !backgroundCommandStream.validateToken(commandId, token)) {
+    return new Response("Invalid stream token", { status: 403 });
+  }
+
+  const session = getProjectBackgroundCommand(id, commandId);
+  if (!session) {
+    return new Response("Command session not found", { status: 404 });
+  }
+
+  const state = backgroundCommandStream.getState(commandId);
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      let closed = false;
+      let unsubscribeEvent = () => {};
+      let unsubscribeEnd = () => {};
+      const heartbeat = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(": keep-alive\n\n"));
+      }, HEARTBEAT_INTERVAL_MS);
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        unsubscribeEvent();
+        unsubscribeEnd();
+        controller.close();
+      };
+
+      const initialStatus = state?.status ?? session.status;
+      const initialFinished =
+        state?.finished ??
+        (initialStatus === "exited" ||
+          initialStatus === "failed" ||
+          initialStatus === "stopped" ||
+          initialStatus === "stale");
+
+      if (state?.stdout || session.stdoutTail) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "stdout",
+              chunk: state?.stdout || session.stdoutTail,
+            })}\n\n`,
+          ),
+        );
+      }
+      if (state?.stderr || session.stderrTail) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "stderr",
+              chunk: state?.stderr || session.stderrTail,
+            })}\n\n`,
+          ),
+        );
+      }
+      if (initialFinished) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "status",
+              status: initialStatus,
+              exitCode: state?.exitCode ?? session.exitCode,
+              signal: state?.signal ?? session.signal,
+              detectedUrls: state?.detectedUrls ?? session.detectedUrls,
+              finished: true,
+            })}\n\n`,
+          ),
+        );
+        close();
+        return;
+      }
+
+      unsubscribeEvent = backgroundCommandStream.onEvent(
+        commandId,
+        (event: BackgroundCommandStreamEvent) => {
+          if (closed) return;
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+          );
+          if (
+            event.type === "status" &&
+            (event.status === "exited" ||
+              event.status === "failed" ||
+              event.status === "stopped" ||
+              event.status === "stale")
+          ) {
+            setTimeout(() => {
+              close();
+            }, 100);
+          }
+        },
+      );
+
+      unsubscribeEnd = backgroundCommandStream.onEnd(commandId, () => {
+        close();
+      });
+
+      req.signal.addEventListener("abort", () => {
+        unsubscribeEvent();
+        unsubscribeEnd();
+        close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/app/api/projects/[id]/commands/route.ts
+++ b/app/api/projects/[id]/commands/route.ts
@@ -1,0 +1,113 @@
+import { getProject } from "@/src/db/queries";
+import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
+import type { ProjectBackgroundCommandsSummary } from "@/src/lib/api-types";
+import { redactText } from "@/src/lib/redaction";
+import {
+  clearProjectRecentBackgroundCommands,
+  listProjectBackgroundCommands,
+  startProjectBackgroundCommand,
+} from "@/src/workspace/background-commands";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+const startCommandSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("script"),
+    scriptName: z.string().trim().min(1),
+  }),
+  z.object({
+    kind: z.literal("custom"),
+    command: z.string().trim().min(1),
+  }),
+]);
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  const listed = listProjectBackgroundCommands(project.id);
+  const commands: ProjectBackgroundCommandsSummary = {
+    running: listed.running.map(serializeBackgroundCommandSession),
+    recent: listed.recent.map(serializeBackgroundCommandSession),
+    runningCount: listed.runningCount,
+  };
+  return Response.json({ commands });
+}
+
+export async function POST(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = startCommandSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: "invalid request body" }, { status: 400 });
+  }
+
+  try {
+    const result = await startProjectBackgroundCommand(
+      project.id,
+      project.localPath,
+      parsed.data,
+    );
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 },
+      );
+    }
+    return Response.json({
+      session: serializeBackgroundCommandSession(result.session),
+      streamToken: result.streamToken,
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+
+  try {
+    const cleared = clearProjectRecentBackgroundCommands(project.id);
+    return Response.json({ cleared });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -39,12 +39,16 @@ import { Composer } from "./composer";
 import { sessionTokenUsage } from "./message-metrics";
 import { generateChatId } from "./chat-utils";
 import { Worklog } from "@/components/features/run-trace/worklog";
+import { WorklogResizeHandle } from "@/components/features/run-trace/worklog-resize-handle";
+import { useWorklogWidth } from "@/components/features/run-trace/use-worklog-width";
 import { useSessionStore } from "@/components/features/sessions/session-store";
 import { useSidebar } from "@/components/features/sessions/session-sidebar";
 import {
   useProjectGitStatus,
+  useProjectCommands,
   useProjectSummary,
   useProjectsList,
+  notifyOpenWorklogStatus,
 } from "@/components/features/projects/hooks";
 
 interface ChatProps {
@@ -105,8 +109,16 @@ function ChatSession({
     [sessionId],
   );
   const [worklogOpen, setWorklogOpen] = useState(false);
-  const [worklogExpanded, setWorklogExpanded] = useState(false);
   const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
+  const layoutRef = useRef<HTMLDivElement>(null);
+  const {
+    width: worklogWidth,
+    expanded: worklogExpanded,
+    isResizing: worklogResizing,
+    setToMax: expandWorklog,
+    toggleExpanded: toggleWorklogExpanded,
+    startResize: startWorklogResize,
+  } = useWorklogWidth(layoutRef);
   const [restoreVersion, setRestoreVersion] = useState(0);
   const [messageDisplayOverride, setMessageDisplayOverride] = useState<
     AntonUIMessage[] | null
@@ -142,6 +154,9 @@ function ChatSession({
   const effectiveProjectId = initialProjectId ?? selectedProjectId;
   const project = useProjectSummary(effectiveProjectId);
   const projectGitStatus = useProjectGitStatus(project ? effectiveProjectId : null);
+  const projectCommands = useProjectCommands(
+    project?.status === "ready" ? project.id : null,
+  );
 
   const transport = useMemo(
     () =>
@@ -463,13 +478,22 @@ function ChatSession({
       typeof window !== "undefined" &&
       window.matchMedia("(min-width: 1280px)").matches
     ) {
-      if (worklogOpen) {
-        setWorklogExpanded(false);
-      }
       setWorklogOpen((open) => !open);
     } else {
       setMobileWorklogOpen((open) => !open);
     }
+  };
+
+  const openProjectStatus = () => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(min-width: 1280px)").matches
+    ) {
+      setWorklogOpen(true);
+    } else {
+      setMobileWorklogOpen(true);
+    }
+    notifyOpenWorklogStatus();
   };
 
   return (
@@ -511,7 +535,10 @@ function ChatSession({
         </div>
       </header>
 
-      <div className="relative flex min-h-0 max-w-full flex-1 overflow-hidden">
+      <div
+        ref={layoutRef}
+        className="relative flex min-h-0 max-w-full flex-1 overflow-hidden"
+      >
         <section className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden">
           <MessageList
             messages={displayMessages}
@@ -557,29 +584,42 @@ function ChatSession({
             mcpServers={mcpServers}
             selectedMcpServerIds={selectedMcpServerIds}
             onSelectedMcpServerIdsChange={setSelectedMcpServerIds}
+            runningCommandCount={projectCommands.runningCount}
+            onOpenProjectStatus={openProjectStatus}
           />
         </section>
 
-        <Worklog
-          messages={displayMessages}
-          onApproval={approveTool}
-          project={project}
-          visible={worklogOpen}
-          expanded={worklogExpanded}
-          onFileOpen={() => {
-            sidebar.setOpen(false);
-            setWorklogExpanded(true);
-          }}
-          onExpandToggle={() => setWorklogExpanded((value) => !value)}
+        <div
           className={cn(
-            "hidden shrink-0 overflow-hidden transition-[width] duration-200 ease-in xl:flex",
-            worklogOpen
-              ? worklogExpanded
-                ? "xl:w-[65%]"
-                : "xl:w-[420px]"
-              : "xl:w-0 xl:border-l-0",
+            "relative hidden shrink-0 overflow-hidden xl:block",
+            !worklogResizing && "transition-[width] duration-200 ease-in",
+            !worklogOpen && "pointer-events-none xl:border-l-0",
           )}
-        />
+          style={{ width: worklogOpen ? worklogWidth : 0 }}
+        >
+          <div className="relative h-full" style={{ width: worklogWidth }}>
+            {worklogOpen ? (
+              <WorklogResizeHandle
+                onResizeStart={startWorklogResize}
+                active={worklogResizing}
+              />
+            ) : null}
+            <Worklog
+              messages={displayMessages}
+              onApproval={approveTool}
+              project={project}
+              visible={worklogOpen}
+              expanded={worklogExpanded}
+              onFileOpen={() => {
+                sidebar.setOpen(false);
+                expandWorklog();
+                setWorklogOpen(true);
+              }}
+              onExpandToggle={toggleWorklogExpanded}
+              className="h-full w-full min-w-0"
+            />
+          </div>
+        </div>
 
         {mobileWorklogOpen && (
           <div

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -66,6 +66,8 @@ interface ComposerProps {
   mcpServers: McpServerSummary[];
   selectedMcpServerIds: string[];
   onSelectedMcpServerIdsChange: (ids: string[]) => void;
+  runningCommandCount?: number;
+  onOpenProjectStatus?: () => void;
 }
 
 const MIN_HEIGHT = 24;
@@ -97,6 +99,8 @@ export function Composer({
   mcpServers,
   selectedMcpServerIds,
   onSelectedMcpServerIdsChange,
+  runningCommandCount = 0,
+  onOpenProjectStatus,
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const [mcpOpen, setMcpOpen] = useState(false);
@@ -232,6 +236,15 @@ export function Composer({
             className="max-w-[20rem]"
             contentAlign="start"
           />
+          {runningCommandCount > 0 ? (
+            <button
+              type="button"
+              onClick={onOpenProjectStatus}
+              className="inline-flex items-center gap-1 rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400 ring-1 ring-emerald-400/30 hover:bg-emerald-400/15"
+            >
+              {runningCommandCount} running
+            </button>
+          ) : null}
         </div>
       </div>
     </form>

--- a/components/features/projects/background-commands-panel.tsx
+++ b/components/features/projects/background-commands-panel.tsx
@@ -1,0 +1,710 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  ExternalLink,
+  Loader2,
+  Play,
+  RotateCcw,
+  ScrollText,
+  Square,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ErrorBanner } from "@/components/shared/feedback-states";
+import { TerminalOutput } from "@/components/features/run-trace/terminal-output";
+import { cn } from "@/lib/utils";
+import type {
+  BackgroundCommandSessionSummary,
+  ProjectStatusSummary,
+} from "@/src/lib/api-types";
+import { jsonHeaders, requestJson } from "@/src/lib/client-fetch";
+import {
+  useProjectCommands,
+  notifyProjectCommandsChanged,
+  type StartBackgroundCommandInput,
+} from "@/components/features/projects/hooks";
+import { useBackgroundCommandStream } from "@/components/features/projects/use-background-command-stream";
+
+const PRIORITY_SCRIPTS = [
+  "dev",
+  "start",
+  "serve",
+  "preview",
+  "watch",
+  "storybook",
+  "test:watch",
+] as const;
+
+export function BackgroundCommandsPanel({
+  projectId,
+  status,
+}: {
+  projectId: string;
+  status: ProjectStatusSummary;
+}) {
+  const { commands, error, refresh, runningCount } =
+    useProjectCommands(projectId);
+  const [customCommand, setCustomCommand] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [openLogsId, setOpenLogsId] = useState<string | null>(null);
+  const [streamTokens, setStreamTokens] = useState<Record<string, string>>({});
+
+  const runningCommands = commands?.running ?? [];
+  const recentCommands = commands?.recent ?? [];
+  const activeCommands = new Set(
+    runningCommands
+      .filter((session) =>
+        ["starting", "running", "stopping"].includes(session.status),
+      )
+      .map((session) => session.command),
+  );
+
+  const scriptButtons = useMemo(() => {
+    const scripts = new Set(status.scripts);
+    const ordered: string[] = [];
+    for (const script of PRIORITY_SCRIPTS) {
+      if (scripts.has(script)) ordered.push(script);
+    }
+    for (const script of status.scripts) {
+      if (!ordered.includes(script)) ordered.push(script);
+    }
+    return ordered;
+  }, [status.scripts]);
+
+  const runCommand = async (
+    input: StartBackgroundCommandInput,
+    actionKey: string,
+  ) => {
+    setPendingAction(actionKey);
+    setActionError(null);
+    try {
+      const data = await requestJson<{
+        session: BackgroundCommandSessionSummary;
+        streamToken: string;
+      }>(`/api/projects/${projectId}/commands`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify(input),
+      });
+      setStreamTokens((current) => ({
+        ...current,
+        [data.session.id]: data.streamToken,
+      }));
+      setOpenLogsId(data.session.id);
+      notifyProjectCommandsChanged(projectId);
+      await refresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to start command");
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const stopCommand = async (session: BackgroundCommandSessionSummary) => {
+    setPendingAction(`stop:${session.id}`);
+    setActionError(null);
+    try {
+      await requestJson(`/api/projects/${projectId}/commands/${session.id}/stop`, {
+        method: "POST",
+        headers: jsonHeaders(),
+      });
+      notifyProjectCommandsChanged(projectId);
+      await refresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to stop command");
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const restartCommand = async (session: BackgroundCommandSessionSummary) => {
+    setPendingAction(`restart:${session.id}`);
+    setActionError(null);
+    try {
+      const data = await requestJson<{
+        session: BackgroundCommandSessionSummary;
+        streamToken: string;
+      }>(`/api/projects/${projectId}/commands/${session.id}/restart`, {
+        method: "POST",
+        headers: jsonHeaders(),
+      });
+      setStreamTokens((current) => ({
+        ...current,
+        [data.session.id]: data.streamToken,
+      }));
+      setOpenLogsId(data.session.id);
+      notifyProjectCommandsChanged(projectId);
+      await refresh();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to restart command",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const rerunCommand = async (session: BackgroundCommandSessionSummary) => {
+    const scriptName = scriptNameFromStoredCommand(session);
+    if (session.commandKind === "script" && scriptName) {
+      await runCommand({ kind: "script", scriptName }, `rerun:${session.id}`);
+      return;
+    }
+    await runCommand({ kind: "custom", command: session.command }, `rerun:${session.id}`);
+  };
+
+  const clearRecent = async () => {
+    setPendingAction("clear");
+    setActionError(null);
+    try {
+      await requestJson(`/api/projects/${projectId}/commands`, {
+        method: "DELETE",
+        headers: jsonHeaders(),
+      });
+      setOpenLogsId(null);
+      notifyProjectCommandsChanged(projectId);
+      await refresh();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to clear recent commands",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  return (
+    <section className="border-b border-border px-3 py-2">
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <h3 className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Commands
+        </h3>
+        {runningCount > 0 ? (
+          <span className="rounded-full bg-emerald-400/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400 ring-1 ring-emerald-400/30">
+            {runningCount} running
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="mb-2">
+          <ErrorBanner message={error} />
+        </div>
+      ) : null}
+      {actionError ? (
+        <div className="mb-2">
+          <ErrorBanner message={actionError} />
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        {runningCommands.length > 0 ? (
+          <div className="space-y-2">
+            {runningCommands.map((session) => (
+              <RunningCommandCard
+                key={session.id}
+                session={session}
+                pendingAction={pendingAction}
+                logsOpen={openLogsId === session.id}
+                streamToken={streamTokens[session.id]}
+                projectId={projectId}
+                onToggleLogs={() =>
+                  setOpenLogsId((current) =>
+                    current === session.id ? null : session.id,
+                  )
+                }
+                onStop={() => void stopCommand(session)}
+                onRestart={() => void restartCommand(session)}
+              />
+            ))}
+          </div>
+        ) : null}
+
+        <CommandGroup title="Scripts">
+          {scriptButtons.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {scriptButtons.map((script) => {
+                const disabled =
+                  activeCommands.has(
+                    scriptLaunchCommand(status.packageManager, script),
+                  ) || pendingAction === `script:${script}`;
+                return (
+                  <Button
+                    key={script}
+                    type="button"
+                    size="xs"
+                    variant="secondary"
+                    disabled={disabled}
+                    onClick={() =>
+                      void runCommand(
+                        { kind: "script", scriptName: script },
+                        `script:${script}`,
+                      )
+                    }
+                    className="font-mono text-[10px]"
+                  >
+                    {pendingAction === `script:${script}` ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <Play className="size-3" />
+                    )}
+                    {script}
+                  </Button>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">No npm scripts detected.</p>
+          )}
+        </CommandGroup>
+
+        <CommandGroup title="Custom command">
+          <form
+            className="flex items-center gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const trimmed = customCommand.trim();
+              if (!trimmed || activeCommands.has(trimmed)) return;
+              void runCommand({ kind: "custom", command: trimmed }, `custom:${trimmed}`);
+            }}
+          >
+            <Input
+              value={customCommand}
+              onChange={(event) => setCustomCommand(event.target.value)}
+              placeholder="python -m http.server"
+              className="h-7 font-mono text-[11px]"
+            />
+            <Button
+              type="submit"
+              size="xs"
+              disabled={
+                !customCommand.trim() ||
+                activeCommands.has(customCommand.trim()) ||
+                pendingAction?.startsWith("custom:") === true
+              }
+            >
+              Run
+            </Button>
+          </form>
+        </CommandGroup>
+
+        <CommandGroup
+          title="Recent"
+          action={
+            recentCommands.length > 0 ? (
+              <Button
+                type="button"
+                size="xs"
+                variant="ghost"
+                className="h-5 px-1.5 text-[10px] text-muted-foreground"
+                disabled={pendingAction === "clear"}
+                onClick={() => void clearRecent()}
+              >
+                {pendingAction === "clear" ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  "Clear"
+                )}
+              </Button>
+            ) : null
+          }
+        >
+          {recentCommands.length > 0 ? (
+            <div className="space-y-2">
+              {recentCommands.map((session) => (
+                <RecentCommandCard
+                  key={session.id}
+                  session={session}
+                  pendingAction={pendingAction}
+                  logsOpen={openLogsId === session.id}
+                  streamToken={streamTokens[session.id]}
+                  projectId={projectId}
+                  rerunDisabled={activeCommands.has(session.command)}
+                  onToggleLogs={() =>
+                    setOpenLogsId((current) =>
+                      current === session.id ? null : session.id,
+                    )
+                  }
+                  onRerun={() => void rerunCommand(session)}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">No recent commands.</p>
+          )}
+        </CommandGroup>
+      </div>
+    </section>
+  );
+}
+
+function CommandGroup({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <h4 className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+          {title}
+        </h4>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function RunningCommandCard({
+  session,
+  pendingAction,
+  logsOpen,
+  streamToken,
+  projectId,
+  onToggleLogs,
+  onStop,
+  onRestart,
+}: {
+  session: BackgroundCommandSessionSummary;
+  pendingAction: string | null;
+  logsOpen: boolean;
+  streamToken?: string;
+  projectId: string;
+  onToggleLogs: () => void;
+  onStop: () => void;
+  onRestart: () => void;
+}) {
+  const now = useElapsedClock();
+  const primaryUrl = session.detectedUrls[0] ?? null;
+  return (
+    <div className="rounded-md bg-background/25 px-2 py-1.5 ring-1 ring-border/50">
+      <div className="flex flex-wrap items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={session.status} />
+            <code className="truncate font-mono text-[10px] text-foreground">
+              {session.command}
+            </code>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground">
+            <span>{formatElapsed(session.startedAt, now)}</span>
+            {primaryUrl ? (
+              <a
+                href={primaryUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-sky-400 hover:underline"
+              >
+                Open
+                <ExternalLink className="size-3" />
+              </a>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={onToggleLogs}
+            aria-label="View logs"
+            title="Logs"
+          >
+            <ScrollText className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            disabled={pendingAction === `stop:${session.id}`}
+            onClick={onStop}
+            aria-label="Stop command"
+            title="Stop"
+          >
+            <Square className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            disabled={pendingAction === `restart:${session.id}`}
+            onClick={onRestart}
+            aria-label="Restart command"
+            title="Restart"
+          >
+            <RotateCcw className="size-3" />
+          </Button>
+        </div>
+      </div>
+      {logsOpen ? (
+        <div className="mt-2">
+          <CommandLogViewer
+            projectId={projectId}
+            session={session}
+            streamToken={streamToken}
+            live={["starting", "running", "stopping"].includes(session.status)}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RecentCommandCard({
+  session,
+  pendingAction,
+  logsOpen,
+  streamToken,
+  projectId,
+  rerunDisabled,
+  onToggleLogs,
+  onRerun,
+}: {
+  session: BackgroundCommandSessionSummary;
+  pendingAction: string | null;
+  logsOpen: boolean;
+  streamToken?: string;
+  projectId: string;
+  rerunDisabled: boolean;
+  onToggleLogs: () => void;
+  onRerun: () => void;
+}) {
+  return (
+    <div className="rounded-md bg-background/25 px-2 py-1.5 ring-1 ring-border/50">
+      <div className="flex flex-wrap items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={session.status} />
+            <code className="truncate font-mono text-[10px] text-foreground">
+              {session.command}
+            </code>
+          </div>
+          <div className="mt-1 text-[10px] text-muted-foreground">
+            {formatDuration(session.startedAt, session.finishedAt)}
+            {session.exitCode !== null ? ` · exit ${session.exitCode}` : null}
+            {session.signal ? ` · ${session.signal}` : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            onClick={onToggleLogs}
+            aria-label="View logs"
+            title="Logs"
+          >
+            <ScrollText className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            disabled={rerunDisabled || pendingAction === `rerun:${session.id}`}
+            onClick={onRerun}
+            aria-label="Rerun command"
+            title="Rerun"
+          >
+            <RotateCcw className="size-3" />
+          </Button>
+        </div>
+      </div>
+      {logsOpen ? (
+        <div className="mt-2">
+          <CommandLogViewer
+            projectId={projectId}
+            session={session}
+            streamToken={streamToken}
+            live={false}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CommandLogViewer({
+  projectId,
+  session,
+  streamToken,
+  live,
+}: {
+  projectId: string;
+  session: BackgroundCommandSessionSummary;
+  streamToken?: string;
+  live: boolean;
+}) {
+  const [polledSession, setPolledSession] =
+    useState<BackgroundCommandSessionSummary>(session);
+  const streamState = useBackgroundCommandStream(
+    projectId,
+    session.id,
+    streamToken,
+    live && Boolean(streamToken),
+  );
+
+  useEffect(() => {
+    queueMicrotask(() => setPolledSession(session));
+  }, [session]);
+
+  useEffect(() => {
+    if (!live || streamToken) return;
+
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await requestJson<{ session: BackgroundCommandSessionSummary }>(
+          `/api/projects/${projectId}/commands/${session.id}`,
+        );
+        if (!cancelled) setPolledSession(data.session);
+      } catch {
+        // Keep showing the last known tail when polling fails.
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, 2_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [live, projectId, session.id, streamToken]);
+
+  const source = live && !streamToken ? polledSession : session;
+  const stdout =
+    live && streamToken ? streamState.stdout || source.stdoutTail : source.stdoutTail;
+  const stderr =
+    live && streamToken ? streamState.stderr || source.stderrTail : source.stderrTail;
+
+  return (
+    <TerminalOutput
+      command={source.command}
+      output={{
+        stdout,
+        stderr,
+        exitCode: source.exitCode,
+        signal: source.signal,
+      }}
+    />
+  );
+}
+
+function StatusBadge({ status }: { status: BackgroundCommandSessionSummary["status"] }) {
+  const meta = statusMeta(status);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ring-1",
+        meta.className,
+      )}
+    >
+      {meta.spinner ? <Loader2 className="size-3 animate-spin" /> : null}
+      {meta.label}
+    </span>
+  );
+}
+
+function statusMeta(status: BackgroundCommandSessionSummary["status"]) {
+  switch (status) {
+    case "starting":
+      return {
+        label: "Starting",
+        spinner: true,
+        className: "text-amber-400 ring-amber-400/30 bg-amber-400/10",
+      };
+    case "running":
+      return {
+        label: "Running",
+        spinner: true,
+        className: "text-emerald-400 ring-emerald-400/30 bg-emerald-400/10",
+      };
+    case "stopping":
+      return {
+        label: "Stopping",
+        spinner: true,
+        className: "text-amber-400 ring-amber-400/30 bg-amber-400/10",
+      };
+    case "exited":
+      return {
+        label: "Exited",
+        spinner: false,
+        className: "text-muted-foreground ring-border bg-secondary",
+      };
+    case "failed":
+      return {
+        label: "Failed",
+        spinner: false,
+        className: "text-destructive ring-destructive/30 bg-destructive/10",
+      };
+    case "stopped":
+      return {
+        label: "Stopped",
+        spinner: false,
+        className: "text-muted-foreground ring-border bg-secondary",
+      };
+    case "stale":
+      return {
+        label: "Stale",
+        spinner: false,
+        className: "text-amber-400 ring-amber-400/30 bg-amber-400/10",
+      };
+  }
+}
+
+function formatElapsed(startedAt: number | null, now: number): string {
+  if (!startedAt) return "—";
+  const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return `${minutes}m ${rem}s`;
+}
+
+function useElapsedClock(intervalMs = 1_000): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+    }, intervalMs);
+    return () => window.clearInterval(interval);
+  }, [intervalMs]);
+
+  return now;
+}
+
+function formatDuration(startedAt: number | null, finishedAt: number | null): string {
+  if (!startedAt || !finishedAt) return "—";
+  const seconds = Math.max(0, Math.floor((finishedAt - startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rem = seconds % 60;
+  return `${minutes}m ${rem}s`;
+}
+
+function scriptLaunchCommand(
+  packageManager: ProjectStatusSummary["packageManager"],
+  scriptName: string,
+): string {
+  const pm = packageManager ?? "npm";
+  return pm === "npm"
+    ? `npm run ${scriptName}`
+    : `${pm} run ${scriptName}`;
+}
+
+function scriptNameFromStoredCommand(
+  session: BackgroundCommandSessionSummary,
+): string | null {
+  const match = session.command.match(/\b(?:npm|pnpm|yarn|bun)\s+run\s+(\S+)/);
+  return match?.[1] ?? null;
+}

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -1,8 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useSyncExternalStore, useState } from "react";
 
-import type { ProjectGitStatusSummary, ProjectStatusSummary, ProjectSummary } from "@/src/lib/api-types";
+import type {
+  ProjectBackgroundCommandsSummary,
+  ProjectFileTreeSummary,
+  ProjectGitStatusSummary,
+  ProjectStatusSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
 import { errorMessage, getJson } from "@/src/lib/client-fetch";
 
 export const PROJECT_GIT_CHANGED_EVENT = "anton-project-git-change";
@@ -144,6 +150,160 @@ export function notifyProjectGitChanged(projectId: string): void {
 }
 
 const PROJECT_STATUS_POLL_INTERVAL_MS = 120_000;
+const PROJECT_COMMANDS_POLL_INTERVAL_MS = 5_000;
+
+export const PROJECT_COMMANDS_CHANGED_EVENT = "anton-project-commands-change";
+
+export type StartBackgroundCommandInput =
+  | { kind: "script"; scriptName: string }
+  | { kind: "custom"; command: string };
+
+export const OPEN_WORKLOG_STATUS_EVENT = "anton-open-worklog-status";
+
+type ProjectStatusStoreState = {
+  status: ProjectStatusSummary | null;
+  loading: boolean;
+  error: string | null;
+};
+
+type ProjectStatusStore = {
+  state: ProjectStatusStoreState;
+  listeners: Set<() => void>;
+  subscribers: number;
+  pollTimeout: number | null;
+  loadPromise: Promise<void> | null;
+};
+
+const EMPTY_STATUS_STATE: ProjectStatusStoreState = {
+  status: null,
+  loading: false,
+  error: null,
+};
+
+const projectStatusStores = new Map<string, ProjectStatusStore>();
+
+function getProjectStatusStore(projectId: string): ProjectStatusStore {
+  const existing = projectStatusStores.get(projectId);
+  if (existing) return existing;
+
+  const store: ProjectStatusStore = {
+    state: EMPTY_STATUS_STATE,
+    listeners: new Set(),
+    subscribers: 0,
+    pollTimeout: null,
+    loadPromise: null,
+  };
+  projectStatusStores.set(projectId, store);
+  return store;
+}
+
+function setProjectStatusStoreState(
+  store: ProjectStatusStore,
+  patch: Partial<ProjectStatusStoreState>,
+): void {
+  store.state = { ...store.state, ...patch };
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function clearProjectStatusPoll(store: ProjectStatusStore): void {
+  if (store.pollTimeout !== null) {
+    window.clearTimeout(store.pollTimeout);
+    store.pollTimeout = null;
+  }
+}
+
+function scheduleProjectStatusPoll(projectId: string, store: ProjectStatusStore): void {
+  clearProjectStatusPoll(store);
+  if (store.subscribers === 0) return;
+
+  store.pollTimeout = window.setTimeout(() => {
+    store.pollTimeout = null;
+    void loadProjectStatus(projectId, store, { background: true }).finally(() => {
+      scheduleProjectStatusPoll(projectId, store);
+    });
+  }, PROJECT_STATUS_POLL_INTERVAL_MS);
+}
+
+async function loadProjectStatus(
+  projectId: string,
+  store: ProjectStatusStore,
+  options: { background?: boolean } = {},
+): Promise<void> {
+  if (store.loadPromise) {
+    await store.loadPromise;
+    return;
+  }
+
+  const hasCache = store.state.status !== null;
+  if (!options.background && !hasCache) {
+    setProjectStatusStoreState(store, { loading: true });
+  }
+
+  store.loadPromise = (async () => {
+    try {
+      const data = await getJson<{ status: ProjectStatusSummary }>(
+        `/api/projects/${projectId}/status`,
+      );
+      setProjectStatusStoreState(store, {
+        status: data.status,
+        error: null,
+        loading: false,
+      });
+    } catch (err) {
+      setProjectStatusStoreState(store, {
+        status: hasCache ? store.state.status : null,
+        error:
+          err instanceof Error ? err.message : "Failed to load project status",
+        loading: false,
+      });
+    } finally {
+      store.loadPromise = null;
+    }
+  })();
+
+  await store.loadPromise;
+}
+
+function subscribeProjectStatus(
+  projectId: string,
+  listener: () => void,
+): () => void {
+  const store = getProjectStatusStore(projectId);
+  store.subscribers += 1;
+  store.listeners.add(listener);
+
+  if (store.state.status === null && store.loadPromise === null) {
+    void loadProjectStatus(projectId, store).finally(() => {
+      scheduleProjectStatusPoll(projectId, store);
+    });
+  } else {
+    scheduleProjectStatusPoll(projectId, store);
+  }
+
+  const onProjectGitChanged = (event: Event) => {
+    if (
+      event instanceof CustomEvent &&
+      typeof event.detail === "string" &&
+      event.detail === projectId
+    ) {
+      void loadProjectStatus(projectId, store, { background: true }).finally(() => {
+        scheduleProjectStatusPoll(projectId, store);
+      });
+    }
+  };
+  window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+
+  return () => {
+    store.listeners.delete(listener);
+    store.subscribers = Math.max(0, store.subscribers - 1);
+    window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    if (store.subscribers === 0) {
+      clearProjectStatusPoll(store);
+    }
+  };
+}
 
 export function useProjectStatus(projectId: string | null): {
   status: ProjectStatusSummary | null;
@@ -151,93 +311,418 @@ export function useProjectStatus(projectId: string | null): {
   error: string | null;
   refresh: () => Promise<void>;
 } {
-  const [loaded, setLoaded] = useState<{
-    projectId: string;
-    status: ProjectStatusSummary | null;
-    error: string | null;
-  } | null>(null);
-  const [loading, setLoading] = useState(false);
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!projectId) return () => {};
+      return subscribeProjectStatus(projectId, listener);
+    },
+    [projectId],
+  );
 
-  const refresh = async () => {
-    if (!projectId) return;
-    setLoading(true);
-    try {
-      const data = await getJson<{ status: ProjectStatusSummary }>(
-        `/api/projects/${projectId}/status`,
-      );
-      setLoaded({ projectId, status: data.status, error: null });
-    } catch (err) {
-      setLoaded({
-        projectId,
-        status: null,
-        error: err instanceof Error ? err.message : "Failed to load project status",
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!projectId) {
-      queueMicrotask(() => setLoaded(null));
-      return;
-    }
-
-    let cancelled = false;
-    let pollTimeout: number | null = null;
-    const load = async () => {
-      if (cancelled) return;
-      setLoading(true);
-      try {
-        const data = await getJson<{ status: ProjectStatusSummary }>(
-          `/api/projects/${projectId}/status`,
-        );
-        if (!cancelled) {
-          setLoaded({ projectId, status: data.status, error: null });
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setLoaded({
-            projectId,
-            status: null,
-            error:
-              err instanceof Error ? err.message : "Failed to load project status",
-          });
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    const schedulePoll = () => {
-      if (cancelled) return;
-      pollTimeout = window.setTimeout(() => {
-        void load().finally(schedulePoll);
-      }, PROJECT_STATUS_POLL_INTERVAL_MS);
-    };
-
-    void load().finally(schedulePoll);
-    const onProjectGitChanged = (event: Event) => {
-      if (
-        event instanceof CustomEvent &&
-        typeof event.detail === "string" &&
-        event.detail === projectId
-      ) {
-        void load();
-      }
-    };
-    window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
-    return () => {
-      cancelled = true;
-      if (pollTimeout !== null) window.clearTimeout(pollTimeout);
-      window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
-    };
+  const getSnapshot = useCallback((): ProjectStatusStoreState => {
+    if (!projectId) return EMPTY_STATUS_STATE;
+    return getProjectStatusStore(projectId).state;
   }, [projectId]);
 
-  const isCurrent = loaded?.projectId === projectId;
+  const state = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_STATUS_STATE);
+
+  const refresh = useCallback(async () => {
+    if (!projectId) return;
+    const store = getProjectStatusStore(projectId);
+    await loadProjectStatus(projectId, store);
+    scheduleProjectStatusPoll(projectId, store);
+  }, [projectId]);
+
   return {
-    status: isCurrent ? loaded?.status ?? null : null,
-    loading,
-    error: isCurrent ? loaded?.error ?? null : null,
+    status: state.status,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+  };
+}
+
+export function notifyOpenWorklogStatus(): void {
+  window.dispatchEvent(new CustomEvent(OPEN_WORKLOG_STATUS_EVENT));
+}
+
+export function notifyProjectCommandsChanged(projectId: string): void {
+  window.dispatchEvent(
+    new CustomEvent(PROJECT_COMMANDS_CHANGED_EVENT, { detail: projectId }),
+  );
+}
+
+type ProjectCommandsStoreState = {
+  commands: ProjectBackgroundCommandsSummary | null;
+  loading: boolean;
+  error: string | null;
+};
+
+type ProjectCommandsStore = {
+  state: ProjectCommandsStoreState;
+  listeners: Set<() => void>;
+  subscribers: number;
+  pollTimeout: number | null;
+  loadPromise: Promise<void> | null;
+};
+
+const EMPTY_COMMANDS_STATE: ProjectCommandsStoreState = {
+  commands: null,
+  loading: false,
+  error: null,
+};
+
+const projectCommandsStores = new Map<string, ProjectCommandsStore>();
+
+function getProjectCommandsStore(projectId: string): ProjectCommandsStore {
+  const existing = projectCommandsStores.get(projectId);
+  if (existing) return existing;
+
+  const store: ProjectCommandsStore = {
+    state: EMPTY_COMMANDS_STATE,
+    listeners: new Set(),
+    subscribers: 0,
+    pollTimeout: null,
+    loadPromise: null,
+  };
+  projectCommandsStores.set(projectId, store);
+  return store;
+}
+
+function setProjectCommandsStoreState(
+  store: ProjectCommandsStore,
+  patch: Partial<ProjectCommandsStoreState>,
+): void {
+  store.state = { ...store.state, ...patch };
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function clearProjectCommandsPoll(store: ProjectCommandsStore): void {
+  if (store.pollTimeout !== null) {
+    window.clearTimeout(store.pollTimeout);
+    store.pollTimeout = null;
+  }
+}
+
+function scheduleProjectCommandsPoll(projectId: string, store: ProjectCommandsStore): void {
+  clearProjectCommandsPoll(store);
+  if (store.subscribers === 0) return;
+  if ((store.state.commands?.runningCount ?? 0) === 0) return;
+
+  store.pollTimeout = window.setTimeout(() => {
+    store.pollTimeout = null;
+    void loadProjectCommands(projectId, store).finally(() => {
+      scheduleProjectCommandsPoll(projectId, store);
+    });
+  }, PROJECT_COMMANDS_POLL_INTERVAL_MS);
+}
+
+async function loadProjectCommands(
+  projectId: string,
+  store: ProjectCommandsStore,
+  options: { background?: boolean } = {},
+): Promise<void> {
+  if (store.loadPromise) {
+    await store.loadPromise;
+    return;
+  }
+
+  const hasCache = store.state.commands !== null;
+  if (!options.background && !hasCache) {
+    setProjectCommandsStoreState(store, { loading: true });
+  }
+
+  store.loadPromise = (async () => {
+    try {
+      const data = await getJson<{ commands: ProjectBackgroundCommandsSummary }>(
+        `/api/projects/${projectId}/commands`,
+      );
+      setProjectCommandsStoreState(store, {
+        commands: data.commands,
+        error: null,
+        loading: false,
+      });
+    } catch (err) {
+      setProjectCommandsStoreState(store, {
+        commands: hasCache ? store.state.commands : null,
+        error:
+          err instanceof Error ? err.message : "Failed to load commands",
+        loading: false,
+      });
+    } finally {
+      store.loadPromise = null;
+    }
+  })();
+
+  await store.loadPromise;
+}
+
+function subscribeProjectCommands(
+  projectId: string,
+  listener: () => void,
+): () => void {
+  const store = getProjectCommandsStore(projectId);
+  store.subscribers += 1;
+  store.listeners.add(listener);
+
+  if (store.state.commands === null && store.loadPromise === null) {
+    void loadProjectCommands(projectId, store).finally(() => {
+      scheduleProjectCommandsPoll(projectId, store);
+    });
+  } else {
+    scheduleProjectCommandsPoll(projectId, store);
+  }
+
+  const onCommandsChanged = (event: Event) => {
+    if (
+      event instanceof CustomEvent &&
+      typeof event.detail === "string" &&
+      event.detail === projectId
+    ) {
+      void loadProjectCommands(projectId, store, { background: true }).finally(() => {
+        scheduleProjectCommandsPoll(projectId, store);
+      });
+    }
+  };
+  window.addEventListener(PROJECT_COMMANDS_CHANGED_EVENT, onCommandsChanged);
+
+  return () => {
+    store.listeners.delete(listener);
+    store.subscribers = Math.max(0, store.subscribers - 1);
+    window.removeEventListener(PROJECT_COMMANDS_CHANGED_EVENT, onCommandsChanged);
+    if (store.subscribers === 0) {
+      clearProjectCommandsPoll(store);
+    }
+  };
+}
+
+export function useProjectCommands(projectId: string | null): {
+  commands: ProjectBackgroundCommandsSummary | null;
+  loading: boolean;
+  error: string | null;
+  runningCount: number;
+  refresh: () => Promise<void>;
+} {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!projectId) return () => {};
+      return subscribeProjectCommands(projectId, listener);
+    },
+    [projectId],
+  );
+
+  const getSnapshot = useCallback((): ProjectCommandsStoreState => {
+    if (!projectId) return EMPTY_COMMANDS_STATE;
+    return getProjectCommandsStore(projectId).state;
+  }, [projectId]);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_COMMANDS_STATE);
+
+  const refresh = useCallback(async () => {
+    if (!projectId) return;
+    const store = getProjectCommandsStore(projectId);
+    await loadProjectCommands(projectId, store, {
+      background: store.state.commands !== null,
+    });
+    scheduleProjectCommandsPoll(projectId, store);
+  }, [projectId]);
+
+  return {
+    commands: state.commands,
+    loading: state.loading,
+    error: state.error,
+    runningCount: state.commands?.runningCount ?? 0,
+    refresh,
+  };
+}
+
+const PROJECT_FILES_POLL_INTERVAL_MS = 60_000;
+
+type ProjectFilesStoreState = {
+  fileTree: ProjectFileTreeSummary | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+};
+
+type ProjectFilesStore = {
+  state: ProjectFilesStoreState;
+  listeners: Set<() => void>;
+  subscribers: number;
+  pollTimeout: number | null;
+  loadPromise: Promise<void> | null;
+};
+
+const EMPTY_FILES_STATE: ProjectFilesStoreState = {
+  fileTree: null,
+  loading: false,
+  refreshing: false,
+  error: null,
+};
+
+const projectFilesStores = new Map<string, ProjectFilesStore>();
+
+function getProjectFilesStore(projectId: string): ProjectFilesStore {
+  const existing = projectFilesStores.get(projectId);
+  if (existing) return existing;
+
+  const store: ProjectFilesStore = {
+    state: EMPTY_FILES_STATE,
+    listeners: new Set(),
+    subscribers: 0,
+    pollTimeout: null,
+    loadPromise: null,
+  };
+  projectFilesStores.set(projectId, store);
+  return store;
+}
+
+function setProjectFilesStoreState(
+  store: ProjectFilesStore,
+  patch: Partial<ProjectFilesStoreState>,
+): void {
+  store.state = { ...store.state, ...patch };
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function clearProjectFilesPoll(store: ProjectFilesStore): void {
+  if (store.pollTimeout !== null) {
+    window.clearTimeout(store.pollTimeout);
+    store.pollTimeout = null;
+  }
+}
+
+function scheduleProjectFilesPoll(projectId: string, store: ProjectFilesStore): void {
+  clearProjectFilesPoll(store);
+  if (store.subscribers === 0) return;
+
+  store.pollTimeout = window.setTimeout(() => {
+    store.pollTimeout = null;
+    void loadProjectFiles(projectId, store, { background: true }).finally(() => {
+      scheduleProjectFilesPoll(projectId, store);
+    });
+  }, PROJECT_FILES_POLL_INTERVAL_MS);
+}
+
+async function loadProjectFiles(
+  projectId: string,
+  store: ProjectFilesStore,
+  options: { background?: boolean } = {},
+): Promise<void> {
+  if (store.loadPromise) {
+    await store.loadPromise;
+    return;
+  }
+
+  const hasCache = store.state.fileTree !== null;
+  if (options.background) {
+    setProjectFilesStoreState(store, { refreshing: true });
+  } else if (!hasCache) {
+    setProjectFilesStoreState(store, { loading: true });
+  }
+
+  store.loadPromise = (async () => {
+    try {
+      const data = await getJson<{ fileTree: ProjectFileTreeSummary }>(
+        `/api/projects/${projectId}/files`,
+      );
+      setProjectFilesStoreState(store, {
+        fileTree: data.fileTree,
+        error: null,
+        loading: false,
+        refreshing: false,
+      });
+    } catch (err) {
+      setProjectFilesStoreState(store, {
+        fileTree: hasCache ? store.state.fileTree : null,
+        error: errorMessage(err, "Failed to load project files"),
+        loading: false,
+        refreshing: false,
+      });
+    } finally {
+      store.loadPromise = null;
+    }
+  })();
+
+  await store.loadPromise;
+}
+
+function subscribeProjectFiles(
+  projectId: string,
+  listener: () => void,
+): () => void {
+  const store = getProjectFilesStore(projectId);
+  store.subscribers += 1;
+  store.listeners.add(listener);
+
+  if (store.state.fileTree === null && store.loadPromise === null) {
+    void loadProjectFiles(projectId, store).finally(() => {
+      scheduleProjectFilesPoll(projectId, store);
+    });
+  } else {
+    scheduleProjectFilesPoll(projectId, store);
+  }
+
+  const onProjectGitChanged = (event: Event) => {
+    if (
+      event instanceof CustomEvent &&
+      typeof event.detail === "string" &&
+      event.detail === projectId
+    ) {
+      void loadProjectFiles(projectId, store, { background: true });
+    }
+  };
+  window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+
+  return () => {
+    store.listeners.delete(listener);
+    store.subscribers = Math.max(0, store.subscribers - 1);
+    window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    if (store.subscribers === 0) {
+      clearProjectFilesPoll(store);
+    }
+  };
+}
+
+export function useProjectFileTree(projectId: string | null): {
+  fileTree: ProjectFileTreeSummary | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!projectId) return () => {};
+      return subscribeProjectFiles(projectId, listener);
+    },
+    [projectId],
+  );
+
+  const getSnapshot = useCallback((): ProjectFilesStoreState => {
+    if (!projectId) return EMPTY_FILES_STATE;
+    return getProjectFilesStore(projectId).state;
+  }, [projectId]);
+
+  const state = useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_FILES_STATE);
+
+  const refresh = useCallback(async () => {
+    if (!projectId) return;
+    const store = getProjectFilesStore(projectId);
+    await loadProjectFiles(projectId, store, {
+      background: store.state.fileTree !== null,
+    });
+    scheduleProjectFilesPoll(projectId, store);
+  }, [projectId]);
+
+  return {
+    fileTree: state.fileTree,
+    loading: state.loading,
+    refreshing: state.refreshing,
+    error: state.error,
     refresh,
   };
 }

--- a/components/features/projects/use-background-command-stream.ts
+++ b/components/features/projects/use-background-command-stream.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+export type BackgroundCommandStreamEvent =
+  | { type: "stdout"; chunk: string }
+  | { type: "stderr"; chunk: string }
+  | {
+      type: "status";
+      status: string;
+      exitCode?: number | null;
+      signal?: string | null;
+      detectedUrls?: string[];
+      finished?: boolean;
+    };
+
+export interface BackgroundCommandStreamState {
+  stdout: string;
+  stderr: string;
+  status: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  detectedUrls: string[];
+  finished: boolean;
+  error?: string;
+}
+
+interface BackgroundCommandStreamStore {
+  state: BackgroundCommandStreamState;
+  listeners: Set<() => void>;
+  subscribers: number;
+  eventSource: EventSource | null;
+  reconnectTimeout: number | null;
+  closeTimeout: number | null;
+}
+
+const EMPTY_STATE: BackgroundCommandStreamState = {
+  stdout: "",
+  stderr: "",
+  status: "starting",
+  detectedUrls: [],
+  finished: false,
+};
+
+const MAX_OUTPUT_CHARS = 64 * 1024;
+const RECONNECT_DELAY_MS = 1_000;
+const CLOSE_GRACE_MS = 500;
+
+const stores = new Map<string, BackgroundCommandStreamStore>();
+
+export function useBackgroundCommandStream(
+  projectId: string | undefined,
+  commandId: string | undefined,
+  token: string | undefined,
+  enabled: boolean,
+): BackgroundCommandStreamState {
+  const active = useMemo(
+    () =>
+      enabled && projectId && commandId && token
+        ? { projectId, commandId, token }
+        : undefined,
+    [enabled, projectId, commandId, token],
+  );
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!active) return () => {};
+      return subscribeToBackgroundCommandStream(active, onStoreChange);
+    },
+    [active],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!active) return EMPTY_STATE;
+    return getStore(storeKey(active.projectId, active.commandId, active.token))
+      .state;
+  }, [active]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY_STATE);
+}
+
+function subscribeToBackgroundCommandStream(
+  active: { projectId: string; commandId: string; token: string },
+  listener: () => void,
+): () => void {
+  const key = storeKey(active.projectId, active.commandId, active.token);
+  const store = getStore(key);
+  store.subscribers += 1;
+  store.listeners.add(listener);
+
+  if (store.closeTimeout !== null) {
+    window.clearTimeout(store.closeTimeout);
+    store.closeTimeout = null;
+  }
+
+  if (!store.state.finished) {
+    connectStore(active, store);
+  }
+
+  return () => {
+    store.listeners.delete(listener);
+    store.subscribers = Math.max(0, store.subscribers - 1);
+    if (store.subscribers > 0 || store.closeTimeout !== null) return;
+
+    store.closeTimeout = window.setTimeout(() => {
+      store.closeTimeout = null;
+      if (store.subscribers > 0) return;
+      closeStore(key, store);
+    }, CLOSE_GRACE_MS);
+  };
+}
+
+function getStore(key: string): BackgroundCommandStreamStore {
+  const existing = stores.get(key);
+  if (existing) return existing;
+
+  const store: BackgroundCommandStreamStore = {
+    state: EMPTY_STATE,
+    listeners: new Set(),
+    subscribers: 0,
+    eventSource: null,
+    reconnectTimeout: null,
+    closeTimeout: null,
+  };
+  stores.set(key, store);
+  return store;
+}
+
+function connectStore(
+  active: { projectId: string; commandId: string; token: string },
+  store: BackgroundCommandStreamStore,
+): void {
+  if (store.eventSource || store.reconnectTimeout !== null) return;
+
+  const eventSource = new EventSource(
+    `/api/projects/${encodeURIComponent(active.projectId)}/commands/${encodeURIComponent(active.commandId)}/stream?token=${encodeURIComponent(active.token)}`,
+  );
+  store.eventSource = eventSource;
+
+  eventSource.onmessage = (event) => {
+    let data: BackgroundCommandStreamEvent;
+    try {
+      data = JSON.parse(event.data) as BackgroundCommandStreamEvent;
+    } catch {
+      return;
+    }
+
+    if (data.type === "stdout") {
+      setStoreState(store, {
+        ...store.state,
+        stdout: capOutput(store.state.stdout + data.chunk),
+      });
+      return;
+    }
+
+    if (data.type === "stderr") {
+      setStoreState(store, {
+        ...store.state,
+        stderr: capOutput(store.state.stderr + data.chunk),
+      });
+      return;
+    }
+
+    setStoreState(store, {
+      ...store.state,
+      status: data.status,
+      exitCode: data.exitCode,
+      signal: data.signal,
+      detectedUrls: data.detectedUrls ?? store.state.detectedUrls,
+      finished: true,
+    });
+    closeEventSource(store, eventSource);
+  };
+
+  eventSource.onerror = () => {
+    if (store.eventSource !== eventSource) return;
+    closeEventSource(store, eventSource);
+    if (store.state.finished || store.subscribers === 0) return;
+
+    store.reconnectTimeout = window.setTimeout(() => {
+      store.reconnectTimeout = null;
+      if (!store.state.finished && store.subscribers > 0) {
+        connectStore(active, store);
+      }
+    }, RECONNECT_DELAY_MS);
+  };
+}
+
+function setStoreState(
+  store: BackgroundCommandStreamStore,
+  state: BackgroundCommandStreamState,
+): void {
+  store.state = state;
+  for (const listener of store.listeners) {
+    listener();
+  }
+}
+
+function closeStore(key: string, store: BackgroundCommandStreamStore): void {
+  closeEventSource(store, store.eventSource);
+  if (store.reconnectTimeout !== null) {
+    window.clearTimeout(store.reconnectTimeout);
+    store.reconnectTimeout = null;
+  }
+  stores.delete(key);
+}
+
+function closeEventSource(
+  store: BackgroundCommandStreamStore,
+  eventSource: EventSource | null,
+): void {
+  if (!eventSource || store.eventSource !== eventSource) return;
+  store.eventSource = null;
+  eventSource.close();
+}
+
+function capOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) return output;
+  return output.slice(output.length - MAX_OUTPUT_CHARS);
+}
+
+function storeKey(projectId: string, commandId: string, token: string): string {
+  return `${projectId}:${commandId}:${token}`;
+}

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -138,7 +138,7 @@ export function PullRequestPanel({
           </TabsList>
         </div>
         <TabsContent value="changes" className="m-0 min-w-0">
-          <ChangesView
+          <LocalChangesView
             files={pullRequest.files}
             selected={selected}
             onSelect={setSelectedFile}
@@ -167,7 +167,6 @@ export function PullRequestPanel({
 
 export function PullRequestEmptyPanel({
   gitStatus,
-  localFiles,
   loading,
   creating,
   error,
@@ -175,7 +174,6 @@ export function PullRequestEmptyPanel({
   onCreatePullRequest,
 }: {
   gitStatus: ProjectGitStatusSummary | null;
-  localFiles: ProjectPullRequestFileSummary[];
   loading: boolean;
   creating: boolean;
   error: string | null;
@@ -188,11 +186,6 @@ export function PullRequestEmptyPanel({
     gitStatus && canShowCreateAction && !createReady
       ? pullRequestCreateBlocker(gitStatus)
       : null;
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const selected =
-    localFiles.find((file) => file.filename === selectedFile) ??
-    localFiles[0] ??
-    null;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <section className="border-b border-border px-3 py-3">
@@ -253,18 +246,6 @@ export function PullRequestEmptyPanel({
           </div>
         ) : null}
       </section>
-      {localFiles.length > 0 ? (
-        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <div className="border-b border-border px-3 py-2 text-[11px] font-medium text-muted-foreground">
-            Local changes
-          </div>
-          <ChangesView
-            files={localFiles}
-            selected={selected}
-            onSelect={setSelectedFile}
-          />
-        </div>
-      ) : null}
     </div>
   );
 }
@@ -303,7 +284,7 @@ function emptyPullRequestMessage(gitStatus: ProjectGitStatusSummary | null): str
   return `No GitHub pull request matches ${gitStatus.branch}.`;
 }
 
-function ChangesView({
+export function LocalChangesView({
   files,
   selected,
   onSelect,

--- a/components/features/run-trace/project-diff-panel.tsx
+++ b/components/features/run-trace/project-diff-panel.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+} from "@/components/shared/feedback-states";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectGitStatusSummary,
+  ProjectLocalDiffSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
+import { getJson } from "@/src/lib/client-fetch";
+import {
+  notifyProjectGitChanged,
+  PROJECT_GIT_CHANGED_EVENT,
+} from "@/components/features/projects/hooks";
+import { LocalChangesView } from "./pr-sidebar";
+
+export function ProjectDiffPanel({
+  project,
+  visible = true,
+}: {
+  project: ProjectSummary | null;
+  visible?: boolean;
+}) {
+  const [gitStatus, setGitStatus] = useState<ProjectGitStatusSummary | null>(null);
+  const [localDiff, setLocalDiff] = useState<ProjectLocalDiffSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+  const projectId = project?.status === "ready" ? project.id : null;
+
+  useEffect(() => {
+    if (!visible || !projectId) {
+      queueMicrotask(() => {
+        setGitStatus(null);
+        setLocalDiff(null);
+        setError(null);
+        setLoading(false);
+      });
+      return;
+    }
+
+    let cancelled = false;
+    const load = async (showLoading: boolean) => {
+      if (showLoading) setLoading(true);
+      try {
+        const statusData = await getJson<{ status: ProjectGitStatusSummary }>(
+          `/api/projects/${projectId}/git/status`,
+        );
+        if (cancelled) return;
+        setGitStatus(statusData.status);
+
+        if (statusData.status.dirtyCount > 0) {
+          const diffData = await getJson<{ diff: ProjectLocalDiffSummary }>(
+            `/api/projects/${projectId}/git/diff`,
+          );
+          if (cancelled) return;
+          setLocalDiff(diffData.diff);
+          setError(null);
+        } else {
+          setLocalDiff(null);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load diff");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load(true);
+    const onProjectGitChanged = (event: Event) => {
+      if (
+        event instanceof CustomEvent &&
+        typeof event.detail === "string" &&
+        event.detail === projectId
+      ) {
+        void load(false);
+      }
+    };
+    window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    };
+  }, [projectId, visible]);
+
+  if (!project) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <EmptyState message="Select a ready project to view changes." />
+      </div>
+    );
+  }
+
+  if (project.status !== "ready") {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <EmptyState message={`Project is ${project.status}. Diff is unavailable until ready.`} />
+      </div>
+    );
+  }
+
+  const files = localDiff?.files ?? [];
+  const selected =
+    files.find((file) => file.filename === selectedFile) ?? files[0] ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <section className="shrink-0 border-b border-border px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0 text-[11px] text-muted-foreground">
+            {gitStatus ? (
+              <p className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                <span className="font-mono text-foreground">
+                  {gitStatus.branch ?? "detached"}
+                </span>
+                <span>·</span>
+                <span>{gitStatus.dirtyCount} dirty</span>
+                {gitStatus.upstream ? (
+                  <>
+                    <span>·</span>
+                    <span className="font-mono">{gitStatus.upstream}</span>
+                  </>
+                ) : null}
+                {gitStatus.ahead !== null && gitStatus.behind !== null ? (
+                  <>
+                    <span>·</span>
+                    <span>
+                      {gitStatus.ahead}↑ {gitStatus.behind}↓
+                    </span>
+                  </>
+                ) : null}
+              </p>
+            ) : (
+              <p>Loading git state…</p>
+            )}
+          </div>
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => {
+              notifyProjectGitChanged(project.id);
+            }}
+            disabled={loading}
+            aria-label="Refresh diff"
+            title="Refresh diff"
+          >
+            <RefreshCw className={cn(loading && "animate-spin")} />
+          </Button>
+        </div>
+        {error ? (
+          <div className="mt-2">
+            <ErrorBanner message={error} />
+          </div>
+        ) : null}
+      </section>
+
+      {loading && files.length === 0 ? (
+        <div className="px-3 py-4">
+          <LoadingState label="Loading changes..." />
+        </div>
+      ) : files.length > 0 ? (
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <LocalChangesView
+            files={files}
+            selected={selected}
+            onSelect={setSelectedFile}
+          />
+        </div>
+      ) : (
+        <div className="px-3 py-4">
+          <EmptyState message="Working tree clean." />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/features/run-trace/project-files-panel.tsx
+++ b/components/features/run-trace/project-files-panel.tsx
@@ -22,12 +22,12 @@ import {
 } from "@pierre/trees/react";
 
 import { Button } from "@/components/ui/button";
-import { errorMessage, getJson } from "@/src/lib/client-fetch";
+import { useProjectFileTree } from "@/components/features/projects/hooks";
 import type {
   ProjectFileContentSummary,
-  ProjectFileTreeSummary,
   ProjectSummary,
 } from "@/src/lib/api-types";
+import { errorMessage, getJson } from "@/src/lib/client-fetch";
 import { cn } from "@/lib/utils";
 import { ProjectFileCodeView } from "./project-file-code-view";
 
@@ -43,14 +43,6 @@ function countBadgeGitChanges(
 
 const projectFilesHeaderRowClass =
   "flex shrink-0 items-center border-b border-border p-1.5";
-
-type ProjectFileTreeState = {
-  fileTree: ProjectFileTreeSummary | null;
-  loading: boolean;
-  refreshing: boolean;
-  error: string | null;
-  refresh: () => void;
-};
 
 type OpenFileState = {
   path: string;
@@ -71,11 +63,11 @@ export function ProjectFilesPanel({
   expanded: boolean;
   onFileOpen?: () => void;
 }) {
-  const state = useProjectFileTree(project, { enabled: visible });
   const readyProject = project?.status === "ready";
+  const projectId = readyProject ? project.id : null;
+  const state = useProjectFileTree(visible ? projectId : null);
   const [openFiles, setOpenFiles] = useState<OpenFileState[]>([]);
   const [activePath, setActivePath] = useState<string | null>(null);
-  const projectId = readyProject ? project.id : null;
 
   useEffect(() => {
     queueMicrotask(() => {
@@ -136,7 +128,7 @@ export function ProjectFilesPanel({
         <ProjectFilesEmptyState message="Select an active project to browse files." />
       ) : !readyProject ? (
         <ProjectFilesEmptyState message="Project files are available after the workspace is ready." />
-      ) : state.loading ? (
+      ) : state.loading && !state.fileTree ? (
         <ProjectFilesEmptyState message="Loading project files..." loading />
       ) : state.fileTree && state.fileTree.paths.length > 0 ? (
         <div
@@ -151,7 +143,7 @@ export function ProjectFilesPanel({
             gitStatus={state.fileTree.gitStatus}
             truncated={state.fileTree.truncated}
             refreshing={state.refreshing}
-            onRefresh={state.refresh}
+            onRefresh={() => void state.refresh()}
             onFileOpen={openFile}
             selectedPath={activePath}
             className={cn(
@@ -390,73 +382,6 @@ function ProjectFileViewer({
       )}
     </div>
   );
-}
-
-function useProjectFileTree(
-  project: ProjectSummary | null,
-  options: { enabled: boolean },
-): ProjectFileTreeState {
-  const [fileTree, setFileTree] = useState<ProjectFileTreeSummary | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const projectId = project?.status === "ready" ? project.id : null;
-
-  const loadFileTree = useCallback(
-    async (mode: "initial" | "refresh" = "initial") => {
-      if (!projectId) return;
-      if (mode === "initial") {
-        setLoading(true);
-      } else {
-        setRefreshing(true);
-      }
-      setError(null);
-      try {
-        const data = await getJson<{ fileTree: ProjectFileTreeSummary }>(
-          `/api/projects/${projectId}/files`,
-        );
-        setFileTree(data.fileTree);
-      } catch (err) {
-        setError(errorMessage(err, "Failed to load project files"));
-      } finally {
-        setLoading(false);
-        setRefreshing(false);
-      }
-    },
-    [projectId],
-  );
-
-  useEffect(() => {
-    if (!options.enabled || !projectId) {
-      queueMicrotask(() => {
-        setFileTree(null);
-        setLoading(false);
-        setRefreshing(false);
-        setError(null);
-      });
-      return;
-    }
-    queueMicrotask(() => void loadFileTree("initial"));
-  }, [loadFileTree, options.enabled, projectId]);
-
-  useEffect(() => {
-    if (!options.enabled || !projectId) return;
-    const refreshGitStatus = () => void loadFileTree("refresh");
-    window.addEventListener("focus", refreshGitStatus);
-    const intervalId = window.setInterval(refreshGitStatus, 15_000);
-    return () => {
-      window.removeEventListener("focus", refreshGitStatus);
-      window.clearInterval(intervalId);
-    };
-  }, [loadFileTree, options.enabled, projectId]);
-
-  return {
-    fileTree,
-    loading,
-    refreshing,
-    error,
-    refresh: () => void loadFileTree(fileTree ? "refresh" : "initial"),
-  };
 }
 
 async function loadProjectFile(

--- a/components/features/run-trace/project-status-panel.tsx
+++ b/components/features/run-trace/project-status-panel.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useState, type ReactNode } from "react";
 import {
-  Activity,
   CheckCircle2,
   Clock,
   Copy,
@@ -18,6 +17,7 @@ import {
   ErrorBanner,
   LoadingState,
 } from "@/components/shared/feedback-states";
+import { BackgroundCommandsPanel } from "@/components/features/projects/background-commands-panel";
 import { cn } from "@/lib/utils";
 import type { ProjectStatusSummary, ProjectSummary } from "@/src/lib/api-types";
 import { notifyProjectGitChanged, useProjectStatus } from "@/components/features/projects/hooks";
@@ -49,18 +49,9 @@ export function ProjectStatusPanel({
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
-      <section className="border-b border-border px-3 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border">
-              <Activity className="size-3" />
-              Project status
-            </div>
-            <h2 className="mt-2 text-sm font-semibold">{project.fullName}</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Workspace root, git state, scripts, and last agent run.
-            </p>
-          </div>
+      <section className="border-b border-border px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="truncate text-sm font-medium">{project.fullName}</h2>
           <Button
             type="button"
             size="icon-sm"
@@ -77,7 +68,7 @@ export function ProjectStatusPanel({
           </Button>
         </div>
         {error ? (
-          <div className="mt-3">
+          <div className="mt-2">
             <ErrorBanner message={error} />
           </div>
         ) : null}
@@ -90,66 +81,21 @@ export function ProjectStatusPanel({
       ) : status ? (
         <div className="space-y-0">
           <StatusSection title="Overview">
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-              <Metric label="Branch" value={status.git.branch ?? "—"} />
-              <Metric label="Dirty" value={status.git.dirtyCount} />
-              <Metric
-                label="Package manager"
-                value={status.packageManager ?? "none"}
-              />
+            <div className="space-y-1.5 text-[11px] text-muted-foreground">
+              <p className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                <span className="font-mono text-foreground">
+                  {status.git.branch ?? "—"}
+                </span>
+                <span>·</span>
+                <span>{status.git.dirtyCount} dirty</span>
+                <span>·</span>
+                <span>{status.packageManager ?? "no pm"}</span>
+              </p>
+              <PathRow path={status.project.localPath} />
             </div>
           </StatusSection>
 
-          <StatusSection title="Root path">
-            <PathRow path={status.project.localPath} />
-          </StatusSection>
-
-          <StatusSection title="Git">
-            <div className="space-y-2 text-xs text-muted-foreground">
-              <div className="flex flex-wrap gap-2">
-                {status.git.upstream ? (
-                  <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px]">
-                    {status.git.upstream}
-                  </span>
-                ) : (
-                  <span>No upstream configured</span>
-                )}
-                {status.git.ahead !== null && status.git.behind !== null ? (
-                  <span>
-                    {status.git.ahead} ahead · {status.git.behind} behind origin
-                  </span>
-                ) : null}
-              </div>
-              {status.dirtyFiles.length > 0 ? (
-                <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md bg-background/35 p-2 font-mono text-[10px] ring-1 ring-border/70">
-                  {status.dirtyFiles.map((file) => (
-                    <li key={file} className="truncate">
-                      {file}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p>Working tree clean</p>
-              )}
-            </div>
-          </StatusSection>
-
-          <StatusSection title="Scripts">
-            {status.scripts.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {status.scripts.map((script) => (
-                  <span
-                    key={script}
-                    className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
-                  >
-                    {script}
-                  </span>
-                ))}
-              </div>
-            ) : (
-              <p className="text-xs text-muted-foreground">No npm scripts detected</p>
-            )}
-          </StatusSection>
+          <BackgroundCommandsPanel projectId={project.id} status={status} />
 
           <StatusSection title="Last run">
             {status.lastRun ? (
@@ -178,8 +124,8 @@ function StatusSection({
   children: ReactNode;
 }) {
   return (
-    <section className="border-b border-border px-3 py-3">
-      <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+    <section className="border-b border-border px-3 py-2">
+      <h3 className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
         {title}
       </h3>
       {children}
@@ -187,26 +133,17 @@ function StatusSection({
   );
 }
 
-function Metric({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="rounded-md bg-background/45 px-2 py-1.5 ring-1 ring-border">
-      <div className="text-[10px] uppercase text-muted-foreground">{label}</div>
-      <div className="truncate font-mono text-xs font-semibold">{value}</div>
-    </div>
-  );
-}
-
 function PathRow({ path }: { path: string }) {
   const [copied, setCopied] = useState(false);
 
   return (
-    <div className="flex items-start gap-2">
-      <code className="min-w-0 flex-1 break-all rounded-md bg-background/35 px-2 py-1.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border/70">
+    <div className="flex min-w-0 items-center gap-1">
+      <code className="min-w-0 flex-1 truncate font-mono text-[10px] text-muted-foreground">
         {path}
       </code>
       <Button
         type="button"
-        size="icon-sm"
+        size="icon-xs"
         variant="ghost"
         aria-label="Copy root path"
         title="Copy root path"
@@ -220,8 +157,17 @@ function PathRow({ path }: { path: string }) {
           }
         }}
       >
-        {copied ? <CheckCircle2 className="size-3.5" /> : <Copy className="size-3.5" />}
+        {copied ? <CheckCircle2 className="size-3" /> : <Copy className="size-3" />}
       </Button>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-md bg-background/45 px-2 py-1.5 ring-1 ring-border">
+      <div className="text-[10px] uppercase text-muted-foreground">{label}</div>
+      <div className="truncate font-mono text-xs font-semibold">{value}</div>
     </div>
   );
 }
@@ -233,7 +179,7 @@ function LastRunCard({
 }) {
   const statusMeta = runStatusMeta(lastRun.status);
   return (
-    <div className="rounded-md bg-background/35 p-2.5 ring-1 ring-border/70">
+    <>
       <div className="flex flex-wrap items-center gap-2">
         <span
           className={cn(
@@ -277,7 +223,7 @@ function LastRunCard({
           <ExternalLink className="size-3" />
         </Link>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/components/features/run-trace/use-worklog-width.ts
+++ b/components/features/run-trace/use-worklog-width.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+export const WORKLOG_WIDTH_MIN = 420;
+export const WORKLOG_WIDTH_MAX_RATIO = 0.65;
+const WORKLOG_WIDTH_STORAGE_KEY = "anton-worklog-width";
+
+function readStoredWorklogWidth(): number | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.localStorage.getItem(WORKLOG_WIDTH_STORAGE_KEY);
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function maxWorklogWidth(containerWidth: number): number {
+  return Math.max(
+    WORKLOG_WIDTH_MIN,
+    Math.floor(containerWidth * WORKLOG_WIDTH_MAX_RATIO),
+  );
+}
+
+function clampWorklogWidth(width: number, containerWidth: number): number {
+  return Math.min(
+    maxWorklogWidth(containerWidth),
+    Math.max(WORKLOG_WIDTH_MIN, Math.round(width)),
+  );
+}
+
+export function useWorklogWidth(containerRef: RefObject<HTMLElement | null>): {
+  width: number;
+  maxWidth: number;
+  expanded: boolean;
+  isResizing: boolean;
+  setWidth: (width: number) => void;
+  setToMin: () => void;
+  setToMax: () => void;
+  toggleExpanded: () => void;
+  startResize: (clientX: number) => void;
+} {
+  // Keep SSR and the first client render identical; hydrate from storage after mount.
+  const [width, setWidthState] = useState(WORKLOG_WIDTH_MIN);
+  const [maxWidth, setMaxWidth] = useState(WORKLOG_WIDTH_MIN);
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeStartRef = useRef<{ startX: number; startWidth: number } | null>(
+    null,
+  );
+
+  const containerWidth = useCallback(() => {
+    return containerRef.current?.clientWidth ?? window.innerWidth;
+  }, [containerRef]);
+
+  const measureMaxWidth = useCallback(() => {
+    return maxWorklogWidth(containerWidth());
+  }, [containerWidth]);
+
+  const persistWidth = useCallback((next: number) => {
+    window.localStorage.setItem(WORKLOG_WIDTH_STORAGE_KEY, String(next));
+  }, []);
+
+  const setWidth = useCallback(
+    (next: number) => {
+      const clamped = clampWorklogWidth(next, containerWidth());
+      setMaxWidth(measureMaxWidth());
+      setWidthState(clamped);
+      persistWidth(clamped);
+    },
+    [containerWidth, measureMaxWidth, persistWidth],
+  );
+
+  const setToMin = useCallback(() => {
+    setWidth(WORKLOG_WIDTH_MIN);
+  }, [setWidth]);
+
+  const setToMax = useCallback(() => {
+    const max = measureMaxWidth();
+    setMaxWidth(max);
+    setWidthState(max);
+    persistWidth(max);
+  }, [measureMaxWidth, persistWidth]);
+
+  const expanded = width >= maxWidth - 1;
+
+  const toggleExpanded = useCallback(() => {
+    if (expanded) {
+      setToMin();
+    } else {
+      setToMax();
+    }
+  }, [expanded, setToMax, setToMin]);
+
+  const startResize = useCallback((clientX: number) => {
+    setWidthState((current) => {
+      resizeStartRef.current = { startX: clientX, startWidth: current };
+      return current;
+    });
+    setIsResizing(true);
+  }, []);
+
+  useEffect(() => {
+    const nextContainerWidth = containerWidth();
+    const max = maxWorklogWidth(nextContainerWidth);
+    const stored = readStoredWorklogWidth();
+    const nextWidth =
+      stored !== null
+        ? clampWorklogWidth(stored, nextContainerWidth)
+        : WORKLOG_WIDTH_MIN;
+    queueMicrotask(() => {
+      setMaxWidth(max);
+      setWidthState(clampWorklogWidth(nextWidth, nextContainerWidth));
+    });
+  }, [containerWidth]);
+
+  useEffect(() => {
+    const onResize = () => {
+      const nextContainerWidth = containerWidth();
+      const max = maxWorklogWidth(nextContainerWidth);
+      setMaxWidth(max);
+      setWidthState((current) => {
+        const clamped = clampWorklogWidth(current, nextContainerWidth);
+        persistWidth(clamped);
+        return clamped;
+      });
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [containerWidth, persistWidth]);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMove = (event: MouseEvent) => {
+      const start = resizeStartRef.current;
+      if (!start) return;
+      const delta = start.startX - event.clientX;
+      setWidthState(
+        clampWorklogWidth(start.startWidth + delta, containerWidth()),
+      );
+    };
+
+    const onUp = () => {
+      resizeStartRef.current = null;
+      setIsResizing(false);
+      setWidthState((current) => {
+        persistWidth(current);
+        return current;
+      });
+    };
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [containerWidth, isResizing, persistWidth]);
+
+  return {
+    width,
+    maxWidth,
+    expanded,
+    isResizing,
+    setWidth,
+    setToMin,
+    setToMax,
+    toggleExpanded,
+    startResize,
+  };
+}

--- a/components/features/run-trace/worklog-resize-handle.tsx
+++ b/components/features/run-trace/worklog-resize-handle.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface WorklogResizeHandleProps {
+  onResizeStart: (clientX: number) => void;
+  active?: boolean;
+}
+
+export function WorklogResizeHandle({
+  onResizeStart,
+  active = false,
+}: WorklogResizeHandleProps) {
+  return (
+    <button
+      type="button"
+      aria-label="Resize trace workspace"
+      title="Drag to resize"
+      onMouseDown={(event) => {
+        event.preventDefault();
+        onResizeStart(event.clientX);
+      }}
+      className={cn(
+        "absolute top-0 left-0 z-10 h-full w-1.5 -translate-x-1/2 cursor-col-resize border-0 bg-transparent p-0",
+        "before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-border/80 before:transition-colors",
+        "hover:before:bg-ring/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        active && "before:bg-ring",
+      )}
+    />
+  );
+}

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   FileText,
   GitBranch,
+  GitCompareArrows,
   FolderTree,
   Info,
   ListTodo,
@@ -57,11 +58,11 @@ import { getSessionTodoSnapshots } from "./trace-data";
 import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
 import { ProjectFilesPanel } from "./project-files-panel";
 import { ProjectStatusPanel } from "./project-status-panel";
+import { ProjectDiffPanel } from "./project-diff-panel";
 import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
-import { PROJECT_GIT_CHANGED_EVENT } from "@/components/features/projects/hooks";
+import { PROJECT_GIT_CHANGED_EVENT, OPEN_WORKLOG_STATUS_EVENT } from "@/components/features/projects/hooks";
 import type {
   ProjectGitStatusSummary,
-  ProjectLocalDiffSummary,
   ProjectPullRequestListItem,
   ProjectPullRequestSummary,
   ProjectSummary,
@@ -80,7 +81,7 @@ const traceWorkspaceTabLabelButtonClass =
   "min-w-0 rounded pl-0 pr-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 export type WorklogEntry = ToolTraceEntry;
-type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "status";
+type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "diff" | "status";
 
 interface WorklogProps {
   messages: AntonUIMessage[];
@@ -134,6 +135,20 @@ export function Worklog({
   };
 
   useEffect(() => {
+    const onOpenStatus = () => {
+      setTabs((current) =>
+        current.includes("status") ? current : [...current, "status"],
+      );
+      setActiveTab("status");
+      setMenuOpen(false);
+    };
+    window.addEventListener(OPEN_WORKLOG_STATUS_EVENT, onOpenStatus);
+    return () => {
+      window.removeEventListener(OPEN_WORKLOG_STATUS_EVENT, onOpenStatus);
+    };
+  }, []);
+
+  useEffect(() => {
     if (pullRequestNumber === null && !hasGithubProject) {
       queueMicrotask(() => {
         setTabs((current) => current.filter((tab) => tab !== "pr"));
@@ -166,7 +181,7 @@ export function Worklog({
       )}
       aria-label="Trace workspace"
     >
-      <div className="flex h-full min-w-0 w-full shrink-0 flex-col xl:min-w-[420px]">
+      <div className="flex h-full min-w-0 w-full shrink-0 flex-col">
         <header className={cn(traceWorkspaceHeaderRowClass, "justify-between gap-1")}>
           <div className="flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide">
             {tabs.map((tab) => {
@@ -230,21 +245,26 @@ export function Worklog({
                 <Plus />
               </Button>
               {menuOpen && availableTabs.length > 0 && (
-                <div className="absolute right-0 top-full z-50 mt-1 w-36 rounded-md bg-popover p-1 text-xs text-popover-foreground shadow-lg ring-1 ring-border">
-                  {availableTabs.map((tab) => {
-                    const meta = tabMeta(tab.id, prState.pullRequest);
-                    return (
-                      <button
-                        key={tab.id}
-                        type="button"
-                        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-accent"
-                        onClick={() => addTab(tab.id)}
-                      >
-                        <meta.Icon className="size-3.5 text-muted-foreground" />
-                        {meta.label}
-                      </button>
-                    );
-                  })}
+                <div className="absolute right-0 top-full z-50 mt-1 w-36 min-w-36 overflow-hidden rounded-md bg-popover text-popover-foreground shadow-none ring-1 ring-border">
+                  <ul className="p-0.5">
+                    {availableTabs.map((tab) => {
+                      const meta = tabMeta(tab.id, prState.pullRequest);
+                      return (
+                        <li key={tab.id}>
+                          <button
+                            type="button"
+                            className="flex w-full cursor-default select-none items-center rounded-sm py-1 pr-2 pl-1.5 text-left text-xs leading-4 outline-none hover:bg-accent hover:text-accent-foreground"
+                            onClick={() => addTab(tab.id)}
+                          >
+                            <span className="inline-flex items-center gap-1.5">
+                              <meta.Icon className="size-3.5 shrink-0" />
+                              {meta.label}
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
                 </div>
               )}
             </div>
@@ -289,6 +309,8 @@ export function Worklog({
           />
         ) : activeTab === "status" ? (
           <ProjectStatusPanel project={project} />
+        ) : activeTab === "diff" ? (
+          <ProjectDiffPanel project={project} visible={visible} />
         ) : activeTab === "pr" && prState.pullRequest ? (
           <PullRequestPanel
             pullRequest={prState.pullRequest}
@@ -301,7 +323,6 @@ export function Worklog({
         ) : activeTab === "pr" && hasGithubProject ? (
           <PullRequestEmptyPanel
             gitStatus={prState.gitStatus}
-            localFiles={prState.localDiff?.files ?? []}
             loading={prState.loading}
             creating={prState.creating}
             error={prState.error}
@@ -322,6 +343,7 @@ const SIDEBAR_TABS = [
   { id: "todos", label: "Todos", Icon: ListTodo },
   { id: "pr", label: "PR", Icon: GitBranch },
   { id: "files", label: "Files", Icon: FolderTree },
+  { id: "diff", label: "Diff", Icon: GitCompareArrows },
   { id: "status", label: "Status", Icon: Info },
 ] as const satisfies readonly {
   id: SidebarTab;
@@ -667,7 +689,6 @@ function useProjectPullRequest(
   options: { enabled: boolean; poll: boolean },
 ): {
   gitStatus: ProjectGitStatusSummary | null;
-  localDiff: ProjectLocalDiffSummary | null;
   pullRequest: ProjectPullRequestSummary | null;
   loading: boolean;
   creating: boolean;
@@ -677,7 +698,6 @@ function useProjectPullRequest(
   createPullRequest: () => void;
 } {
   const [gitStatus, setGitStatus] = useState<ProjectGitStatusSummary | null>(null);
-  const [localDiff, setLocalDiff] = useState<ProjectLocalDiffSummary | null>(null);
   const [pullRequest, setPullRequest] = useState<ProjectPullRequestSummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
@@ -709,7 +729,6 @@ function useProjectPullRequest(
     ) {
       queueMicrotask(() => {
         setGitStatus(null);
-        setLocalDiff(null);
         setCurrentPullRequest(null);
         setError(null);
         setLoading(false);
@@ -731,23 +750,6 @@ function useProjectPullRequest(
         );
         if (cancelled) return;
         setGitStatus(statusData.status);
-        let localDiffError: string | null = null;
-        if (statusData.status.dirtyCount > 0) {
-          try {
-            const diffData = await getJson<{ diff: ProjectLocalDiffSummary }>(
-              `/api/projects/${project.id}/git/diff`,
-            );
-            if (cancelled) return;
-            setLocalDiff(diffData.diff);
-          } catch (err) {
-            if (cancelled) return;
-            setLocalDiff(null);
-            localDiffError =
-              err instanceof Error ? err.message : "Failed to load local diff";
-          }
-        } else {
-          setLocalDiff(null);
-        }
         if (selectedPullRequestNumber !== null) {
           let prData: { pullRequest: ProjectPullRequestSummary };
           try {
@@ -763,12 +765,12 @@ function useProjectPullRequest(
           }
           if (cancelled) return;
           setCurrentPullRequest(prData.pullRequest);
-          setError(localDiffError);
+          setError(null);
           return;
         }
         if (!statusData.status.branch || statusData.status.isDefaultBranch) {
           setCurrentPullRequest(null);
-          setError(localDiffError);
+          setError(null);
           return;
         }
         let prData: { pullRequest: ProjectPullRequestSummary | null };
@@ -787,7 +789,7 @@ function useProjectPullRequest(
         }
         if (cancelled) return;
         setCurrentPullRequest(prData.pullRequest);
-        setError(localDiffError);
+        setError(null);
       } catch (err) {
         if (!cancelled) {
           setError(errorMessage(err, "Failed to load PR"));
@@ -835,7 +837,6 @@ function useProjectPullRequest(
 
   return {
     gitStatus,
-    localDiff,
     pullRequest,
     loading,
     creating,

--- a/src/db/migrations/0011_panoramic_hedge_knight.sql
+++ b/src/db/migrations/0011_panoramic_hedge_knight.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `background_command_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`command` text NOT NULL,
+	`command_kind` text NOT NULL,
+	`status` text NOT NULL,
+	`pid` integer,
+	`started_at` integer,
+	`finished_at` integer,
+	`exit_code` integer,
+	`signal` text,
+	`stdout_tail` text DEFAULT '' NOT NULL,
+	`stderr_tail` text DEFAULT '' NOT NULL,
+	`detected_urls` text DEFAULT '[]' NOT NULL,
+	`created_by` text,
+	`created_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('now') * 1000) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `background_command_sessions_project_id_idx` ON `background_command_sessions` (`project_id`);--> statement-breakpoint
+CREATE INDEX `background_command_sessions_status_idx` ON `background_command_sessions` (`status`);--> statement-breakpoint
+CREATE INDEX `background_command_sessions_project_started_idx` ON `background_command_sessions` (`project_id`,`started_at`);

--- a/src/db/migrations/meta/0011_snapshot.json
+++ b/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1473 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6ab2699e-6843-4a26-b910-86d4039c0737",
+  "prevId": "1d4dc4f9-b209-4002-9f2f-721a58375012",
+  "tables": {
+    "background_command_sessions": {
+      "name": "background_command_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_kind": {
+          "name": "command_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stdout_tail": {
+          "name": "stdout_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stderr_tail": {
+          "name": "stderr_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "detected_urls": {
+          "name": "detected_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "background_command_sessions_project_id_idx": {
+          "name": "background_command_sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_status_idx": {
+          "name": "background_command_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_project_started_idx": {
+          "name": "background_command_sessions_project_started_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "background_command_sessions_project_id_projects_id_fk": {
+          "name": "background_command_sessions_project_id_projects_id_fk",
+          "tableFrom": "background_command_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_max_steps": {
+          "name": "default_max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_permission_mode": {
+          "name": "default_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779508584446,
       "tag": "0010_spicy_morbius",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1779613188894,
+      "tag": "0011_panoramic_hedge_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 
@@ -10,6 +10,7 @@ import {
 } from "@/src/lib/trace";
 import { db } from "./client";
 import {
+  backgroundCommandSessions,
   githubInstallations,
   memories,
   messages,
@@ -23,10 +24,12 @@ import {
   toolApprovals,
   toolCalls,
   workspaceSettings,
+  type BackgroundCommandSession,
   type GithubInstallation,
   type Memory,
   type McpServer,
   type McpTrustDecision,
+  type NewBackgroundCommandSession,
   type NewMcpServer,
   type NewRun,
   type NewRunContextSummary,
@@ -1079,5 +1082,130 @@ function uniqueMcpNamespace(base: string, currentId?: string): string {
   let suffix = 2;
   while (namespaces.has(`${base}_${suffix}`)) suffix += 1;
   return `${base}_${suffix}`;
+}
+
+const ACTIVE_BACKGROUND_COMMAND_STATUSES = [
+  "starting",
+  "running",
+  "stopping",
+] as const;
+
+export function markStaleBackgroundCommandSessions(): void {
+  const now = new Date();
+  db.update(backgroundCommandSessions)
+    .set({
+      status: "stale",
+      pid: null,
+      finishedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      inArray(backgroundCommandSessions.status, [...ACTIVE_BACKGROUND_COMMAND_STATUSES]),
+    )
+    .run();
+}
+
+export function createBackgroundCommandSession(
+  input: NewBackgroundCommandSession,
+): BackgroundCommandSession {
+  const now = new Date();
+  const row: BackgroundCommandSession = {
+    ...input,
+    pid: input.pid ?? null,
+    startedAt: input.startedAt ?? now,
+    finishedAt: input.finishedAt ?? null,
+    exitCode: input.exitCode ?? null,
+    signal: input.signal ?? null,
+    stdoutTail: input.stdoutTail ?? "",
+    stderrTail: input.stderrTail ?? "",
+    detectedUrls: input.detectedUrls ?? [],
+    createdBy: input.createdBy ?? null,
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+  };
+  db.insert(backgroundCommandSessions).values(row).run();
+  return row;
+}
+
+export function getBackgroundCommandSession(
+  id: string,
+): BackgroundCommandSession | undefined {
+  return db
+    .select()
+    .from(backgroundCommandSessions)
+    .where(eq(backgroundCommandSessions.id, id))
+    .get();
+}
+
+export function getRunningBackgroundCommandForProject(
+  projectId: string,
+  command: string,
+): BackgroundCommandSession | undefined {
+  return db
+    .select()
+    .from(backgroundCommandSessions)
+    .where(
+      and(
+        eq(backgroundCommandSessions.projectId, projectId),
+        eq(backgroundCommandSessions.command, command),
+        inArray(backgroundCommandSessions.status, [
+          ...ACTIVE_BACKGROUND_COMMAND_STATUSES,
+        ]),
+      ),
+    )
+    .orderBy(desc(backgroundCommandSessions.startedAt))
+    .get();
+}
+
+export function listBackgroundCommandSessionsForProject(
+  projectId: string,
+  limit: number,
+): BackgroundCommandSession[] {
+  return db
+    .select()
+    .from(backgroundCommandSessions)
+    .where(eq(backgroundCommandSessions.projectId, projectId))
+    .orderBy(desc(backgroundCommandSessions.startedAt))
+    .limit(limit)
+    .all();
+}
+
+export function updateBackgroundCommandSession(
+  id: string,
+  patch: Partial<
+    Pick<
+      BackgroundCommandSession,
+      | "status"
+      | "pid"
+      | "startedAt"
+      | "finishedAt"
+      | "exitCode"
+      | "signal"
+      | "stdoutTail"
+      | "stderrTail"
+      | "detectedUrls"
+    >
+  >,
+): BackgroundCommandSession | undefined {
+  db.update(backgroundCommandSessions)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(eq(backgroundCommandSessions.id, id))
+    .run();
+  return getBackgroundCommandSession(id);
+}
+
+export function clearRecentBackgroundCommandSessions(projectId: string): number {
+  const result = db
+    .delete(backgroundCommandSessions)
+    .where(
+      and(
+        eq(backgroundCommandSessions.projectId, projectId),
+        notInArray(backgroundCommandSessions.status, [
+          ...ACTIVE_BACKGROUND_COMMAND_STATUSES,
+        ]),
+      ),
+    )
+    .run();
+  return result.changes;
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -314,6 +314,55 @@ export const memories = sqliteTable(
   (table) => [index("memories_updated_at_idx").on(table.updatedAt)],
 );
 
+export const backgroundCommandSessions = sqliteTable(
+  "background_command_sessions",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    command: text("command").notNull(),
+    commandKind: text("command_kind", { enum: ["script", "custom"] }).notNull(),
+    status: text("status", {
+      enum: [
+        "starting",
+        "running",
+        "stopping",
+        "exited",
+        "failed",
+        "stopped",
+        "stale",
+      ],
+    }).notNull(),
+    pid: integer("pid"),
+    startedAt: integer("started_at", { mode: "timestamp_ms" }),
+    finishedAt: integer("finished_at", { mode: "timestamp_ms" }),
+    exitCode: integer("exit_code"),
+    signal: text("signal"),
+    stdoutTail: text("stdout_tail").notNull().default(""),
+    stderrTail: text("stderr_tail").notNull().default(""),
+    detectedUrls: text("detected_urls", { mode: "json" })
+      .notNull()
+      .$type<string[]>()
+      .default(sql`'[]'`),
+    createdBy: text("created_by"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .default(sql`(unixepoch('now') * 1000)`),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .notNull()
+      .default(sql`(unixepoch('now') * 1000)`),
+  },
+  (table) => [
+    index("background_command_sessions_project_id_idx").on(table.projectId),
+    index("background_command_sessions_status_idx").on(table.status),
+    index("background_command_sessions_project_started_idx").on(
+      table.projectId,
+      table.startedAt,
+    ),
+  ],
+);
+
 export type WorkspaceSettings = typeof workspaceSettings.$inferSelect;
 export type NewWorkspaceSettings = typeof workspaceSettings.$inferInsert;
 export type GithubInstallation = typeof githubInstallations.$inferSelect;
@@ -340,3 +389,7 @@ export type McpTrustDecision = typeof mcpTrustDecisions.$inferSelect;
 export type NewMcpTrustDecision = typeof mcpTrustDecisions.$inferInsert;
 export type Memory = typeof memories.$inferSelect;
 export type NewMemory = typeof memories.$inferInsert;
+export type BackgroundCommandSession =
+  typeof backgroundCommandSessions.$inferSelect;
+export type NewBackgroundCommandSession =
+  typeof backgroundCommandSessions.$inferInsert;

--- a/src/lib/api-serializers.ts
+++ b/src/lib/api-serializers.ts
@@ -6,8 +6,18 @@ import {
   type McpServerConfig,
 } from "@/src/agent/mcp-config";
 import { getMcpTrustDecision } from "@/src/db/queries";
-import type { Memory, McpServer, Project } from "@/src/db/schema";
-import type { McpServerSummary, ProjectMemory, ProjectSummary } from "./api-types";
+import type {
+  BackgroundCommandSession,
+  Memory,
+  McpServer,
+  Project,
+} from "@/src/db/schema";
+import type {
+  BackgroundCommandSessionSummary,
+  McpServerSummary,
+  ProjectMemory,
+  ProjectSummary,
+} from "./api-types";
 
 export function serializeProject(project: Project): ProjectSummary {
   return {
@@ -34,6 +44,28 @@ export function serializeMemory(memory: Memory): ProjectMemory {
     content: memory.content,
     createdAt: memory.createdAt.getTime(),
     updatedAt: memory.updatedAt.getTime(),
+  };
+}
+
+export function serializeBackgroundCommandSession(
+  session: BackgroundCommandSession,
+): BackgroundCommandSessionSummary {
+  return {
+    id: session.id,
+    projectId: session.projectId,
+    command: session.command,
+    commandKind: session.commandKind,
+    status: session.status,
+    pid: session.pid,
+    startedAt: session.startedAt?.getTime() ?? null,
+    finishedAt: session.finishedAt?.getTime() ?? null,
+    exitCode: session.exitCode,
+    signal: session.signal,
+    stdoutTail: session.stdoutTail,
+    stderrTail: session.stderrTail,
+    detectedUrls: session.detectedUrls,
+    createdAt: session.createdAt.getTime(),
+    updatedAt: session.updatedAt.getTime(),
   };
 }
 

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -247,6 +247,41 @@ export type ProjectMemory = {
   updatedAt: number;
 };
 
+export type BackgroundCommandStatus =
+  | "starting"
+  | "running"
+  | "stopping"
+  | "exited"
+  | "failed"
+  | "stopped"
+  | "stale";
+
+export type BackgroundCommandKind = "script" | "custom";
+
+export type BackgroundCommandSessionSummary = {
+  id: string;
+  projectId: string;
+  command: string;
+  commandKind: BackgroundCommandKind;
+  status: BackgroundCommandStatus;
+  pid: number | null;
+  startedAt: number | null;
+  finishedAt: number | null;
+  exitCode: number | null;
+  signal: string | null;
+  stdoutTail: string;
+  stderrTail: string;
+  detectedUrls: string[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ProjectBackgroundCommandsSummary = {
+  running: BackgroundCommandSessionSummary[];
+  recent: BackgroundCommandSessionSummary[];
+  runningCount: number;
+};
+
 export type SkillSummary = {
   slug: string;
   name: string;

--- a/src/lib/background-command-stream.ts
+++ b/src/lib/background-command-stream.ts
@@ -1,0 +1,156 @@
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+
+export type BackgroundCommandStreamEvent =
+  | {
+      type: "stdout";
+      chunk: string;
+    }
+  | {
+      type: "stderr";
+      chunk: string;
+    }
+  | {
+      type: "status";
+      status: string;
+      exitCode?: number | null;
+      signal?: string | null;
+      detectedUrls?: string[];
+    };
+
+export interface BackgroundCommandStreamState {
+  token: string;
+  stdout: string;
+  stderr: string;
+  status: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  detectedUrls: string[];
+  finished: boolean;
+}
+
+const MAX_STREAM_OUTPUT_CHARS = 64 * 1024;
+const STREAM_RECONNECT_TTL_MS = 60_000;
+
+class BackgroundCommandStreamEmitter extends EventEmitter {
+  private streams = new Map<string, BackgroundCommandStreamState>();
+
+  prepareStream(sessionId: string): string {
+    const existing = this.streams.get(sessionId);
+    if (existing) return existing.token;
+
+    const token = randomUUID();
+    this.streams.set(sessionId, {
+      token,
+      stdout: "",
+      stderr: "",
+      status: "starting",
+      detectedUrls: [],
+      finished: false,
+    });
+    return token;
+  }
+
+  startStream(sessionId: string, initial?: Partial<BackgroundCommandStreamState>): string {
+    const token = this.streams.get(sessionId)?.token ?? randomUUID();
+    this.streams.set(sessionId, {
+      token,
+      stdout: initial?.stdout ?? "",
+      stderr: initial?.stderr ?? "",
+      status: initial?.status ?? "starting",
+      exitCode: initial?.exitCode,
+      signal: initial?.signal,
+      detectedUrls: initial?.detectedUrls ?? [],
+      finished: initial?.finished ?? false,
+    });
+    this.emit("start", sessionId);
+    return token;
+  }
+
+  emitEvent(
+    sessionId: string,
+    event: BackgroundCommandStreamEvent,
+  ): void {
+    const state = this.streams.get(sessionId);
+    if (!state) return;
+
+    if (event.type === "stdout") {
+      state.stdout = capOutput(state.stdout + event.chunk);
+    } else if (event.type === "stderr") {
+      state.stderr = capOutput(state.stderr + event.chunk);
+    } else if (event.type === "status") {
+      state.status = event.status;
+      state.exitCode = event.exitCode;
+      state.signal = event.signal;
+      if (event.detectedUrls) {
+        state.detectedUrls = event.detectedUrls;
+      }
+      if (
+        event.status === "exited" ||
+        event.status === "failed" ||
+        event.status === "stopped" ||
+        event.status === "stale"
+      ) {
+        state.finished = true;
+      }
+    }
+
+    this.emit(`event:${sessionId}`, event, state);
+  }
+
+  validateToken(sessionId: string, token: string): boolean {
+    return this.streams.get(sessionId)?.token === token;
+  }
+
+  getState(sessionId: string): BackgroundCommandStreamState | undefined {
+    return this.streams.get(sessionId);
+  }
+
+  endStream(sessionId: string): void {
+    this.emit(`end:${sessionId}`);
+    setTimeout(() => {
+      this.streams.delete(sessionId);
+    }, STREAM_RECONNECT_TTL_MS);
+  }
+
+  onEvent(
+    sessionId: string,
+    callback: (
+      event: BackgroundCommandStreamEvent,
+      state: BackgroundCommandStreamState,
+    ) => void,
+  ): () => void {
+    const listener = (
+      event: BackgroundCommandStreamEvent,
+      state: BackgroundCommandStreamState,
+    ) => callback(event, state);
+    this.on(`event:${sessionId}`, listener);
+    return () => {
+      this.off(`event:${sessionId}`, listener);
+    };
+  }
+
+  onEnd(sessionId: string, callback: () => void): () => void {
+    const listener = () => callback();
+    this.on(`end:${sessionId}`, listener);
+    return () => {
+      this.off(`end:${sessionId}`, listener);
+    };
+  }
+}
+
+function capOutput(output: string): string {
+  if (output.length <= MAX_STREAM_OUTPUT_CHARS) return output;
+  return output.slice(output.length - MAX_STREAM_OUTPUT_CHARS);
+}
+
+const globalForBackgroundCommandStream = globalThis as typeof globalThis & {
+  __antonBackgroundCommandStream?: BackgroundCommandStreamEmitter;
+};
+
+export const backgroundCommandStream =
+  globalForBackgroundCommandStream.__antonBackgroundCommandStream ??
+  new BackgroundCommandStreamEmitter();
+
+globalForBackgroundCommandStream.__antonBackgroundCommandStream =
+  backgroundCommandStream;

--- a/src/workspace/background-commands.ts
+++ b/src/workspace/background-commands.ts
@@ -1,0 +1,556 @@
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { execa, type ResultPromise } from "execa";
+
+import {
+  buildBashEnvironment,
+  evaluateBashCommandPolicy,
+} from "@/src/agent/command-policy";
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import {
+  detectPackageManager,
+  readPackageJson,
+  runScriptCommand,
+} from "@/src/agent/tools/package-manager";
+import {
+  clearRecentBackgroundCommandSessions,
+  createBackgroundCommandSession,
+  getBackgroundCommandSession,
+  getRunningBackgroundCommandForProject,
+  listBackgroundCommandSessionsForProject,
+  markStaleBackgroundCommandSessions,
+  updateBackgroundCommandSession,
+} from "@/src/db/queries";
+import type { BackgroundCommandSession } from "@/src/db/schema";
+import { backgroundCommandStream } from "@/src/lib/background-command-stream";
+import { redactText } from "@/src/lib/redaction";
+
+const execFileAsync = promisify(execFile);
+
+const MAX_TAIL_BYTES = 64 * 1024;
+const RECENT_LIMIT = 20;
+
+const ACTIVE_STATUSES = new Set(["starting", "running", "stopping"]);
+const LOCALHOST_URL_RE =
+  /https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(?::\d+)?(?:\/[^\s"'<>]*)?/gi;
+
+type ActiveProcess = {
+  subprocess: ResultPromise;
+};
+
+const activeProcesses = new Map<string, ActiveProcess>();
+const userStopRequestedSessions = new Set<string>();
+
+let bootstrapped = false;
+
+function ensureBootstrapped(): void {
+  if (bootstrapped) return;
+  bootstrapped = true;
+  markStaleBackgroundCommandSessions();
+}
+
+export type StartBackgroundCommandInput =
+  | { kind: "script"; scriptName: string }
+  | { kind: "custom"; command: string };
+
+export type StartBackgroundCommandResult =
+  | { ok: true; session: BackgroundCommandSession; streamToken: string }
+  | { ok: false; error: string; status?: number };
+
+export function listProjectBackgroundCommands(projectId: string): {
+  running: BackgroundCommandSession[];
+  recent: BackgroundCommandSession[];
+  runningCount: number;
+} {
+  ensureBootstrapped();
+  const sessions = listBackgroundCommandSessionsForProject(projectId, RECENT_LIMIT);
+  const running = sessions.filter((session) => ACTIVE_STATUSES.has(session.status));
+  const recent = sessions.filter((session) => !ACTIVE_STATUSES.has(session.status));
+  return {
+    running,
+    recent,
+    runningCount: running.filter(
+      (session) => session.status === "running" || session.status === "starting",
+    ).length,
+  };
+}
+
+export function getProjectBackgroundCommand(
+  projectId: string,
+  commandId: string,
+): BackgroundCommandSession | undefined {
+  ensureBootstrapped();
+  const session = getBackgroundCommandSession(commandId);
+  if (!session || session.projectId !== projectId) return undefined;
+  return session;
+}
+
+export function clearProjectRecentBackgroundCommands(projectId: string): number {
+  ensureBootstrapped();
+  return clearRecentBackgroundCommandSessions(projectId);
+}
+
+export async function startProjectBackgroundCommand(
+  projectId: string,
+  projectRoot: string,
+  input: StartBackgroundCommandInput,
+): Promise<StartBackgroundCommandResult> {
+  ensureBootstrapped();
+  const root = ensureWorkspaceRootAt(projectRoot);
+
+  let command = "";
+  const commandKind: "script" | "custom" = input.kind;
+  let spawnArgs: { file: string; args: string[]; shell?: false } | {
+    file: string;
+    args: string[];
+    shell: true;
+  };
+
+  if (input.kind === "script") {
+    const packageJson = readPackageJson(root);
+    if (!packageJson.ok) {
+      return { ok: false, error: packageJson.error, status: 400 };
+    }
+    const scripts = packageJson.value.scripts ?? {};
+    if (typeof scripts[input.scriptName] !== "string") {
+      return { ok: false, error: `Script "${input.scriptName}" not found.`, status: 404 };
+    }
+    const packageManager = detectPackageManager(root, packageJson.value);
+    const argv = runScriptCommand(packageManager, input.scriptName);
+    command = `${argv.join(" ")}`;
+    spawnArgs = { file: argv[0]!, args: argv.slice(1), shell: false };
+  } else {
+    command = input.command.trim();
+    if (!command) {
+      return { ok: false, error: "Command is required.", status: 400 };
+    }
+    const policy = evaluateBashCommandPolicy(command, { workspaceRoot: root });
+    if (!policy.allowed) {
+      return { ok: false, error: policy.reason, status: 403 };
+    }
+    spawnArgs = { file: "bash", args: ["-lc", command], shell: false };
+  }
+
+  const duplicate = getRunningBackgroundCommandForProject(projectId, command);
+  if (duplicate) {
+    return {
+      ok: false,
+      error: "An identical command is already running for this project.",
+      status: 409,
+    };
+  }
+
+  const now = new Date();
+  const session = createBackgroundCommandSession({
+    id: randomUUID(),
+    projectId,
+    command,
+    commandKind,
+    status: "starting",
+    startedAt: now,
+    stdoutTail: "",
+    stderrTail: "",
+    detectedUrls: [],
+    createdBy: null,
+  });
+
+  const streamToken = backgroundCommandStream.startStream(session.id, {
+    status: "starting",
+  });
+
+  try {
+    await spawnSessionProcess(session.id, root, spawnArgs);
+    const updated = getBackgroundCommandSession(session.id);
+    if (!updated) {
+      return { ok: false, error: "Failed to start command session.", status: 500 };
+    }
+    return { ok: true, session: updated, streamToken };
+  } catch (err) {
+    const message = redactText(errorMessage(err));
+    updateBackgroundCommandSession(session.id, {
+      status: "failed",
+      finishedAt: new Date(),
+      stderrTail: capTail(message),
+    });
+    backgroundCommandStream.emitEvent(session.id, {
+      type: "status",
+      status: "failed",
+      exitCode: null,
+      signal: null,
+    });
+    backgroundCommandStream.endStream(session.id);
+    return { ok: false, error: message, status: 500 };
+  }
+}
+
+export async function stopProjectBackgroundCommand(
+  projectId: string,
+  commandId: string,
+): Promise<{ ok: true; session: BackgroundCommandSession } | { ok: false; error: string; status?: number }> {
+  ensureBootstrapped();
+  const session = getProjectBackgroundCommand(projectId, commandId);
+  if (!session) {
+    return { ok: false, error: "Command session not found.", status: 404 };
+  }
+  if (!ACTIVE_STATUSES.has(session.status)) {
+    return { ok: false, error: "Command is not running.", status: 400 };
+  }
+
+  userStopRequestedSessions.add(commandId);
+  updateBackgroundCommandSession(commandId, { status: "stopping" });
+  backgroundCommandStream.emitEvent(commandId, { type: "status", status: "stopping" });
+
+  void terminateProcess(commandId);
+
+  const updated = getBackgroundCommandSession(commandId);
+  if (!updated) {
+    return { ok: false, error: "Command session not found.", status: 404 };
+  }
+  return { ok: true, session: updated };
+}
+
+export async function restartProjectBackgroundCommand(
+  projectId: string,
+  commandId: string,
+  projectRoot: string,
+): Promise<StartBackgroundCommandResult> {
+  ensureBootstrapped();
+  const session = getProjectBackgroundCommand(projectId, commandId);
+  if (!session) {
+    return { ok: false, error: "Command session not found.", status: 404 };
+  }
+
+  if (ACTIVE_STATUSES.has(session.status)) {
+    userStopRequestedSessions.add(commandId);
+    await terminateProcess(commandId);
+  }
+
+  const duplicate = getRunningBackgroundCommandForProject(projectId, session.command);
+  if (duplicate && duplicate.id !== commandId) {
+    return {
+      ok: false,
+      error: "An identical command is already running for this project.",
+      status: 409,
+    };
+  }
+
+  userStopRequestedSessions.delete(commandId);
+
+  const root = ensureWorkspaceRootAt(projectRoot);
+  const spawnArgs = spawnArgsForSession(session, root);
+  if (!spawnArgs.ok) {
+    return { ok: false, error: spawnArgs.error, status: 400 };
+  }
+
+  const now = new Date();
+  updateBackgroundCommandSession(commandId, {
+    status: "starting",
+    pid: null,
+    startedAt: now,
+    finishedAt: null,
+    exitCode: null,
+    signal: null,
+    stdoutTail: "",
+    stderrTail: "",
+    detectedUrls: [],
+  });
+
+  const streamToken = backgroundCommandStream.startStream(commandId, {
+    status: "starting",
+    stdout: "",
+    stderr: "",
+    detectedUrls: [],
+    finished: false,
+  });
+
+  try {
+    await spawnSessionProcess(commandId, root, spawnArgs.value);
+    const updated = getBackgroundCommandSession(commandId);
+    if (!updated) {
+      return { ok: false, error: "Failed to restart command session.", status: 500 };
+    }
+    return { ok: true, session: updated, streamToken };
+  } catch (err) {
+    const message = redactText(errorMessage(err));
+    updateBackgroundCommandSession(commandId, {
+      status: "failed",
+      finishedAt: new Date(),
+      stderrTail: capTail(message),
+    });
+    backgroundCommandStream.emitEvent(commandId, {
+      type: "status",
+      status: "failed",
+      exitCode: null,
+      signal: null,
+    });
+    backgroundCommandStream.endStream(commandId);
+    return { ok: false, error: message, status: 500 };
+  }
+}
+
+export function getBackgroundCommandStreamToken(sessionId: string): string {
+  ensureBootstrapped();
+  return backgroundCommandStream.prepareStream(sessionId);
+}
+
+async function spawnSessionProcess(
+  sessionId: string,
+  cwd: string,
+  spawnArgs: { file: string; args: string[]; shell?: false },
+): Promise<void> {
+  const subprocess = execa(spawnArgs.file, spawnArgs.args, {
+    cwd,
+    env: buildBashEnvironment(),
+    extendEnv: false,
+    reject: false,
+    stripFinalNewline: false,
+    cleanup: true,
+    forceKillAfterDelay: false,
+    windowsHide: true,
+    detached: process.platform !== "win32",
+  });
+
+  activeProcesses.set(sessionId, { subprocess });
+
+  updateBackgroundCommandSession(sessionId, {
+    status: "running",
+    pid: subprocess.pid ?? null,
+    startedAt: new Date(),
+  });
+  backgroundCommandStream.emitEvent(sessionId, { type: "status", status: "running" });
+
+  let stdoutTail = "";
+  let stderrTail = "";
+  let detectedUrls: string[] = [];
+
+  subprocess.stdout?.on("data", (chunk: Buffer) => {
+    const text = redactText(chunk.toString("utf8"));
+    stdoutTail = capTail(stdoutTail + text);
+    detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
+    updateBackgroundCommandSession(sessionId, {
+      stdoutTail,
+      detectedUrls,
+    });
+    backgroundCommandStream.emitEvent(sessionId, { type: "stdout", chunk: text });
+  });
+
+  subprocess.stderr?.on("data", (chunk: Buffer) => {
+    const text = redactText(chunk.toString("utf8"));
+    stderrTail = capTail(stderrTail + text);
+    detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
+    updateBackgroundCommandSession(sessionId, {
+      stderrTail,
+      detectedUrls,
+    });
+    backgroundCommandStream.emitEvent(sessionId, { type: "stderr", chunk: text });
+  });
+
+  void subprocess.then((result) => {
+    finalizeProcess(sessionId, {
+      exitCode: result.exitCode ?? null,
+      signal: result.signal ?? null,
+      stdoutTail,
+      stderrTail,
+      detectedUrls,
+    });
+  }).catch((err) => {
+    finalizeProcess(sessionId, {
+      exitCode: null,
+      signal: null,
+      stdoutTail,
+      stderrTail: capTail(`${stderrTail}${redactText(errorMessage(err))}`),
+      detectedUrls,
+      failed: true,
+    });
+  });
+}
+
+async function terminateProcess(sessionId: string): Promise<void> {
+  const active = activeProcesses.get(sessionId);
+  if (!active) {
+    const session = getBackgroundCommandSession(sessionId);
+    if (session && ACTIVE_STATUSES.has(session.status)) {
+      updateBackgroundCommandSession(sessionId, {
+        status: "stopped",
+        finishedAt: new Date(),
+        pid: null,
+        signal: "SIGKILL",
+      });
+      backgroundCommandStream.emitEvent(sessionId, {
+        type: "status",
+        status: "stopped",
+        exitCode: session.exitCode,
+        signal: "SIGKILL",
+        detectedUrls: session.detectedUrls,
+      });
+      backgroundCommandStream.endStream(sessionId);
+    }
+    userStopRequestedSessions.delete(sessionId);
+    return;
+  }
+
+  const { subprocess } = active;
+  await killProcessTree(subprocess.pid, subprocess);
+  activeProcesses.delete(sessionId);
+}
+
+async function killProcessTree(
+  pid: number | undefined,
+  subprocess: ResultPromise,
+): Promise<void> {
+  if (pid !== undefined && process.platform === "win32") {
+    try {
+      await execFileAsync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+        windowsHide: true,
+      });
+      return;
+    } catch {
+      // Fall through to subprocess.kill below.
+    }
+  }
+
+  if (pid !== undefined && process.platform !== "win32") {
+    try {
+      process.kill(-pid, "SIGKILL");
+      return;
+    } catch {
+      // Fall through to subprocess.kill below.
+    }
+  }
+
+  try {
+    subprocess.kill("SIGKILL");
+  } catch {
+    if (pid !== undefined && process.platform !== "win32") {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Process already exited.
+      }
+    }
+  }
+}
+
+function finalizeProcess(
+  sessionId: string,
+  input: {
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+    stdoutTail: string;
+    stderrTail: string;
+    detectedUrls: string[];
+    failed?: boolean;
+  },
+): void {
+  activeProcesses.delete(sessionId);
+  const userStopped = userStopRequestedSessions.has(sessionId);
+  userStopRequestedSessions.delete(sessionId);
+
+  const current = getBackgroundCommandSession(sessionId);
+  if (!current) {
+    backgroundCommandStream.endStream(sessionId);
+    return;
+  }
+
+  if (
+    userStopped ||
+    current.status === "stopped" ||
+    current.status === "stopping"
+  ) {
+    updateBackgroundCommandSession(sessionId, {
+      status: "stopped",
+      finishedAt: current.finishedAt ?? new Date(),
+      pid: null,
+      exitCode: input.exitCode ?? current.exitCode,
+      signal: input.signal ?? current.signal ?? "SIGKILL",
+      stdoutTail: input.stdoutTail || current.stdoutTail,
+      stderrTail: input.stderrTail || current.stderrTail,
+      detectedUrls: input.detectedUrls.length > 0 ? input.detectedUrls : current.detectedUrls,
+    });
+    backgroundCommandStream.emitEvent(sessionId, {
+      type: "status",
+      status: "stopped",
+      exitCode: input.exitCode ?? current.exitCode,
+      signal: input.signal ?? current.signal ?? "SIGKILL",
+      detectedUrls:
+        input.detectedUrls.length > 0 ? input.detectedUrls : current.detectedUrls,
+    });
+    backgroundCommandStream.endStream(sessionId);
+    return;
+  }
+
+  const status =
+    input.failed || (input.exitCode !== null && input.exitCode !== 0)
+      ? "failed"
+      : "exited";
+
+  updateBackgroundCommandSession(sessionId, {
+    status,
+    finishedAt: new Date(),
+    pid: null,
+    exitCode: input.exitCode,
+    signal: input.signal,
+    stdoutTail: input.stdoutTail,
+    stderrTail: input.stderrTail,
+    detectedUrls: input.detectedUrls,
+  });
+
+  backgroundCommandStream.emitEvent(sessionId, {
+    type: "status",
+    status,
+    exitCode: input.exitCode,
+    signal: input.signal,
+    detectedUrls: input.detectedUrls,
+  });
+  backgroundCommandStream.endStream(sessionId);
+}
+
+function spawnArgsForSession(
+  session: BackgroundCommandSession,
+  root: string,
+):
+  | { ok: true; value: { file: string; args: string[]; shell?: false } }
+  | { ok: false; error: string } {
+  if (session.commandKind === "custom") {
+    const policy = evaluateBashCommandPolicy(session.command, { workspaceRoot: root });
+    if (!policy.allowed) {
+      return { ok: false, error: policy.reason };
+    }
+    return {
+      ok: true,
+      value: { file: "bash", args: ["-lc", session.command], shell: false },
+    };
+  }
+
+  const parts = session.command.trim().split(/\s+/);
+  if (parts.length === 0) {
+    return { ok: false, error: "Invalid script command." };
+  }
+  return {
+    ok: true,
+    value: { file: parts[0]!, args: parts.slice(1), shell: false },
+  };
+}
+
+function detectLocalhostUrls(text: string): string[] {
+  const matches = text.match(LOCALHOST_URL_RE) ?? [];
+  return [...new Set(matches)];
+}
+
+function mergeDetectedUrls(existing: string[], found: string[]): string[] {
+  if (found.length === 0) return existing;
+  return [...new Set([...existing, ...found])];
+}
+
+function capTail(output: string): string {
+  const buf = Buffer.from(output, "utf8");
+  if (buf.byteLength <= MAX_TAIL_BYTES) return output;
+  return buf.subarray(buf.byteLength - MAX_TAIL_BYTES).toString("utf8");
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}


### PR DESCRIPTION
## Summary
- Add project-scoped **background command sessions** — start/stop/restart package scripts and custom commands from the Status panel, with SSE log streaming, duplicate prevention, and Windows process-tree kill on stop
- Scope **project selection to chat sessions** instead of a global active project
- Add **Diff** tab for git changes; compact Status layout with Commands panel and composer running indicator
- **Resizable worklog sidebar** (420px–65%) with clip animation and persisted width
- **Shared client caches** for Status, Files, and Commands tabs to avoid redundant fetches on tab switch

Closes #108

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Start a package script from Status → Running → open logs → stop → confirm process terminates
- [ ] Refresh browser → command history and log tails persist; stale after Next.js restart
- [ ] Switch Status/Files tabs → instant render from cache, no duplicate `/status` or `/commands` on revisit
- [ ] Drag worklog left edge to resize; expand/shrink buttons jump to min/max
- [ ] Open Diff tab → local changes with file list and patch viewer
- [ ] Clear Recent commands removes exited sessions
- [ ] Composer shows "N running" badge; click opens Status tab

## Visual verification
- Desktop xl: worklog open/close animation, Status Commands panel, Diff tab, compact Add-tab popup
- Composer project row with running-command badge


Made with [Cursor](https://cursor.com)