### PR TITLE
Trace workspace follow-up: PR tab, popup sorting, sidebar animation

### DIFF
--- a/app/api/projects/[id]/git/branches/route.ts
+++ b/app/api/projects/[id]/git/branches/route.ts
@@ -110,36 +110,39 @@ async function branchSummary(
   defaultBranch: string,
   root: string,
 ): Promise<ProjectBranchesSummary> {
+  const branchRefFormat = "%(refname:short)|%(committerdate:unix)";
   const [currentBranch, localRaw, remoteRaw] = await Promise.all([
     gitOutput(root, ["branch", "--show-current"]).catch(() => ""),
-    gitOutput(root, ["for-each-ref", "--format=%(refname:short)", "refs/heads"]),
+    gitOutput(root, ["for-each-ref", `--format=${branchRefFormat}`, "refs/heads"]),
     gitOutput(root, [
       "for-each-ref",
-      "--format=%(refname:short)",
+      `--format=${branchRefFormat}`,
       "refs/remotes/origin",
     ]).catch(() => ""),
   ]);
   const current = currentBranch.trim() || null;
-  const localBranches = splitLines(localRaw);
-  const localNames = new Set(localBranches);
-  const remoteBranches = splitLines(remoteRaw)
-    .filter((branch) => branch !== "origin" && branch !== "origin/HEAD")
-    .filter((branch) => !localNames.has(branch.replace(/^origin\//, "")));
+  const localBranches = parseBranchRefs(localRaw);
+  const localNames = new Set(localBranches.map((branch) => branch.name));
+  const remoteBranches = parseBranchRefs(remoteRaw)
+    .filter((branch) => branch.name !== "origin" && branch.name !== "origin/HEAD")
+    .filter((branch) => !localNames.has(branch.name.replace(/^origin\//, "")));
 
   return {
     projectId,
     currentBranch: current,
     defaultBranch,
     branches: [
-      ...localBranches.map((name) => ({
-        name,
+      ...localBranches.map((branch) => ({
+        name: branch.name,
         kind: "local" as const,
-        current: name === current,
+        current: branch.name === current,
+        lastCommitAt: branch.lastCommitAt,
       })),
-      ...remoteBranches.map((name) => ({
-        name,
+      ...remoteBranches.map((branch) => ({
+        name: branch.name,
         kind: "remote" as const,
         current: false,
+        lastCommitAt: branch.lastCommitAt,
       })),
     ].sort(compareBranches(defaultBranch)),
   };
@@ -200,6 +203,19 @@ function normalizeRemoteBranchName(name: string): string {
 
 function splitLines(value: string): string[] {
   return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function parseBranchRefs(value: string): { name: string; lastCommitAt: number | null }[] {
+  return splitLines(value).map((line) => {
+    const separator = line.lastIndexOf("|");
+    if (separator === -1) {
+      return { name: line, lastCommitAt: null };
+    }
+    const name = line.slice(0, separator).trim();
+    const parsed = Number.parseInt(line.slice(separator + 1).trim(), 10);
+    const lastCommitAt = Number.isFinite(parsed) ? parsed * 1000 : null;
+    return { name, lastCommitAt };
+  });
 }
 
 function compareBranches(defaultBranch: string) {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -592,12 +592,20 @@ function ChatSession({
         <div
           className={cn(
             "relative hidden shrink-0 overflow-hidden xl:block",
-            !worklogResizing && "transition-[width] duration-200 ease-in",
+            !worklogResizing && "transition-[width] duration-200 ease-in-out",
             !worklogOpen && "pointer-events-none xl:border-l-0",
           )}
           style={{ width: worklogOpen ? worklogWidth : 0 }}
         >
-          <div className="relative h-full" style={{ width: worklogWidth }}>
+          <div
+            className={cn(
+              "relative h-full",
+              !worklogResizing &&
+                worklogOpen &&
+                "transition-[width] duration-200 ease-in-out",
+            )}
+            style={{ width: worklogWidth }}
+          >
             {worklogOpen ? (
               <WorklogResizeHandle
                 onResizeStart={startWorklogResize}

--- a/components/features/projects/branch-switcher.tsx
+++ b/components/features/projects/branch-switcher.tsx
@@ -29,7 +29,99 @@ import type {
 } from "@/src/lib/api-types";
 import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 
+import { PopupSectionHeader } from "@/components/shared/popup-section-header";
+import {
+  PopupSortSelect,
+  type PopupSortOption,
+} from "@/components/shared/popup-sort-select";
+
 import { notifyProjectGitChanged } from "./hooks";
+
+type BranchSort =
+  | "recent-desc"
+  | "recent-asc"
+  | "name-asc"
+  | "name-desc"
+  | "local-first"
+  | "remote-first";
+
+const BRANCH_SORT_OPTIONS = [
+  { value: "recent-desc", label: "Recent" },
+  { value: "recent-asc", label: "Oldest" },
+  { value: "name-asc", label: "Name A-Z" },
+  { value: "name-desc", label: "Name Z-A" },
+  { value: "local-first", label: "Local first" },
+  { value: "remote-first", label: "Remote first" },
+] as const satisfies readonly PopupSortOption<BranchSort>[];
+
+function branchCommitTime(branch: ProjectBranchSummary): number {
+  return branch.lastCommitAt ?? 0;
+}
+
+function sortBranches(
+  branches: ProjectBranchSummary[],
+  sort: BranchSort,
+): ProjectBranchSummary[] {
+  const sorted = [...branches];
+  switch (sort) {
+    case "recent-desc":
+      sorted.sort(
+        (a, b) => branchCommitTime(b) - branchCommitTime(a) || a.name.localeCompare(b.name),
+      );
+      break;
+    case "recent-asc":
+      sorted.sort(
+        (a, b) => branchCommitTime(a) - branchCommitTime(b) || a.name.localeCompare(b.name),
+      );
+      break;
+    case "name-asc":
+      sorted.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case "name-desc":
+      sorted.sort((a, b) => b.name.localeCompare(a.name));
+      break;
+    case "local-first":
+      sorted.sort((a, b) => {
+        if (a.kind !== b.kind) return a.kind === "local" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+      break;
+    case "remote-first":
+      sorted.sort((a, b) => {
+        if (a.kind !== b.kind) return a.kind === "remote" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+      break;
+  }
+
+  const current = sorted.find((branch) => branch.current);
+  if (!current) return sorted;
+  return [current, ...sorted.filter((branch) => !branch.current)];
+}
+
+function relativeBranchTime(timestamp: number | null): string {
+  if (timestamp === null || !Number.isFinite(timestamp)) return "Unknown";
+  const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const divisions = [
+    { amount: 60, unit: "second" },
+    { amount: 60, unit: "minute" },
+    { amount: 24, unit: "hour" },
+    { amount: 7, unit: "day" },
+    { amount: 4.345, unit: "week" },
+    { amount: 12, unit: "month" },
+    { amount: Number.POSITIVE_INFINITY, unit: "year" },
+  ] as const;
+  let duration = diffSeconds;
+  for (const division of divisions) {
+    if (Math.abs(duration) < division.amount) {
+      return new Intl.RelativeTimeFormat(undefined, {
+        numeric: "auto",
+      }).format(Math.round(duration), division.unit);
+    }
+    duration /= division.amount;
+  }
+  return "";
+}
 
 export function BranchSwitcher({
   project,
@@ -61,14 +153,17 @@ export function BranchSwitcher({
   const [newBranch, setNewBranch] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [issueError, setIssueError] = useState<string | null>(null);
+  const [branchSort, setBranchSort] = useState<BranchSort>("recent-desc");
   const displayedBranch = currentBranch ?? project?.defaultBranch ?? null;
 
   const filteredBranches = useMemo(() => {
     const needle = query.trim().toLowerCase();
     const items = branches?.branches ?? [];
-    if (!needle) return items;
-    return items.filter((branch) => branch.name.toLowerCase().includes(needle));
-  }, [branches, query]);
+    const filtered = needle
+      ? items.filter((branch) => branch.name.toLowerCase().includes(needle))
+      : items;
+    return sortBranches(filtered, branchSort);
+  }, [branches, branchSort, query]);
 
   const filteredIssues = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -256,9 +351,17 @@ export function BranchSwitcher({
           </div>
         </div>
         <div className="max-h-72 overflow-y-auto p-0.5">
-          <div className="px-1.5 py-1 text-[10px] font-medium uppercase text-muted-foreground">
-            Branches
-          </div>
+          <PopupSectionHeader
+            title="Branches"
+            action={
+              <PopupSortSelect
+                value={branchSort}
+                options={BRANCH_SORT_OPTIONS}
+                onChange={setBranchSort}
+                aria-label="Sort branches"
+              />
+            }
+          />
           {error ? (
             <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
               {error}
@@ -275,14 +378,14 @@ export function BranchSwitcher({
                     type="button"
                     onClick={() => selectBranch(branch)}
                     disabled={switching !== null}
-                    className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
+                    className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
                   >
                     {switching === branch.name ? (
-                      <Loader2 className="size-3 animate-spin text-primary" />
+                      <Loader2 className="mt-0.5 size-3 animate-spin text-primary" />
                     ) : (
                       <GitBranch
                         className={cn(
-                          "size-3",
+                          "mt-0.5 size-3",
                           branch.kind === "remote"
                             ? "text-sky-400"
                             : "text-muted-foreground",
@@ -293,6 +396,12 @@ export function BranchSwitcher({
                     <span className="min-w-0">
                       <span className="block truncate font-mono font-medium">
                         {branch.name}
+                      </span>
+                      <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                        {branch.kind === "remote" ? "remote" : "local"}
+                        {branch.lastCommitAt !== null
+                          ? ` · ${relativeBranchTime(branch.lastCommitAt)}`
+                          : null}
                       </span>
                     </span>
                     {branch.current ? (

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   AlertCircle,
+  Check,
   CheckCircle2,
+  ChevronDown,
   Clock,
   ExternalLink,
   FileText,
+  GitBranch,
   GitCommit,
   GitPullRequest,
   Loader2,
   MessageSquare,
   RefreshCw,
   RotateCcw,
+  Search,
   XCircle,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Tabs,
   TabsContent,
@@ -29,25 +38,37 @@ import type {
   ProjectPullRequestCommitSummary,
   ProjectPullRequestDiscussionItem,
   ProjectPullRequestFileSummary,
+  ProjectPullRequestListItem,
   ProjectPullRequestSummary,
   ProjectPullRequestCheckSummary,
+  ProjectSummary,
 } from "@/src/lib/api-types";
+import { errorMessage, getJson } from "@/src/lib/client-fetch";
 import { Markdown } from "@/components/features/chat/markdown";
+import { PopupSectionHeader } from "@/components/shared/popup-section-header";
+import {
+  PopupSortSelect,
+  type PopupSortOption,
+} from "@/components/shared/popup-sort-select";
 import { PatchDiffView } from "./diff-view";
 
 export function PullRequestPanel({
   pullRequest,
   loading,
   error,
+  project,
   projectId,
   onRefresh,
+  onSelectPullRequest,
 }: {
   pullRequest: ProjectPullRequestSummary;
   gitStatus: ProjectGitStatusSummary | null;
   loading: boolean;
   error: string | null;
+  project: ProjectSummary | null;
   projectId: string | null;
   onRefresh: () => void;
+  onSelectPullRequest: (number: number) => void;
 }) {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const selected =
@@ -62,9 +83,11 @@ export function PullRequestPanel({
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
               <StateBadge pullRequest={pullRequest} />
-              <span className="truncate text-muted-foreground">
-                PR #{pullRequest.number}
-              </span>
+              <PullRequestSelector
+                project={project}
+                pullRequest={pullRequest}
+                onSelect={onSelectPullRequest}
+              />
             </div>
             <h2 className="mt-1 line-clamp-2 text-sm font-semibold leading-5">
               {pullRequest.title}
@@ -170,15 +193,19 @@ export function PullRequestEmptyPanel({
   loading,
   creating,
   error,
+  project,
   onRefresh,
   onCreatePullRequest,
+  onSelectPullRequest,
 }: {
   gitStatus: ProjectGitStatusSummary | null;
   loading: boolean;
   creating: boolean;
   error: string | null;
+  project: ProjectSummary | null;
   onRefresh: () => void;
   onCreatePullRequest: () => void;
+  onSelectPullRequest: (number: number) => void;
 }) {
   const createReady = canCreatePullRequest(gitStatus);
   const canShowCreateAction = Boolean(gitStatus?.branch && !gitStatus.isDefaultBranch);
@@ -191,9 +218,16 @@ export function PullRequestEmptyPanel({
       <section className="border-b border-border px-3 py-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <div className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border">
-              <GitPullRequest className="size-3" />
-              No PR
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border">
+                <GitPullRequest className="size-3" />
+                No PR
+              </span>
+              <PullRequestSelector
+                project={project}
+                pullRequest={null}
+                onSelect={onSelectPullRequest}
+              />
             </div>
             <h2 className="mt-2 text-sm font-semibold">Pull request</h2>
             <p className="mt-1 text-xs text-muted-foreground">
@@ -913,6 +947,228 @@ function relativeTime(timestamp: number): string {
     duration /= division.amount;
   }
   return "";
+}
+
+function relativePullRequestTime(timestamp: number): string {
+  return relativeTime(timestamp);
+}
+
+type PullRequestSort =
+  | "updated-desc"
+  | "updated-asc"
+  | "created-desc"
+  | "created-asc"
+  | "number-desc"
+  | "number-asc"
+  | "title-asc";
+
+const PULL_REQUEST_SORT_OPTIONS = [
+  { value: "updated-desc", label: "Recent" },
+  { value: "updated-asc", label: "Oldest" },
+  { value: "created-desc", label: "Newest" },
+  { value: "created-asc", label: "Earliest" },
+  { value: "number-desc", label: "# ↓" },
+  { value: "number-asc", label: "# ↑" },
+  { value: "title-asc", label: "Title A-Z" },
+] as const satisfies readonly PopupSortOption<PullRequestSort>[];
+
+function sortPullRequests(
+  items: ProjectPullRequestListItem[],
+  sort: PullRequestSort,
+): ProjectPullRequestListItem[] {
+  const sorted = [...items];
+  switch (sort) {
+    case "updated-desc":
+      return sorted.sort((a, b) => b.updatedAt - a.updatedAt);
+    case "updated-asc":
+      return sorted.sort((a, b) => a.updatedAt - b.updatedAt);
+    case "created-desc":
+      return sorted.sort((a, b) => b.createdAt - a.createdAt);
+    case "created-asc":
+      return sorted.sort((a, b) => a.createdAt - b.createdAt);
+    case "number-desc":
+      return sorted.sort((a, b) => b.number - a.number);
+    case "number-asc":
+      return sorted.sort((a, b) => a.number - b.number);
+    case "title-asc":
+      return sorted.sort((a, b) => a.title.localeCompare(b.title));
+  }
+}
+
+export function PullRequestSelector({
+  project,
+  pullRequest,
+  onSelect,
+}: {
+  project: ProjectSummary | null;
+  pullRequest: ProjectPullRequestSummary | null;
+  onSelect: (number: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [pullRequests, setPullRequests] = useState<ProjectPullRequestListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selecting, setSelecting] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pullRequestSort, setPullRequestSort] =
+    useState<PullRequestSort>("updated-desc");
+  const label = pullRequest ? `PR #${pullRequest.number}` : "PR";
+
+  const filteredPullRequests = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const filtered = needle
+      ? pullRequests.filter((item) =>
+          [
+            `#${item.number}`,
+            item.title,
+            item.authorLogin,
+            item.baseBranch,
+            item.headBranch,
+          ].some((value) => value.toLowerCase().includes(needle)),
+        )
+      : pullRequests;
+    return sortPullRequests(filtered, pullRequestSort);
+  }, [pullRequests, pullRequestSort, query]);
+
+  const loadPullRequests = useCallback(async () => {
+    if (!project || project.provider !== "github" || project.status !== "ready") return;
+    setLoading(true);
+    try {
+      const data = await getJson<{ pullRequests: ProjectPullRequestListItem[] }>(
+        `/api/projects/${project.id}/github/pull-requests`,
+      );
+      setPullRequests(data.pullRequests);
+      setError(null);
+    } catch (err) {
+      setPullRequests([]);
+      setError(errorMessage(err, "Failed to load pull requests"));
+    } finally {
+      setLoading(false);
+    }
+  }, [project]);
+
+  const selectPullRequest = (item: ProjectPullRequestListItem) => {
+    setSelecting(item.number);
+    onSelect(item.number);
+    setOpen(false);
+    window.setTimeout(() => setSelecting(null), 600);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) void loadPullRequests();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-0.5 rounded-sm px-1 py-0.5 font-mono text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label={pullRequest ? `Select pull request, current ${label}` : "Select pull request"}
+        >
+          <span className="truncate">{label}</span>
+          <ChevronDown className="size-3 shrink-0 opacity-70" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" side="bottom" className="w-80 overflow-hidden p-0">
+        <div className="border-b border-border p-1.5">
+          <div className="grid grid-cols-[0.75rem_1fr_auto] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
+            <Search className="size-3 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search pull requests"
+              className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
+              aria-label="Search pull requests"
+            />
+            <button
+              type="button"
+              onClick={() => void loadPullRequests()}
+              disabled={loading}
+              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+              aria-label="Refresh pull requests"
+              title="Refresh pull requests"
+            >
+              {loading ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+            </button>
+          </div>
+        </div>
+        <div className="max-h-72 overflow-y-auto p-0.5">
+          <PopupSectionHeader
+            title="Pull requests"
+            action={
+              <PopupSortSelect
+                value={pullRequestSort}
+                options={PULL_REQUEST_SORT_OPTIONS}
+                onChange={setPullRequestSort}
+                aria-label="Sort pull requests"
+              />
+            }
+          />
+          {error ? (
+            <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
+              {error}
+            </div>
+          ) : filteredPullRequests.length === 0 ? (
+            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+              {loading ? "Loading pull requests..." : "No pull requests found."}
+            </div>
+          ) : (
+            <ul className="grid gap-0.5">
+              {filteredPullRequests.map((item) => {
+                const selected = pullRequest?.number === item.number;
+                const stateLabel = item.merged
+                  ? "Merged"
+                  : item.state === "open"
+                    ? "Open"
+                    : "Closed";
+                return (
+                  <li key={item.number}>
+                    <button
+                      type="button"
+                      onClick={() => selectPullRequest(item)}
+                      className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
+                    >
+                      {selecting === item.number ? (
+                        <Loader2 className="mt-0.5 size-3 animate-spin text-primary" />
+                      ) : (
+                        <GitBranch
+                          className={cn(
+                            "mt-0.5 size-3",
+                            item.merged
+                              ? "text-purple-400"
+                              : item.state === "open"
+                                ? "text-emerald-400"
+                                : "text-muted-foreground",
+                          )}
+                        />
+                      )}
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium">
+                          #{item.number} {item.title}
+                        </span>
+                        <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                          {item.headBranch} {"->"} {item.baseBranch} | {stateLabel} |{" "}
+                          {relativePullRequestTime(item.updatedAt)}
+                        </span>
+                      </span>
+                      {selected ? <Check className="mt-0.5 size-3 text-primary" /> : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 function StateBadge({

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
-  Check,
   CheckCircle2,
   FileText,
   GitBranch,
@@ -11,12 +10,9 @@ import {
   FolderTree,
   Info,
   ListTodo,
-  Loader2,
   Maximize2,
   Minimize2,
   Plus,
-  RefreshCw,
-  Search,
   TerminalSquare,
   X,
   XCircle,
@@ -31,11 +27,6 @@ import {
   type ToolTraceEntry,
 } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { Markdown } from "@/components/features/chat/markdown";
 import { DiffView } from "./diff-view";
@@ -63,7 +54,6 @@ import { errorMessage, getJson, jsonHeaders, requestJson } from "@/src/lib/clien
 import { PROJECT_GIT_CHANGED_EVENT, OPEN_WORKLOG_STATUS_EVENT } from "@/components/features/projects/hooks";
 import type {
   ProjectGitStatusSummary,
-  ProjectPullRequestListItem,
   ProjectPullRequestSummary,
   ProjectSummary,
 } from "@/src/lib/api-types";
@@ -109,13 +99,12 @@ export function Worklog({
   const [tabs, setTabs] = useState<SidebarTab[]>(["worklog"]);
   const [activeTab, setActiveTab] = useState<SidebarTab | null>("worklog");
   const [menuOpen, setMenuOpen] = useState(false);
-  const [lastAutoPr, setLastAutoPr] = useState<number | null>(null);
+  const prTabOpen = tabs.includes("pr");
   const prState = useProjectPullRequest(project, {
-    enabled: visible,
+    enabled: visible && prTabOpen,
     poll: visible && activeTab === "pr",
   });
   const hasGithubProject = project?.provider === "github" && project.status === "ready";
-  const pullRequestNumber = prState.pullRequest?.number ?? null;
 
   const addTab = (tab: SidebarTab) => {
     setTabs((current) => (current.includes(tab) ? current : [...current, tab]));
@@ -149,28 +138,17 @@ export function Worklog({
   }, []);
 
   useEffect(() => {
-    if (pullRequestNumber === null && !hasGithubProject) {
-      queueMicrotask(() => {
-        setTabs((current) => current.filter((tab) => tab !== "pr"));
-        setActiveTab((current) => (current === "pr" ? "worklog" : current));
-        setLastAutoPr(null);
-      });
-      return;
-    }
-    if (pullRequestNumber === null || !visible || lastAutoPr === pullRequestNumber) {
-      return;
-    }
+    if (hasGithubProject) return;
     queueMicrotask(() => {
-      setTabs((current) => (current.includes("pr") ? current : [...current, "pr"]));
-      setActiveTab("pr");
-      setLastAutoPr(pullRequestNumber);
+      setTabs((current) => current.filter((tab) => tab !== "pr"));
+      setActiveTab((current) => (current === "pr" ? "worklog" : current));
     });
-  }, [hasGithubProject, lastAutoPr, pullRequestNumber, visible]);
+  }, [hasGithubProject]);
 
   const availableTabs = SIDEBAR_TABS.filter(
     (tab) =>
       !tabs.includes(tab.id) &&
-      (tab.id !== "pr" || hasGithubProject || prState.pullRequest !== null),
+      (tab.id !== "pr" || hasGithubProject),
   );
 
   return (
@@ -185,7 +163,7 @@ export function Worklog({
         <header className={cn(traceWorkspaceHeaderRowClass, "justify-between gap-1")}>
           <div className="flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide">
             {tabs.map((tab) => {
-              const meta = tabMeta(tab, prState.pullRequest);
+              const meta = tabMeta(tab);
               return (
                 <div
                   key={tab}
@@ -208,24 +186,14 @@ export function Worklog({
                     <meta.Icon className="size-3 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
                     <X className="absolute size-3 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
                   </button>
-                  {tab === "pr" ? (
-                    <PullRequestTabSelector
-                      project={project}
-                      pullRequest={prState.pullRequest}
-                      active={activeTab === tab}
-                      onActivate={() => setActiveTab(tab)}
-                      onSelect={prState.selectPullRequest}
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => setActiveTab(tab)}
-                      className={traceWorkspaceTabLabelButtonClass}
-                      aria-pressed={activeTab === tab}
-                    >
-                      <span className="block truncate">{meta.label}</span>
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab(tab)}
+                    className={traceWorkspaceTabLabelButtonClass}
+                    aria-pressed={activeTab === tab}
+                  >
+                    <span className="block truncate">{meta.label}</span>
+                  </button>
                 </div>
               );
             })}
@@ -248,7 +216,7 @@ export function Worklog({
                 <div className="absolute right-0 top-full z-50 mt-1 w-36 min-w-36 overflow-hidden rounded-md bg-popover text-popover-foreground shadow-none ring-1 ring-border">
                   <ul className="p-0.5">
                     {availableTabs.map((tab) => {
-                      const meta = tabMeta(tab.id, prState.pullRequest);
+                      const meta = tabMeta(tab.id);
                       return (
                         <li key={tab.id}>
                           <button
@@ -317,8 +285,10 @@ export function Worklog({
             gitStatus={prState.gitStatus}
             loading={prState.loading}
             error={prState.error}
+            project={project}
             projectId={project?.id ?? null}
             onRefresh={prState.refresh}
+            onSelectPullRequest={prState.selectPullRequest}
           />
         ) : activeTab === "pr" && hasGithubProject ? (
           <PullRequestEmptyPanel
@@ -326,8 +296,10 @@ export function Worklog({
             loading={prState.loading}
             creating={prState.creating}
             error={prState.error}
+            project={project}
             onRefresh={prState.refresh}
             onCreatePullRequest={prState.createPullRequest}
+            onSelectPullRequest={prState.selectPullRequest}
           />
         ) : (
           <EmptyTabsPanel />
@@ -353,209 +325,8 @@ const SIDEBAR_TABS = [
 
 const PR_POLL_INTERVAL_MS = 120_000;
 
-function tabMeta(
-  tab: SidebarTab,
-  pullRequest: ProjectPullRequestSummary | null,
-) {
-  const meta = SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
-  if (tab !== "pr" || !pullRequest) return meta;
-  return { ...meta, label: `PR #${pullRequest.number}` };
-}
-
-function PullRequestTabSelector({
-  project,
-  pullRequest,
-  active,
-  onActivate,
-  onSelect,
-}: {
-  project: ProjectSummary | null;
-  pullRequest: ProjectPullRequestSummary | null;
-  active: boolean;
-  onActivate: () => void;
-  onSelect: (number: number) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [pullRequests, setPullRequests] = useState<ProjectPullRequestListItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [selecting, setSelecting] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const label = pullRequest ? `PR #${pullRequest.number}` : "PR";
-
-  const filteredPullRequests = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return pullRequests;
-    return pullRequests.filter((item) =>
-      [
-        `#${item.number}`,
-        item.title,
-        item.authorLogin,
-        item.baseBranch,
-        item.headBranch,
-      ].some((value) => value.toLowerCase().includes(needle)),
-    );
-  }, [pullRequests, query]);
-
-  const loadPullRequests = useCallback(async () => {
-    if (!project || project.provider !== "github" || project.status !== "ready") return;
-    setLoading(true);
-    try {
-      const data = await getJson<{ pullRequests: ProjectPullRequestListItem[] }>(
-        `/api/projects/${project.id}/github/pull-requests`,
-      );
-      setPullRequests(data.pullRequests);
-      setError(null);
-    } catch (err) {
-      setPullRequests([]);
-      setError(errorMessage(err, "Failed to load pull requests"));
-    } finally {
-      setLoading(false);
-    }
-  }, [project]);
-
-  const selectPullRequest = (item: ProjectPullRequestListItem) => {
-    setSelecting(item.number);
-    onSelect(item.number);
-    setOpen(false);
-    window.setTimeout(() => setSelecting(null), 600);
-  };
-
-  return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (next) {
-          onActivate();
-          void loadPullRequests();
-        }
-      }}
-    >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          onClick={onActivate}
-          className={traceWorkspaceTabLabelButtonClass}
-          aria-pressed={active}
-          aria-label={pullRequest ? `Select pull request, current ${label}` : "Select pull request"}
-        >
-          <span className="block truncate">{label}</span>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" side="bottom" className="w-80 overflow-hidden p-0">
-        <div className="border-b border-border p-1.5">
-          <div className="grid grid-cols-[0.75rem_1fr_auto] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
-            <Search className="size-3 text-muted-foreground" />
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search pull requests"
-              className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
-              aria-label="Search pull requests"
-            />
-            <button
-              type="button"
-              onClick={() => void loadPullRequests()}
-              disabled={loading}
-              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-              aria-label="Refresh pull requests"
-              title="Refresh pull requests"
-            >
-              {loading ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <RefreshCw className="size-3" />
-              )}
-            </button>
-          </div>
-        </div>
-        <div className="max-h-72 overflow-y-auto p-0.5">
-          <div className="px-1.5 py-1 text-[10px] font-medium uppercase text-muted-foreground">
-            Pull requests
-          </div>
-          {error ? (
-            <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
-              {error}
-            </div>
-          ) : filteredPullRequests.length === 0 ? (
-            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
-              {loading ? "Loading pull requests..." : "No pull requests found."}
-            </div>
-          ) : (
-            <ul className="grid gap-0.5">
-              {filteredPullRequests.map((item) => {
-                const selected = pullRequest?.number === item.number;
-                const stateLabel = item.merged
-                  ? "Merged"
-                  : item.state === "open"
-                    ? "Open"
-                    : "Closed";
-                return (
-                  <li key={item.number}>
-                    <button
-                      type="button"
-                      onClick={() => selectPullRequest(item)}
-                      className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
-                    >
-                      {selecting === item.number ? (
-                        <Loader2 className="mt-0.5 size-3 animate-spin text-primary" />
-                      ) : (
-                        <GitBranch
-                          className={cn(
-                            "mt-0.5 size-3",
-                            item.merged
-                              ? "text-purple-400"
-                              : item.state === "open"
-                                ? "text-emerald-400"
-                                : "text-muted-foreground",
-                          )}
-                        />
-                      )}
-                      <span className="min-w-0">
-                        <span className="block truncate font-medium">
-                          #{item.number} {item.title}
-                        </span>
-                        <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                          {item.headBranch} {"->"} {item.baseBranch} | {stateLabel} |{" "}
-                          {relativePullRequestTime(item.updatedAt)}
-                        </span>
-                      </span>
-                      {selected ? <Check className="mt-0.5 size-3 text-primary" /> : null}
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function relativePullRequestTime(timestamp: number): string {
-  if (!Number.isFinite(timestamp)) return "";
-  const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
-  const divisions = [
-    { amount: 60, unit: "second" },
-    { amount: 60, unit: "minute" },
-    { amount: 24, unit: "hour" },
-    { amount: 7, unit: "day" },
-    { amount: 4.345, unit: "week" },
-    { amount: 12, unit: "month" },
-    { amount: Number.POSITIVE_INFINITY, unit: "year" },
-  ] as const;
-  let duration = diffSeconds;
-  for (const division of divisions) {
-    if (Math.abs(duration) < division.amount) {
-      return new Intl.RelativeTimeFormat(undefined, {
-        numeric: "auto",
-      }).format(Math.round(duration), division.unit);
-    }
-    duration /= division.amount;
-  }
-  return "";
+function tabMeta(tab: SidebarTab) {
+  return SIDEBAR_TABS.find((item) => item.id === tab) ?? SIDEBAR_TABS[0];
 }
 
 function EmptyTabsPanel() {

--- a/components/shared/popup-section-header.tsx
+++ b/components/shared/popup-section-header.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function PopupSectionHeader({
+  title,
+  action,
+  className,
+}: {
+  title: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 px-1.5 py-1",
+        className,
+      )}
+    >
+      <span className="text-[10px] font-medium uppercase text-muted-foreground">
+        {title}
+      </span>
+      {action}
+    </div>
+  );
+}

--- a/components/shared/popup-sort-select.tsx
+++ b/components/shared/popup-sort-select.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
+
+export type PopupSortOption<T extends string> = {
+  value: T;
+  label: string;
+};
+
+export function PopupSortSelect<T extends string>({
+  value,
+  options,
+  onChange,
+  "aria-label": ariaLabel,
+  className,
+}: {
+  value: T;
+  options: readonly PopupSortOption<T>[];
+  onChange: (value: T) => void;
+  "aria-label": string;
+  className?: string;
+}) {
+  const selected =
+    options.find((option) => option.value === value) ?? options[0];
+
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as T)}>
+      <SelectTrigger
+        aria-label={ariaLabel}
+        className={cn(
+          "h-5 min-w-0 max-w-[6.5rem] shrink-0 gap-0.5 border-0 bg-transparent px-1 py-0 text-[10px] font-medium leading-4 text-muted-foreground shadow-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-2.5",
+          className,
+        )}
+      >
+        <SelectValue className="truncate">{selected?.label ?? "Sort"}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="end" className="min-w-32">
+        <SelectViewport className="p-0.5">
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              className="py-1 pr-7 pl-1.5 text-xs leading-4"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectViewport>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -88,6 +88,7 @@ export type ProjectBranchSummary = {
   name: string;
   kind: "local" | "remote";
   current: boolean;
+  lastCommitAt: number | null;
 };
 
 export type ProjectBranchesSummary = {


### PR DESCRIPTION
## Summary
- **PR tab:** No auto-open on branch PR detection; normal tab click only. PR selector moved next to merge status pill in the panel header.
- **Popup sorting:** Shared shadcn `PopupSortSelect` for branch and PR popups (Recent, Oldest, name/kind options).
- **Branch Recent:** API returns `lastCommitAt`; branches default to Recent sort with relative commit time in rows.
- **Sidebar resize:** Inner panel width transitions with outer shell on shrink/expand so max→min animates smoothly.

Closes #110

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Open PR tab manually → loads latest branch PR; use **PR #N ▾** in header to switch
- [ ] Branch popup → sort by Recent; rows show commit age
- [ ] PR popup → sort by Recent / Oldest / etc.
- [ ] Expand worklog to max, click shrink → width decreases smoothly (no sliding-window effect)
- [ ] Open/close worklog → curtain reveal without content squash

## Visual verification
- Desktop xl: branch switcher popup, PR panel header selector, worklog shrink from max width

Made with [Cursor](https://cursor.com)