### PR TITLE
fix: harden background commands and polish trace workspace UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Anton Roadmap
 
-Last reviewed: 2026-05-23
+Last reviewed: 2026-05-25
 
 This roadmap is the working backlog for turning Anton from a learning harness into a reliable local AI coding agent. Use each checklist item as the source for future GitHub issues. Mark finished items as `[✔️]` after the related GitHub issue or PR is resolved.
 
@@ -134,7 +134,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 - [✔️] Add file tree and file search panel for the active project.
 - [✔️] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
-- [] Add live terminal output streaming for long-running commands.
+- [✔️] Add live terminal output streaming for long-running commands.
 - [✔️] Add cancellable background command sessions for dev servers and watchers.
 - [] Add command history with rerun support.
 - [✔️] Add settings for default model, max steps, approval strictness, and workspace root.

--- a/app/api/projects/[id]/commands/preflight/route.ts
+++ b/app/api/projects/[id]/commands/preflight/route.ts
@@ -1,0 +1,65 @@
+import { getProject } from "@/src/db/queries";
+import { redactText } from "@/src/lib/redaction";
+import { preflightProjectBackgroundCommand } from "@/src/workspace/background-commands";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+const preflightSchema = z.object({
+  command: z.string().trim().min(1),
+});
+
+export async function POST(req: Request, { params }: Ctx) {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = preflightSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json({ error: "invalid request body" }, { status: 400 });
+  }
+
+  try {
+    const result = preflightProjectBackgroundCommand(
+      project.localPath,
+      parsed.data.command,
+    );
+    if (!result.ok) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 },
+      );
+    }
+
+    return Response.json({
+      allowed: result.allowed,
+      risky: result.risky,
+      categories: result.categories,
+      reason: result.reason,
+    });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/components/features/projects/background-commands-panel.tsx
+++ b/components/features/projects/background-commands-panel.tsx
@@ -12,10 +12,21 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { ErrorBanner } from "@/components/shared/feedback-states";
 import { TerminalOutput } from "@/components/features/run-trace/terminal-output";
 import { cn } from "@/lib/utils";
 import type {
+  BackgroundCommandPreflightResult,
   BackgroundCommandSessionSummary,
   ProjectStatusSummary,
 } from "@/src/lib/api-types";
@@ -51,6 +62,10 @@ export function BackgroundCommandsPanel({
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [openLogsId, setOpenLogsId] = useState<string | null>(null);
   const [streamTokens, setStreamTokens] = useState<Record<string, string>>({});
+  const [riskyCommandPrompt, setRiskyCommandPrompt] = useState<{
+    command: string;
+    preflight: BackgroundCommandPreflightResult;
+  } | null>(null);
 
   const runningCommands = commands?.running ?? [];
   const recentCommands = commands?.recent ?? [];
@@ -73,6 +88,46 @@ export function BackgroundCommandsPanel({
     }
     return ordered;
   }, [status.scripts]);
+
+  const submitCustomCommand = async (command: string) => {
+    const trimmed = command.trim();
+    if (!trimmed || activeCommands.has(trimmed)) return;
+
+    setPendingAction(`custom:${trimmed}`);
+    setActionError(null);
+    try {
+      const preflight = await requestJson<BackgroundCommandPreflightResult>(
+        `/api/projects/${projectId}/commands/preflight`,
+        {
+          method: "POST",
+          headers: jsonHeaders(),
+          body: JSON.stringify({ command: trimmed }),
+        },
+      );
+      if (!preflight.allowed) {
+        setActionError(preflight.reason);
+        return;
+      }
+      if (preflight.risky) {
+        setRiskyCommandPrompt({ command: trimmed, preflight });
+        return;
+      }
+      await runCommand({ kind: "custom", command: trimmed }, `custom:${trimmed}`);
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to validate command",
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const confirmRiskyCommand = async () => {
+    if (!riskyCommandPrompt) return;
+    const { command } = riskyCommandPrompt;
+    setRiskyCommandPrompt(null);
+    await runCommand({ kind: "custom", command }, `custom:${command}`);
+  };
 
   const runCommand = async (
     input: StartBackgroundCommandInput,
@@ -268,7 +323,7 @@ export function BackgroundCommandsPanel({
               event.preventDefault();
               const trimmed = customCommand.trim();
               if (!trimmed || activeCommands.has(trimmed)) return;
-              void runCommand({ kind: "custom", command: trimmed }, `custom:${trimmed}`);
+              void submitCustomCommand(trimmed);
             }}
           >
             <Input
@@ -329,6 +384,7 @@ export function BackgroundCommandsPanel({
                     )
                   }
                   onRerun={() => void rerunCommand(session)}
+                  onRestart={() => void restartCommand(session)}
                 />
               ))}
             </div>
@@ -337,6 +393,48 @@ export function BackgroundCommandsPanel({
           )}
         </CommandGroup>
       </div>
+
+      <AlertDialog
+        open={riskyCommandPrompt !== null}
+        onOpenChange={(open) => {
+          if (!open) setRiskyCommandPrompt(null);
+        }}
+      >
+        <AlertDialogContent size="default" className="max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Run risky command?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="space-y-2 text-left">
+                <p>
+                  This custom command was classified as risky and needs confirmation
+                  before it starts.
+                </p>
+                {riskyCommandPrompt ? (
+                  <>
+                    <code className="block rounded-md bg-muted px-2 py-1 font-mono text-[11px] text-foreground">
+                      {riskyCommandPrompt.command}
+                    </code>
+                    <p className="text-[11px]">
+                      {riskyCommandPrompt.preflight.reason}
+                    </p>
+                    {riskyCommandPrompt.preflight.categories.length > 0 ? (
+                      <p className="text-[11px]">
+                        Risk: {riskyCommandPrompt.preflight.categories.join(", ")}
+                      </p>
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void confirmRiskyCommand()}>
+              Run command
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }
@@ -382,7 +480,7 @@ function RunningCommandCard({
   onStop: () => void;
   onRestart: () => void;
 }) {
-  const now = useElapsedClock();
+  const now = useElapsedClock(session.status !== "stopping");
   const primaryUrl = session.detectedUrls[0] ?? null;
   return (
     <div className="rounded-md bg-background/25 px-2 py-1.5 ring-1 ring-border/50">
@@ -424,7 +522,10 @@ function RunningCommandCard({
             type="button"
             size="icon-xs"
             variant="ghost"
-            disabled={pendingAction === `stop:${session.id}`}
+            disabled={
+              pendingAction === `stop:${session.id}` ||
+              session.status === "stopping"
+            }
             onClick={onStop}
             aria-label="Stop command"
             title="Stop"
@@ -467,6 +568,7 @@ function RecentCommandCard({
   rerunDisabled,
   onToggleLogs,
   onRerun,
+  onRestart,
 }: {
   session: BackgroundCommandSessionSummary;
   pendingAction: string | null;
@@ -476,7 +578,13 @@ function RecentCommandCard({
   rerunDisabled: boolean;
   onToggleLogs: () => void;
   onRerun: () => void;
+  onRestart: () => void;
 }) {
+  const useRestart = session.status === "stale";
+  const actionPending = useRestart
+    ? pendingAction === `restart:${session.id}`
+    : pendingAction === `rerun:${session.id}`;
+
   return (
     <div className="rounded-md bg-background/25 px-2 py-1.5 ring-1 ring-border/50">
       <div className="flex flex-wrap items-start gap-2">
@@ -508,10 +616,10 @@ function RecentCommandCard({
             type="button"
             size="icon-xs"
             variant="ghost"
-            disabled={rerunDisabled || pendingAction === `rerun:${session.id}`}
-            onClick={onRerun}
-            aria-label="Rerun command"
-            title="Rerun"
+            disabled={rerunDisabled || actionPending}
+            onClick={useRestart ? onRestart : onRerun}
+            aria-label={useRestart ? "Restart command" : "Rerun command"}
+            title={useRestart ? "Restart" : "Rerun"}
           >
             <RotateCcw className="size-3" />
           </Button>
@@ -544,11 +652,13 @@ function CommandLogViewer({
 }) {
   const [polledSession, setPolledSession] =
     useState<BackgroundCommandSessionSummary>(session);
+  const source = live ? polledSession : session;
+  const isActive = ["starting", "running", "stopping"].includes(source.status);
   const streamState = useBackgroundCommandStream(
     projectId,
     session.id,
     streamToken,
-    live && Boolean(streamToken),
+    live && Boolean(streamToken) && isActive,
   );
 
   useEffect(() => {
@@ -556,7 +666,8 @@ function CommandLogViewer({
   }, [session]);
 
   useEffect(() => {
-    if (!live || streamToken) return;
+    const terminal = !["starting", "running", "stopping"].includes(polledSession.status);
+    if (!live || terminal) return;
 
     let cancelled = false;
     const poll = async () => {
@@ -571,20 +682,24 @@ function CommandLogViewer({
     };
 
     void poll();
+    const intervalMs = streamToken ? 3_000 : 2_000;
     const interval = window.setInterval(() => {
       void poll();
-    }, 2_000);
+    }, intervalMs);
     return () => {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [live, projectId, session.id, streamToken]);
+  }, [live, projectId, session.id, streamToken, polledSession.status]);
 
-  const source = live && !streamToken ? polledSession : session;
   const stdout =
-    live && streamToken ? streamState.stdout || source.stdoutTail : source.stdoutTail;
+    live && streamToken
+      ? streamState.stdout || source.stdoutTail
+      : source.stdoutTail;
   const stderr =
-    live && streamToken ? streamState.stderr || source.stderrTail : source.stderrTail;
+    live && streamToken
+      ? streamState.stderr || source.stderrTail
+      : source.stderrTail;
 
   return (
     <TerminalOutput
@@ -670,15 +785,16 @@ function formatElapsed(startedAt: number | null, now: number): string {
   return `${minutes}m ${rem}s`;
 }
 
-function useElapsedClock(intervalMs = 1_000): number {
+function useElapsedClock(active = true, intervalMs = 1_000): number {
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
+    if (!active) return;
     const interval = window.setInterval(() => {
       setNow(Date.now());
     }, intervalMs);
     return () => window.clearInterval(interval);
-  }, [intervalMs]);
+  }, [active, intervalMs]);
 
   return now;
 }

--- a/components/features/projects/use-background-command-stream.ts
+++ b/components/features/projects/use-background-command-stream.ts
@@ -46,6 +46,17 @@ const MAX_OUTPUT_CHARS = 64 * 1024;
 const RECONNECT_DELAY_MS = 1_000;
 const CLOSE_GRACE_MS = 500;
 
+const TERMINAL_STATUSES = new Set([
+  "exited",
+  "failed",
+  "stopped",
+  "stale",
+]);
+
+function isTerminalStatus(status: string, finished?: boolean): boolean {
+  return finished === true || TERMINAL_STATUSES.has(status);
+}
+
 const stores = new Map<string, BackgroundCommandStreamStore>();
 
 export function useBackgroundCommandStream(
@@ -161,15 +172,18 @@ function connectStore(
       return;
     }
 
+    const finished = isTerminalStatus(data.status, data.finished);
     setStoreState(store, {
       ...store.state,
       status: data.status,
       exitCode: data.exitCode,
       signal: data.signal,
       detectedUrls: data.detectedUrls ?? store.state.detectedUrls,
-      finished: true,
+      finished,
     });
-    closeEventSource(store, eventSource);
+    if (finished) {
+      closeEventSource(store, eventSource);
+    }
   };
 
   eventSource.onerror = () => {

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -62,13 +62,13 @@ const traceWorkspaceHeaderRowClass =
   "flex shrink-0 items-center border-b border-border p-1.5";
 
 const traceWorkspaceTabClass =
-  "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center rounded text-[11px] font-normal transition-colors";
+  "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center gap-1.5 rounded pl-1.5 pr-2 text-[11px] font-normal transition-colors";
 
 const traceWorkspaceTabCloseButtonClass =
-  "group/close relative ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+  "group/close relative inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 const traceWorkspaceTabLabelButtonClass =
-  "min-w-0 rounded pl-0 pr-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+  "min-w-0 rounded text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 export type WorklogEntry = ToolTraceEntry;
 type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "diff" | "status";

--- a/components/shared/popup-sort-select.tsx
+++ b/components/shared/popup-sort-select.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ListFilter } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 import {
   Select,
@@ -34,15 +36,23 @@ export function PopupSortSelect<T extends string>({
   return (
     <Select value={value} onValueChange={(next) => onChange(next as T)}>
       <SelectTrigger
-        aria-label={ariaLabel}
+        hideChevron
+        aria-label={`${ariaLabel}: ${selected?.label ?? "Sort"}`}
+        title={selected?.label ?? "Sort"}
         className={cn(
-          "h-5 min-w-0 max-w-[6.5rem] shrink-0 gap-0.5 border-0 bg-transparent px-1 py-0 text-[10px] font-medium leading-4 text-muted-foreground shadow-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring [&_svg]:size-2.5",
+          "inline-flex size-5 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring [&_[data-slot=select-value]]:sr-only",
           className,
         )}
       >
-        <SelectValue className="truncate">{selected?.label ?? "Sort"}</SelectValue>
+        <ListFilter className="size-3" />
+        <SelectValue />
       </SelectTrigger>
-      <SelectContent align="end" className="min-w-32">
+      <SelectContent
+        align="start"
+        side="right"
+        sideOffset={6}
+        className="z-[100] min-w-32"
+      >
         <SelectViewport className="p-0.5">
           {options.map((option) => (
             <SelectItem

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -15,8 +15,11 @@ function Select({
 function SelectTrigger({
   className,
   children,
+  hideChevron = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  hideChevron?: boolean;
+}) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
@@ -27,9 +30,11 @@ function SelectTrigger({
       {...props}
     >
       {children}
-      <SelectPrimitive.Icon asChild>
-        <ChevronDown className="size-3.5 opacity-70" />
-      </SelectPrimitive.Icon>
+      {hideChevron ? null : (
+        <SelectPrimitive.Icon asChild>
+          <ChevronDown className="size-3.5 opacity-70" />
+        </SelectPrimitive.Icon>
+      )}
     </SelectPrimitive.Trigger>
   );
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -283,6 +283,13 @@ export type ProjectBackgroundCommandsSummary = {
   runningCount: number;
 };
 
+export type BackgroundCommandPreflightResult = {
+  allowed: boolean;
+  risky: boolean;
+  categories: string[];
+  reason: string;
+};
+
 export type SkillSummary = {
   slug: string;
   name: string;

--- a/src/workspace/background-commands.ts
+++ b/src/workspace/background-commands.ts
@@ -8,6 +8,7 @@ import {
   buildBashEnvironment,
   evaluateBashCommandPolicy,
 } from "@/src/agent/command-policy";
+import type { ToolRiskCategory } from "@/src/agent/permissions";
 import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
 import {
   detectPackageManager,
@@ -31,6 +32,8 @@ const execFileAsync = promisify(execFile);
 
 const MAX_TAIL_BYTES = 64 * 1024;
 const RECENT_LIMIT = 20;
+const TERMINATION_GRACE_MS = 3_000;
+const TERMINAL_WAIT_MS = 10_000;
 
 const ACTIVE_STATUSES = new Set(["starting", "running", "stopping"]);
 const LOCALHOST_URL_RE =
@@ -58,6 +61,49 @@ export type StartBackgroundCommandInput =
 export type StartBackgroundCommandResult =
   | { ok: true; session: BackgroundCommandSession; streamToken: string }
   | { ok: false; error: string; status?: number };
+
+export type PreflightBackgroundCommandResult =
+  | {
+      ok: true;
+      allowed: boolean;
+      risky: boolean;
+      categories: ToolRiskCategory[];
+      reason: string;
+    }
+  | { ok: false; error: string; status?: number };
+
+export function preflightProjectBackgroundCommand(
+  projectRoot: string,
+  command: string,
+): PreflightBackgroundCommandResult {
+  ensureBootstrapped();
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Command is required.", status: 400 };
+  }
+
+  const root = ensureWorkspaceRootAt(projectRoot);
+  const policy = evaluateBashCommandPolicy(trimmed, { workspaceRoot: root });
+  const categories = [...policy.classification.categories];
+  if (!policy.allowed) {
+    return {
+      ok: true,
+      allowed: false,
+      risky: false,
+      categories,
+      reason: policy.reason,
+    };
+  }
+
+  const risky = categories.some((category) => category !== "read-only");
+  return {
+    ok: true,
+    allowed: true,
+    risky,
+    categories,
+    reason: policy.classification.reason,
+  };
+}
 
 export function listProjectBackgroundCommands(projectId: string): {
   running: BackgroundCommandSession[];
@@ -202,7 +248,8 @@ export async function stopProjectBackgroundCommand(
   updateBackgroundCommandSession(commandId, { status: "stopping" });
   backgroundCommandStream.emitEvent(commandId, { type: "status", status: "stopping" });
 
-  void terminateProcess(commandId);
+  await terminateProcess(commandId);
+  await waitForSessionTerminal(commandId);
 
   const updated = getBackgroundCommandSession(commandId);
   if (!updated) {
@@ -224,7 +271,10 @@ export async function restartProjectBackgroundCommand(
 
   if (ACTIVE_STATUSES.has(session.status)) {
     userStopRequestedSessions.add(commandId);
+    updateBackgroundCommandSession(commandId, { status: "stopping" });
+    backgroundCommandStream.emitEvent(commandId, { type: "status", status: "stopping" });
     await terminateProcess(commandId);
+    await waitForSessionTerminal(commandId);
   }
 
   const duplicate = getRunningBackgroundCommandForProject(projectId, session.command);
@@ -370,33 +420,121 @@ async function spawnSessionProcess(
 async function terminateProcess(sessionId: string): Promise<void> {
   const active = activeProcesses.get(sessionId);
   if (!active) {
-    const session = getBackgroundCommandSession(sessionId);
-    if (session && ACTIVE_STATUSES.has(session.status)) {
-      updateBackgroundCommandSession(sessionId, {
-        status: "stopped",
-        finishedAt: new Date(),
-        pid: null,
-        signal: "SIGKILL",
-      });
-      backgroundCommandStream.emitEvent(sessionId, {
-        type: "status",
-        status: "stopped",
-        exitCode: session.exitCode,
-        signal: "SIGKILL",
-        detectedUrls: session.detectedUrls,
-      });
-      backgroundCommandStream.endStream(sessionId);
-    }
-    userStopRequestedSessions.delete(sessionId);
+    forceFinalizeStoppedSession(sessionId);
     return;
   }
 
   const { subprocess } = active;
-  await killProcessTree(subprocess.pid, subprocess);
+  const session = getBackgroundCommandSession(sessionId);
+  await killProcessTreeGracefully(subprocess.pid, subprocess);
+
+  const exit = await readSubprocessExit(subprocess);
   activeProcesses.delete(sessionId);
+
+  if (session && ACTIVE_STATUSES.has(session.status)) {
+    finalizeProcess(sessionId, {
+      exitCode: exit.exitCode,
+      signal: exit.signal,
+      stdoutTail: session.stdoutTail,
+      stderrTail: session.stderrTail,
+      detectedUrls: session.detectedUrls,
+    });
+    return;
+  }
+
+  await waitForSessionTerminal(sessionId);
 }
 
-async function killProcessTree(
+function forceFinalizeStoppedSession(sessionId: string): void {
+  const session = getBackgroundCommandSession(sessionId);
+  if (!session || !ACTIVE_STATUSES.has(session.status)) {
+    userStopRequestedSessions.delete(sessionId);
+    return;
+  }
+
+  finalizeProcess(sessionId, {
+    exitCode: session.exitCode,
+    signal: toProcessSignal(session.signal),
+    stdoutTail: session.stdoutTail,
+    stderrTail: session.stderrTail,
+    detectedUrls: session.detectedUrls,
+  });
+}
+
+async function readSubprocessExit(
+  subprocess: ResultPromise,
+): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }> {
+  try {
+    const result = await Promise.race([
+      subprocess,
+      new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), TERMINATION_GRACE_MS);
+      }),
+    ]);
+    if (result && typeof result === "object" && "exitCode" in result) {
+      return {
+        exitCode: result.exitCode ?? null,
+        signal: result.signal ?? null,
+      };
+    }
+  } catch {
+    // Process was rejected or interrupted.
+  }
+
+  return { exitCode: null, signal: "SIGKILL" };
+}
+
+async function killProcessTreeGracefully(
+  pid: number | undefined,
+  subprocess: ResultPromise,
+): Promise<void> {
+  await sendGracefulTermination(pid, subprocess);
+  if (await waitForSubprocessExit(subprocess, TERMINATION_GRACE_MS)) {
+    return;
+  }
+
+  await sendForceTermination(pid, subprocess);
+  await waitForSubprocessExit(subprocess, TERMINATION_GRACE_MS);
+}
+
+async function sendGracefulTermination(
+  pid: number | undefined,
+  subprocess: ResultPromise,
+): Promise<void> {
+  if (pid !== undefined && process.platform === "win32") {
+    try {
+      await execFileAsync("taskkill", ["/PID", String(pid), "/T"], {
+        windowsHide: true,
+      });
+      return;
+    } catch {
+      // Fall through to subprocess.kill below.
+    }
+  }
+
+  if (pid !== undefined && process.platform !== "win32") {
+    try {
+      process.kill(-pid, "SIGTERM");
+      return;
+    } catch {
+      // Fall through to subprocess.kill below.
+    }
+  }
+
+  try {
+    subprocess.kill("SIGTERM");
+  } catch {
+    if (pid !== undefined && process.platform !== "win32") {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // Process already exited.
+      }
+    }
+  }
+}
+
+async function sendForceTermination(
   pid: number | undefined,
   subprocess: ResultPromise,
 ): Promise<void> {
@@ -433,6 +571,36 @@ async function killProcessTree(
   }
 }
 
+async function waitForSubprocessExit(
+  subprocess: ResultPromise,
+  timeoutMs: number,
+): Promise<boolean> {
+  return Promise.race([
+    subprocess
+      .then(() => true)
+      .catch(() => true),
+    new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(false), timeoutMs);
+    }),
+  ]);
+}
+
+async function waitForSessionTerminal(
+  sessionId: string,
+  timeoutMs = TERMINAL_WAIT_MS,
+): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const session = getBackgroundCommandSession(sessionId);
+    if (!session || !ACTIVE_STATUSES.has(session.status)) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
+  }
+}
+
 function finalizeProcess(
   sessionId: string,
   input: {
@@ -445,14 +613,21 @@ function finalizeProcess(
   },
 ): void {
   activeProcesses.delete(sessionId);
-  const userStopped = userStopRequestedSessions.has(sessionId);
-  userStopRequestedSessions.delete(sessionId);
 
   const current = getBackgroundCommandSession(sessionId);
   if (!current) {
+    userStopRequestedSessions.delete(sessionId);
     backgroundCommandStream.endStream(sessionId);
     return;
   }
+
+  if (!ACTIVE_STATUSES.has(current.status)) {
+    userStopRequestedSessions.delete(sessionId);
+    return;
+  }
+
+  const userStopped = userStopRequestedSessions.has(sessionId);
+  userStopRequestedSessions.delete(sessionId);
 
   if (
     userStopped ||
@@ -464,7 +639,7 @@ function finalizeProcess(
       finishedAt: current.finishedAt ?? new Date(),
       pid: null,
       exitCode: input.exitCode ?? current.exitCode,
-      signal: input.signal ?? current.signal ?? "SIGKILL",
+      signal: input.signal ?? current.signal ?? "SIGTERM",
       stdoutTail: input.stdoutTail || current.stdoutTail,
       stderrTail: input.stderrTail || current.stderrTail,
       detectedUrls: input.detectedUrls.length > 0 ? input.detectedUrls : current.detectedUrls,
@@ -473,7 +648,7 @@ function finalizeProcess(
       type: "status",
       status: "stopped",
       exitCode: input.exitCode ?? current.exitCode,
-      signal: input.signal ?? current.signal ?? "SIGKILL",
+      signal: input.signal ?? current.signal ?? "SIGTERM",
       detectedUrls:
         input.detectedUrls.length > 0 ? input.detectedUrls : current.detectedUrls,
     });
@@ -553,4 +728,8 @@ function capTail(output: string): string {
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+function toProcessSignal(signal: string | null): NodeJS.Signals | null {
+  return signal as NodeJS.Signals | null;
 }


### PR DESCRIPTION
## Summary
- Fix background command SSE streaming so logs continue through `running` and only close on terminal states
- Add custom-command preflight (`POST /api/projects/[id]/commands/preflight`) with risky-command confirmation dialog
- Graceful stop/restart: SIGTERM / `taskkill /T` first, force-kill fallback, and restart waits for prior session to finish
- Polish trace workspace tab spacing and branch/PR sort control (filter icon only, menu opens to the right)
- Mark live terminal output streaming complete in `ROADMAP.md`

Closes #112

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Start `pnpm dev` and verify logs continue after status becomes `running`
- [ ] Stop a running build; confirm status reaches `stopped` (not stuck on `stopping`) and polling stops
- [ ] Restart a command; confirm no duplicate active session
- [ ] Run risky custom command (`npm install`); confirm confirmation dialog appears
- [ ] Try forbidden command; confirm server rejects it
- [ ] Verify package script buttons still start directly
- [ ] Verify branch/PR filter icon and right-side sort menu in desktop viewport

Made with [Cursor](https://cursor.com)