### PR TITLE
feat(trace): token budget gate and timeline run trace UI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -134,6 +134,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 - [✔️] Add file tree and file search panel for the active project.
 - [✔️] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
+- [✔️] Add expandable run details for project last run.
 - [✔️] Add live terminal output streaming for long-running commands.
 - [✔️] Add cancellable background command sessions for dev servers and watchers.
 - [] Add command history with rerun support.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -30,7 +30,7 @@ import {
   type RunContextStatus,
 } from "@/src/agent/context";
 import { buildWorkspaceContextDigest } from "@/src/agent/workspace-context";
-import { budgetForProfile, capRunBudget } from "@/src/agent/run-budget";
+import { budgetForProfile, capRunBudget, applyTokenBudgetMultiplier, availableTokenBudgetMultipliers } from "@/src/agent/run-budget";
 import {
   buildToolApprovalMetadata,
   getNativeToolPermissionMetadata,
@@ -47,6 +47,7 @@ import {
   getActiveRunForSession,
   getMessagePersistenceConflict,
   getProject,
+  getRunById,
   getSession,
   getWorkspaceSettings,
   getToolCall,
@@ -54,6 +55,7 @@ import {
   saveMessagesIncrementally,
   sessionHasStoredMessages,
   setSessionProject,
+  setSessionTokenBudgetMultiplier,
   touchSession,
   updateRun,
   updateToolCall,
@@ -67,6 +69,11 @@ import { isSupportedModelId } from "@/src/lib/models";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import { redactText, redactValue } from "@/src/lib/redaction";
 import {
+  outputExitCode as sharedOutputExitCode,
+  summarizeToolInput,
+  summarizeToolOutput,
+} from "@/src/lib/tool-summaries";
+import {
   buildTokenUsageMetrics,
   openRouterCostFromMetadata,
   type TokenUsageMetrics,
@@ -75,8 +82,13 @@ import {
   collapseAssistantContinuationMessages,
   getApprovalMetadata,
   getAssistantTextDisplay,
+  getBudgetGateData,
+  getLatestOpenBudgetGate,
   getToolTraceEntries,
+  isBudgetGateDataPart,
   isRunDataPart,
+  priorSegmentUsage,
+  type AntonBudgetGateData,
 } from "@/src/lib/trace";
 import type {
   AntonActivityEvent,
@@ -102,6 +114,12 @@ const bodySchema = z.object({
   enabledMcpServerIds: z.array(z.string().min(1)).optional(),
   mode: z.enum(CHAT_MODES).optional(),
   thinkingEnabled: z.boolean().optional(),
+  extendTokenBudget: z
+    .object({
+      runId: z.string().min(1),
+      multiplier: z.union([z.literal(2), z.literal(3), z.literal(5)]),
+    })
+    .optional(),
   messages: z.array(z.unknown()).min(1),
 });
 
@@ -118,7 +136,10 @@ export async function POST(req: Request) {
   const { sessionId } = parsed.data;
   const uiMessages = parsed.data.messages as AntonUIMessage[];
   const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
-  const approvalContinuation = isToolApprovalContinuation(incomingHistory);
+  const budgetExtension = parsed.data.extendTokenBudget;
+  const isBudgetContinuation = budgetExtension !== undefined;
+  const approvalContinuation =
+    !isBudgetContinuation && isToolApprovalContinuation(incomingHistory);
   const mode = approvalContinuation
     ? "agent"
     : parsed.data.mode ?? DEFAULT_CHAT_MODE;
@@ -139,6 +160,38 @@ export async function POST(req: Request) {
 
   const existing = getSession(sessionId);
   const requestedProjectId = parsed.data.projectId ?? null;
+
+  if (isBudgetContinuation) {
+    const cappedRun = getRunById(budgetExtension.runId);
+    if (
+      !cappedRun ||
+      cappedRun.sessionId !== sessionId ||
+      cappedRun.finishReason !== "token_budget_limit"
+    ) {
+      return Response.json(
+        { error: "token budget continuation requires a capped run in this session" },
+        { status: 400 },
+      );
+    }
+    const lastAssistant = incomingHistory.findLast(
+      (message) => message.role === "assistant",
+    );
+    const openGate = lastAssistant
+      ? getLatestOpenBudgetGate(lastAssistant)
+      : undefined;
+    if (!openGate || openGate.runId !== budgetExtension.runId) {
+      return Response.json(
+        { error: "token budget gate is not open for the referenced run" },
+        { status: 400 },
+      );
+    }
+    if (!openGate.options.includes(budgetExtension.multiplier)) {
+      return Response.json(
+        { error: "requested token budget multiplier is not available" },
+        { status: 400 },
+      );
+    }
+  }
 
   if (existing) {
     if (
@@ -188,8 +241,10 @@ export async function POST(req: Request) {
     });
   } else {
     const conflict = getMessagePersistenceConflict(sessionId, incomingHistory, {
-      mutableTailCount: approvalContinuation ? 1 : 0,
-      allowExtraAssistantTail: approvalContinuation,
+      mutableTailCount:
+        approvalContinuation || isBudgetContinuation ? 1 : 0,
+      allowExtraAssistantTail:
+        approvalContinuation || isBudgetContinuation,
     });
     if (conflict) {
       return Response.json(
@@ -230,15 +285,37 @@ export async function POST(req: Request) {
     );
   }
 
-  const budget = capRunBudget(
+  const tokenBudgetMultiplier = isBudgetContinuation
+    ? Math.max(
+        existing?.tokenBudgetMultiplier ?? 1,
+        budgetExtension.multiplier,
+      )
+    : existing?.tokenBudgetMultiplier ?? 1;
+
+  if (isBudgetContinuation) {
+    setSessionTokenBudgetMultiplier(sessionId, tokenBudgetMultiplier);
+  }
+
+  const baseBudget = capRunBudget(
     budgetForProfile(profile),
     workspaceSettings.defaultMaxSteps,
   );
-  const preservation = modelContextPreservation(uiMessages, profile);
+  const budget = applyTokenBudgetMultiplier(baseBudget, tokenBudgetMultiplier);
+  const continuationAssistant = isBudgetContinuation
+    ? incomingHistory.findLast((message) => message.role === "assistant")
+    : undefined;
+  const priorUsage = continuationAssistant
+    ? priorSegmentUsage(continuationAssistant)
+    : { tokensUsed: 0, costUsd: 0 };
+  const preservation = modelContextPreservation(
+    uiMessages,
+    profile,
+    isBudgetContinuation,
+  );
   const preparedMessages = prepareMessagesForModel(
     uiMessages,
     profile,
-    preservation,
+    isBudgetContinuation,
   );
   const userText = latestUserText(uiMessages);
   const sessionContextDigest = mode === "chat"
@@ -303,6 +380,27 @@ export async function POST(req: Request) {
   const stream = createUIMessageStream<AntonUIMessage>({
     originalMessages: uiMessages,
     execute: async ({ writer }) => {
+      if (isBudgetContinuation && budgetExtension) {
+        const lastAssistant = uiMessages.findLast(
+          (message) => message.role === "assistant",
+        );
+        const existingGate = lastAssistant
+          ? getBudgetGateData(lastAssistant, budgetExtension.runId)
+          : undefined;
+        if (existingGate) {
+          const resolvedGate: AntonBudgetGateData = {
+            ...existingGate,
+            status: "resolved",
+            selectedMultiplier: budgetExtension.multiplier,
+          };
+          writer.write({
+            type: "data-budget-gate",
+            id: `${budgetExtension.runId}:budget-gate`,
+            data: resolvedGate,
+          });
+        }
+      }
+
       const trace = createTraceWriter({
         writer,
         runId,
@@ -310,6 +408,11 @@ export async function POST(req: Request) {
         startedAt,
         workspaceRoot: project?.localPath,
         responseKind: mode === "plan" ? "plan" : undefined,
+        tokenBudgetContext: {
+          baseMaxTotalTokens: baseBudget.maxTotalTokens,
+          tokenBudgetMultiplier,
+          priorTokensUsed: priorUsage.tokensUsed,
+        },
       });
       trace.writeRun("running");
       trace.noteContextBudget(contextBudget.report);
@@ -325,6 +428,9 @@ export async function POST(req: Request) {
           contextBudget: contextBudget.report,
           thinkingEnabled: parsed.data.thinkingEnabled ?? false,
           maxStepsCap: workspaceSettings.defaultMaxSteps,
+          tokenBudgetMultiplier,
+          priorTokensUsed: priorUsage.tokensUsed,
+          priorCostUsd: priorUsage.costUsd,
           permissionMode: parsed.data.permissionMode as
             | PermissionMode
             | undefined,
@@ -355,24 +461,28 @@ export async function POST(req: Request) {
             stepProviderMetadata,
             maxSteps,
             maxTotalTokens,
+            baseMaxTotalTokens,
             maxCostUsd,
+            priorTokensUsed,
             maxStepLimitReached,
             tokenBudgetReached,
             costBudgetReached,
             tokenAudit,
           }) => {
-            const budgetLimitReached =
-              maxStepLimitReached || tokenBudgetReached || costBudgetReached;
-            contextTerminalStatus = budgetLimitReached ? "error" : "completed";
+            const hardLimitReached = maxStepLimitReached || costBudgetReached;
+            contextTerminalStatus = hardLimitReached ? "error" : "completed";
             trace.finalize(
-              budgetLimitReached ? "error" : "completed",
+              tokenBudgetReached ? "completed" : hardLimitReached ? "error" : "completed",
               totalUsage,
               providerMetadata,
               finishReason,
               {
                 maxSteps,
                 maxTotalTokens,
+                baseMaxTotalTokens,
                 maxCostUsd,
+                priorTokensUsed,
+                tokenBudgetMultiplier,
                 maxStepLimitReached,
                 tokenBudgetReached,
                 costBudgetReached,
@@ -411,7 +521,9 @@ export async function POST(req: Request) {
       if (persistedMessages.length === 0) return;
       persistFinalToolApprovalStates(runId, messages);
       try {
-        const approvalContinuation = isToolApprovalContinuation(persistedMessages);
+        const approvalContinuation =
+          isToolApprovalContinuation(persistedMessages);
+        const budgetContinuation = isBudgetContinuation;
         const collapsedContinuations =
           persistedMessages.length < visibleMessages.length;
         saveMessagesIncrementally<AntonUIMessage>(
@@ -419,7 +531,7 @@ export async function POST(req: Request) {
           redactValue(persistedMessages) as AntonUIMessage[],
           {
             pruneExtraAssistantTail:
-              approvalContinuation || collapsedContinuations,
+              approvalContinuation || budgetContinuation || collapsedContinuations,
           },
         );
         contextCollector.persist({
@@ -456,7 +568,8 @@ function finalAssistantText(messages: AntonUIMessage[]): string | undefined {
 function prepareMessagesForModel(
   messages: AntonUIMessage[],
   profile: AgentRunProfile,
-  preservation = modelContextPreservation(messages, profile),
+  budgetContinuation: boolean,
+  preservation = modelContextPreservation(messages, profile, budgetContinuation),
 ): AntonUIMessage[] {
   return messages.flatMap((message) => {
     const source =
@@ -466,6 +579,7 @@ function prepareMessagesForModel(
     const parts = compactMessagePartsForModel(
       source,
       source.id === preservation.approvalContinuationMessageId,
+      source.id === preservation.budgetContinuationMessageId,
     )
       .filter(isModelContextPart)
       .map(stripProviderReplayMetadata);
@@ -477,13 +591,18 @@ function prepareMessagesForModel(
 function modelContextPreservation(
   messages: AntonUIMessage[],
   profile: AgentRunProfile,
+  budgetContinuation = false,
 ): {
   approvalContinuationMessageId?: string;
   acceptedPlanMessageId?: string;
+  budgetContinuationMessageId?: string;
 } {
   return {
     ...(isToolApprovalContinuation(messages)
       ? { approvalContinuationMessageId: messages.at(-1)?.id }
+      : {}),
+    ...(budgetContinuation
+      ? { budgetContinuationMessageId: messages.at(-1)?.id }
       : {}),
     ...(isAcceptedPlanProfile(profile)
       ? { acceptedPlanMessageId: messages.findLast(isPlanAssistantMessage)?.id }
@@ -494,10 +613,14 @@ function modelContextPreservation(
 function compactMessagePartsForModel(
   message: AntonUIMessage,
   approvalContinuation: boolean,
+  budgetContinuation: boolean,
 ): AntonUIMessage["parts"] {
   if (message.role !== "assistant") return message.parts;
   if (approvalContinuation) {
     return message.parts.filter(isApprovalContinuationContextPart);
+  }
+  if (budgetContinuation) {
+    return message.parts.filter(isBudgetContinuationContextPart);
   }
 
   const textParts = message.parts.filter((part) => {
@@ -664,6 +787,7 @@ function hasSubstantiveHistoryParts(message: AntonUIMessage): boolean {
     if (part.type === "text" || part.type === "reasoning") {
       return part.text.trim().length > 0;
     }
+    if (isBudgetGateDataPart(part)) return true;
     return part.type !== "step-start";
   });
 }
@@ -675,6 +799,21 @@ function isApprovalContinuationContextPart(
   return (
     part.state === "approval-responded" ||
     part.state === "output-denied"
+  );
+}
+
+function isBudgetContinuationContextPart(
+  part: AntonUIMessage["parts"][number],
+): boolean {
+  if (part.type === "text") {
+    return part.text.trim().length > 0;
+  }
+  if (!("state" in part) || typeof part.state !== "string") return false;
+  return (
+    part.state === "output-available" ||
+    part.state === "output-error" ||
+    part.state === "output-denied" ||
+    part.state === "approval-responded"
   );
 }
 
@@ -704,6 +843,7 @@ function createTraceWriter({
   startedAt,
   workspaceRoot,
   responseKind,
+  tokenBudgetContext,
 }: {
   writer: UIMessageStreamWriter<AntonUIMessage>;
   runId: string;
@@ -711,6 +851,11 @@ function createTraceWriter({
   startedAt: number;
   workspaceRoot?: string;
   responseKind?: "plan";
+  tokenBudgetContext: {
+    baseMaxTotalTokens: number;
+    tokenBudgetMultiplier: number;
+    priorTokensUsed: number;
+  };
 }) {
   let sequence = 0;
   let stepCount = 0;
@@ -857,33 +1002,19 @@ function createTraceWriter({
     }
   };
 
-  const summarizeInput = (input: unknown): string | undefined => {
-    if (typeof input !== "object" || input === null) return undefined;
-    const record = input as Record<string, unknown>;
-    for (const key of ["command", "path", "sourcePath", "pattern", "slug", "task"]) {
-      if (typeof record[key] === "string") return auditSummary(record[key]);
-    }
-    return undefined;
-  };
+  const summarizeInput = (input: unknown): string | undefined =>
+    summarizeToolInput(input, auditSummary);
 
-  const summarizeOutput = (output: unknown, error: unknown): string | undefined => {
-    const message = errorMessageOrUndefined(error);
-    if (message) return auditSummary(message);
-    if (typeof output !== "object" || output === null) return undefined;
-    const record = output as Record<string, unknown>;
-    for (const key of ["error", "failedReason", "path", "summary", "stdout"]) {
-      if (typeof record[key] === "string") return auditSummary(record[key]);
-    }
-    if (typeof record.exitCode === "number") return `exit ${record.exitCode}`;
-    return undefined;
-  };
+  const summarizeOutput = (
+    toolName: string,
+    output: unknown,
+    error: unknown,
+  ): string | undefined =>
+    summarizeToolOutput(toolName, output, error, auditSummary);
 
   const outputExitCode = (output: unknown): number | null => {
-    if (typeof output !== "object" || output === null) return null;
-    const exitCode = (output as Record<string, unknown>).exitCode;
-    return typeof exitCode === "number" && Number.isInteger(exitCode)
-      ? exitCode
-      : null;
+    const exitCode = sharedOutputExitCode(output);
+    return exitCode ?? null;
   };
 
   const toolError = (success: boolean, output: unknown, error: unknown): string | null => {
@@ -931,7 +1062,10 @@ function createTraceWriter({
     limits: {
       maxSteps?: number;
       maxTotalTokens?: number;
+      baseMaxTotalTokens?: number;
       maxCostUsd?: number;
+      priorTokensUsed?: number;
+      tokenBudgetMultiplier?: number;
       maxStepLimitReached?: boolean;
       tokenBudgetReached?: boolean;
       costBudgetReached?: boolean;
@@ -941,7 +1075,11 @@ function createTraceWriter({
   ) => {
     if (finalized) return;
     finalized = true;
-    settleRunningEvents(status === "completed" ? "completed" : "error");
+    if (limits.tokenBudgetReached) {
+      settleRunningEvents("completed");
+    } else {
+      settleRunningEvents(status === "completed" ? "completed" : "error");
+    }
     const finishedAt = Date.now();
     const durationMs = Math.max(0, finishedAt - startedAt);
     const inputTokens = usage?.inputTokens;
@@ -974,7 +1112,10 @@ function createTraceWriter({
       : limits.costBudgetReached
         ? "cost_budget_limit"
       : finishReason;
-    writeRun(status, {
+    const runStatus: AntonRunStatus = limits.tokenBudgetReached
+      ? "completed"
+      : status;
+    writeRun(runStatus, {
       finishedAt,
       durationMs,
       inputTokens,
@@ -1004,17 +1145,31 @@ function createTraceWriter({
       });
     }
     if (limits.tokenBudgetReached) {
-      startEvent({
-        id: `${runId}:token-budget:${sequence + 1}`,
-        kind: "error",
-        status: "error",
-        label: "Token budget reached",
-        summary: `Stopped after reaching the per-run token budget of ${limits.maxTotalTokens ?? "unknown"} tokens.`,
-        details: {
-          finishReason,
-          stepCount,
-          maxTotalTokens: limits.maxTotalTokens,
-        },
+      const segmentTokens = totalTokens ?? 0;
+      const tokensUsed =
+        (limits.priorTokensUsed ?? tokenBudgetContext.priorTokensUsed) +
+        segmentTokens;
+      const currentMultiplier =
+        limits.tokenBudgetMultiplier ?? tokenBudgetContext.tokenBudgetMultiplier;
+      const baseMaxTotalTokens =
+        limits.baseMaxTotalTokens ?? tokenBudgetContext.baseMaxTotalTokens;
+      const currentMaxTotalTokens =
+        limits.maxTotalTokens ??
+        baseMaxTotalTokens * Math.max(1, currentMultiplier);
+      const options = availableTokenBudgetMultipliers(currentMultiplier);
+      const gateData: AntonBudgetGateData = {
+        runId,
+        status: options.length > 0 ? "open" : "exhausted",
+        tokensUsed,
+        baseMaxTotalTokens,
+        currentMaxTotalTokens,
+        currentMultiplier,
+        options,
+      };
+      writer.write({
+        type: "data-budget-gate",
+        id: `${runId}:budget-gate`,
+        data: gateData,
       });
     }
     if (limits.costBudgetReached) {
@@ -1033,7 +1188,7 @@ function createTraceWriter({
       });
     }
     updateRun(runId, {
-      status,
+      status: runStatus,
       finishedAt: new Date(finishedAt),
       durationMs,
       inputTokens: inputTokens ?? null,
@@ -1183,7 +1338,7 @@ function createTraceWriter({
       const currentApproval = structuredApprovalDetails(current?.details?.approval);
       const toolCallUpdate: Parameters<typeof updateToolCall>[1] = {
         status,
-        outputSummary: summarizeOutput(event.output, event.error) ?? null,
+        outputSummary: summarizeOutput(event.toolName, event.output, event.error) ?? null,
         exitCode: outputExitCode(event.output),
         error,
         finishedAt: new Date(),

--- a/app/api/projects/[id]/runs/[runId]/route.ts
+++ b/app/api/projects/[id]/runs/[runId]/route.ts
@@ -1,0 +1,72 @@
+import {
+  getProject,
+  getRunById,
+  getRunContextSummaryByRunId,
+  getRunForProject,
+  listAssistantTurnRunIds,
+  listRunEventsForRun,
+  listToolApprovalsForRun,
+  listToolCallsForRun,
+} from "@/src/db/queries";
+import { serializeProjectRunDetails } from "@/src/lib/run-details-serializers";
+import { redactText } from "@/src/lib/redaction";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string; runId: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const { id, runId } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return Response.json({ error: "project not found" }, { status: 404 });
+  }
+  if (project.status !== "ready") {
+    return Response.json({ error: "project is not ready" }, { status: 400 });
+  }
+
+  const run = getRunForProject(project.id, runId);
+  if (!run) {
+    return Response.json({ error: "run not found" }, { status: 404 });
+  }
+
+  try {
+    const segmentRunIds = listAssistantTurnRunIds(run.sessionId, run.id);
+    const segmentRuns = segmentRunIds.flatMap((id) => {
+      const segmentRun = getRunById(id);
+      return segmentRun ? [segmentRun] : [];
+    });
+    const events = segmentRunIds
+      .flatMap((id) => listRunEventsForRun(id))
+      .sort((left, right) => {
+        const startedDelta =
+          left.startedAt.getTime() - right.startedAt.getTime();
+        if (startedDelta !== 0) return startedDelta;
+        return left.sequence - right.sequence;
+      });
+    const toolCalls = segmentRunIds.flatMap((id) => listToolCallsForRun(id));
+    const approvals = segmentRunIds.flatMap((id) =>
+      listToolApprovalsForRun(id),
+    );
+
+    const details = serializeProjectRunDetails({
+      run,
+      segmentRuns,
+      events,
+      toolCalls,
+      approvals,
+      context: getRunContextSummaryByRunId(run.id),
+    });
+    return Response.json({ details });
+  } catch (err) {
+    return Response.json(
+      { error: redactText(errorMessage(err)) },
+      { status: 500 },
+    );
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/app/api/projects/[id]/status/route.ts
+++ b/app/api/projects/[id]/status/route.ts
@@ -1,5 +1,10 @@
 import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
-import { getLastRunForProject, getProject } from "@/src/db/queries";
+import {
+  getLastRunForProject,
+  getProject,
+  getRunById,
+  listAssistantTurnRunIds,
+} from "@/src/db/queries";
 import { serializeProject } from "@/src/lib/api-serializers";
 import type { ProjectLastRunSummary, ProjectStatusSummary } from "@/src/lib/api-types";
 import { redactText } from "@/src/lib/redaction";
@@ -50,18 +55,38 @@ export async function GET(_req: Request, { params }: Ctx) {
 
 function serializeLastRun(run: Run | undefined): ProjectLastRunSummary | null {
   if (!run) return null;
+  const segments = listAssistantTurnRunIds(run.sessionId, run.id).flatMap(
+    (id) => {
+      const segment = getRunById(id);
+      return segment ? [segment] : [];
+    },
+  );
+  const metricsSource = segments.length > 0 ? segments : [run];
+
   return {
     runId: run.id,
     sessionId: run.sessionId,
     status: run.status,
     model: run.model,
-    startedAt: run.startedAt.getTime(),
+    startedAt: metricsSource[0]?.startedAt.getTime() ?? run.startedAt.getTime(),
     finishedAt: run.finishedAt?.getTime() ?? null,
-    durationMs: run.durationMs ?? null,
-    stepCount: run.stepCount ?? null,
-    totalTokens: run.totalTokens ?? null,
-    costUsd: run.costUsd ?? null,
+    durationMs: sumNullable(metricsSource.map((segment) => segment.durationMs)),
+    stepCount: sumNullable(metricsSource.map((segment) => segment.stepCount)),
+    totalTokens: sumNullable(metricsSource.map((segment) => segment.totalTokens)),
+    costUsd: sumNullable(metricsSource.map((segment) => segment.costUsd)),
+    finishReason: run.finishReason ?? null,
   };
+}
+
+function sumNullable(values: Array<number | null | undefined>): number | null {
+  let total = 0;
+  let seen = false;
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    total += value;
+    seen = true;
+  }
+  return seen ? total : null;
 }
 
 function errorMessage(err: unknown): string {

--- a/app/api/workspace-settings/route.ts
+++ b/app/api/workspace-settings/route.ts
@@ -15,7 +15,7 @@ const permissionModeSchema = z.enum(["default", "auto-review", "full-access"]);
 const patchSchema = z.object({
   localWorkspacesRoot: z.string().trim().min(1).nullable().optional(),
   defaultModel: z.string().trim().min(1).nullable().optional(),
-  defaultMaxSteps: z.number().int().min(1).max(50).nullable().optional(),
+  defaultMaxSteps: z.number().int().min(1).max(64).nullable().optional(),
   defaultPermissionMode: permissionModeSchema.nullable().optional(),
 });
 

--- a/components/features/chat/budget-gate-card.tsx
+++ b/components/features/chat/budget-gate-card.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Gauge } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type {
+  AntonBudgetGateData,
+  TokenBudgetMultiplierOption,
+} from "@/src/lib/trace";
+
+export function BudgetGateCard({
+  gate,
+  disabled,
+  onExtend,
+  compact = false,
+}: {
+  gate: AntonBudgetGateData;
+  disabled?: boolean;
+  onExtend: (runId: string, multiplier: TokenBudgetMultiplierOption) => void;
+  compact?: boolean;
+}) {
+  if (gate.status === "resolved") {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        Budget extended to {gate.selectedMultiplier ?? gate.currentMultiplier}x.
+      </p>
+    );
+  }
+
+  if (gate.status === "exhausted") {
+    return (
+      <p className="text-[11px] text-muted-foreground">
+        Budget exhausted at {gate.currentMultiplier}x (
+        {gate.tokensUsed.toLocaleString()} /{" "}
+        {gate.currentMaxTotalTokens.toLocaleString()} tokens).
+      </p>
+    );
+  }
+
+  if (compact) {
+    return (
+      <div className="grid grid-cols-[0.875rem_minmax(0,1fr)] gap-2 py-0.5">
+        <Gauge className="mt-0.5 size-3.5 shrink-0 text-amber-400" />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="text-[11px] text-foreground/85">
+              Token budget reached · {gate.tokensUsed.toLocaleString()} /{" "}
+              {gate.currentMaxTotalTokens.toLocaleString()} ({gate.currentMultiplier}x)
+            </span>
+            {gate.options.map((multiplier) => (
+              <Button
+                key={multiplier}
+                type="button"
+                size="xs"
+                variant="secondary"
+                disabled={disabled}
+                onClick={() => onExtend(gate.runId, multiplier)}
+              >
+                {multiplier}x
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="mt-2 overflow-hidden rounded-md border border-amber-400/30 bg-amber-400/5 ring-1 ring-amber-400/20">
+      <div className="flex items-start gap-2 px-3 py-2">
+        <Gauge className="mt-0.5 size-3.5 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-foreground">
+            Token budget reached
+          </div>
+          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+            Used {gate.tokensUsed.toLocaleString()} of{" "}
+            {gate.currentMaxTotalTokens.toLocaleString()} tokens at{" "}
+            {gate.currentMultiplier}x.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {gate.options.map((multiplier) => (
+              <Button
+                key={multiplier}
+                type="button"
+                size="xs"
+                variant="secondary"
+                disabled={disabled}
+                onClick={() => onExtend(gate.runId, multiplier)}
+              >
+                {multiplier}x
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/src/lib/models";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import type { PermissionMode } from "@/src/agent/permissions";
-import type { AntonUIMessage } from "@/src/lib/trace";
+import { isBudgetGateDataPart, type AntonUIMessage } from "@/src/lib/trace";
 import type { McpPreflightServer, McpServerSummary } from "@/src/lib/api-types";
 import { getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 import { useWorkspaceAgentDefaults } from "@/components/features/settings/use-workspace-agent-defaults";
@@ -49,6 +49,7 @@ import {
   useProjectSummary,
   useProjectsList,
   notifyOpenWorklogStatus,
+  notifyProjectStatusChanged,
 } from "@/components/features/projects/hooks";
 
 interface ChatProps {
@@ -203,6 +204,9 @@ function ChatSession({
         router.replace(`/s/${sessionId}`);
       }
       void refresh();
+      if (effectiveProjectId) {
+        notifyProjectStatusChanged(effectiveProjectId);
+      }
     },
   });
   const previousStatusRef = useRef(status);
@@ -401,6 +405,21 @@ function ChatSession({
     [addToolApprovalResponse, mode, requestBodyForMode],
   );
 
+  const extendTokenBudget = useCallback(
+    (runId: string, multiplier: 2 | 3 | 5) => {
+      if (lastNonEmptyMessagesRef.current.length > 0) {
+        setMessageDisplayOverride(lastNonEmptyMessagesRef.current);
+      }
+      void sendMessage(undefined, {
+        body: {
+          ...requestBodyForMode(mode),
+          extendTokenBudget: { runId, multiplier },
+        },
+      });
+    },
+    [mode, requestBodyForMode, sendMessage],
+  );
+
   const sendWithMcp = async (
     text: string,
     requestedMode: ChatMode = mode,
@@ -550,6 +569,7 @@ function ChatSession({
               void sendWithMcp("Implement plan", "agent");
             }}
             acceptPlanDisabled={streaming || !effectiveProjectId}
+            onExtendTokenBudget={extendTokenBudget}
           />
 
           {error && (
@@ -792,6 +812,7 @@ function hasVisibleMessageParts(message: AntonUIMessage): boolean {
     if (part.type === "text" || part.type === "reasoning") {
       return part.text.trim().length > 0;
     }
+    if (isBudgetGateDataPart(part)) return true;
     return part.type !== "step-start";
   });
 }

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -18,10 +18,13 @@ import {
 import {
   failedToolOutputMessage,
   getAssistantTextDisplay,
+  getLatestOpenBudgetGate,
   getRunData,
   getToolTraceEntries,
   hasPendingToolApproval,
+  messageHasBudgetLimit,
   type AntonUIMessage,
+  type TokenBudgetMultiplierOption,
 } from "@/src/lib/trace";
 import type { ChatMode } from "@/src/lib/chat-modes";
 import { cn } from "@/lib/utils";
@@ -36,6 +39,7 @@ import {
   type ResponseMetrics,
 } from "./message-metrics";
 import { RunTraceAccordion } from "@/components/features/run-trace/run-trace";
+import { isFailedToolOutput } from "@/components/features/run-trace/tool-display";
 import { getTodoTraceDisplay } from "@/components/features/run-trace/trace-data";
 import {
   HoverCard,
@@ -51,6 +55,10 @@ interface MessageListProps {
   onApproval: ChatAddToolApproveResponseFunction;
   onAcceptPlan: (plan: string) => void;
   acceptPlanDisabled?: boolean;
+  onExtendTokenBudget?: (
+    runId: string,
+    multiplier: TokenBudgetMultiplierOption,
+  ) => void;
 }
 
 export function MessageList({
@@ -61,6 +69,7 @@ export function MessageList({
   onApproval,
   onAcceptPlan,
   acceptPlanDisabled = false,
+  onExtendTokenBudget,
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const todoDisplay = useMemo(() => getTodoTraceDisplay(messages), [messages]);
@@ -83,6 +92,7 @@ export function MessageList({
   const latestMessage = messages.at(-1);
   const activeAssistantMessageId =
     latestMessage?.role === "assistant" ? latestMessage.id : undefined;
+  const streaming = status === "submitted" || status === "streaming";
 
   return (
     <div
@@ -106,6 +116,12 @@ export function MessageList({
             onApproval={onApproval}
             onAcceptPlan={onAcceptPlan}
             acceptPlanDisabled={acceptPlanDisabled}
+            showBudgetGate={
+              !streaming &&
+              message.id === activeAssistantMessageId &&
+              onExtendTokenBudget !== undefined
+            }
+            onExtendTokenBudget={onExtendTokenBudget}
           />
         ))}
       </div>
@@ -127,6 +143,8 @@ function MessageEvent({
   onApproval,
   onAcceptPlan,
   acceptPlanDisabled,
+  showBudgetGate,
+  onExtendTokenBudget,
 }: {
   message: AntonUIMessage;
   status: "submitted" | "streaming" | "ready" | "error";
@@ -135,6 +153,11 @@ function MessageEvent({
   onApproval: ChatAddToolApproveResponseFunction;
   onAcceptPlan: (plan: string) => void;
   acceptPlanDisabled: boolean;
+  showBudgetGate: boolean;
+  onExtendTokenBudget?: (
+    runId: string,
+    multiplier: TokenBudgetMultiplierOption,
+  ) => void;
 }) {
   const isUser = message.role === "user";
   const streaming = status === "submitted" || status === "streaming";
@@ -171,19 +194,23 @@ function MessageEvent({
     !pendingApproval &&
     assistantFinal &&
     responseKind !== "plan";
-  const showToolFailure =
-    !isUser &&
-    failedToolText.length > 0 &&
-    assistantText.length === 0 &&
-    !pendingApproval &&
-    assistantFinal &&
-    responseKind !== "plan";
   const showPlanCard =
     !isUser &&
     responseKind === "plan" &&
     responseText.length > 0 &&
     assistantFinal &&
     !streaming;
+  const openBudgetGate = showBudgetGate ? getLatestOpenBudgetGate(message) : undefined;
+  const suppressToolFailure =
+    openBudgetGate !== undefined || messageHasBudgetLimit(message);
+  const showToolFailure =
+    !isUser &&
+    !suppressToolFailure &&
+    failedToolText.length > 0 &&
+    assistantText.length === 0 &&
+    !pendingApproval &&
+    assistantFinal &&
+    responseKind !== "plan";
 
   return (
     <div
@@ -206,6 +233,9 @@ function MessageEvent({
             status={status}
             todoDisplay={todoDisplay}
             onApproval={onApproval}
+            onExtendTokenBudget={
+              showBudgetGate ? onExtendTokenBudget : undefined
+            }
           />
         )}
         {isUser ? (
@@ -323,15 +353,6 @@ function toolFailureFallbackText(message: AntonUIMessage): string {
     failed.errorText ??
     failedToolOutputMessage(failed.output) ??
     `${failed.name} failed`
-  );
-}
-
-function isFailedToolOutput(output: unknown): boolean {
-  return (
-    typeof output === "object" &&
-    output !== null &&
-    "ok" in output &&
-    (output as { ok: unknown }).ok === false
   );
 }
 

--- a/components/features/projects/hooks.ts
+++ b/components/features/projects/hooks.ts
@@ -12,6 +12,7 @@ import type {
 import { errorMessage, getJson } from "@/src/lib/client-fetch";
 
 export const PROJECT_GIT_CHANGED_EVENT = "anton-project-git-change";
+export const PROJECT_STATUS_CHANGED_EVENT = "anton-project-status-change";
 const PROJECT_GIT_STATUS_POLL_INTERVAL_MS = 120_000;
 
 export function useProjectsList(): {
@@ -147,6 +148,12 @@ export function useProjectGitStatus(
 
 export function notifyProjectGitChanged(projectId: string): void {
   window.dispatchEvent(new CustomEvent(PROJECT_GIT_CHANGED_EVENT, { detail: projectId }));
+}
+
+export function notifyProjectStatusChanged(projectId: string): void {
+  window.dispatchEvent(
+    new CustomEvent(PROJECT_STATUS_CHANGED_EVENT, { detail: projectId }),
+  );
 }
 
 const PROJECT_STATUS_POLL_INTERVAL_MS = 120_000;
@@ -293,12 +300,25 @@ function subscribeProjectStatus(
       });
     }
   };
+  const onProjectStatusChanged = (event: Event) => {
+    if (
+      event instanceof CustomEvent &&
+      typeof event.detail === "string" &&
+      event.detail === projectId
+    ) {
+      void loadProjectStatus(projectId, store, { background: true }).finally(() => {
+        scheduleProjectStatusPoll(projectId, store);
+      });
+    }
+  };
   window.addEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+  window.addEventListener(PROJECT_STATUS_CHANGED_EVENT, onProjectStatusChanged);
 
   return () => {
     store.listeners.delete(listener);
     store.subscribers = Math.max(0, store.subscribers - 1);
     window.removeEventListener(PROJECT_GIT_CHANGED_EVENT, onProjectGitChanged);
+    window.removeEventListener(PROJECT_STATUS_CHANGED_EVENT, onProjectStatusChanged);
     if (store.subscribers === 0) {
       clearProjectStatusPoll(store);
     }

--- a/components/features/run-trace/bash-command-bar.tsx
+++ b/components/features/run-trace/bash-command-bar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { CheckCircle2, Copy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function BashCommandBar({
+  command,
+  trailing,
+  className,
+}: {
+  command: string;
+  trailing?: ReactNode;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-1.5 border-b border-white/8 px-2 py-1",
+        className,
+      )}
+    >
+      <span className="shrink-0 select-none pt-px text-emerald-400">$</span>
+      <span className="min-w-0 flex-1 whitespace-pre-wrap break-all text-foreground/90">
+        {command}
+      </span>
+      <div className="flex shrink-0 items-center gap-0.5">
+        {trailing}
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          className="text-muted-foreground/70 hover:text-foreground"
+          aria-label="Copy command"
+          title="Copy command"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(command);
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1500);
+            } catch {
+              setCopied(false);
+            }
+          }}
+        >
+          {copied ? (
+            <CheckCircle2 className="size-2.5 text-emerald-400" />
+          ) : (
+            <Copy className="size-2.5" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/features/run-trace/live-terminal.tsx
+++ b/components/features/run-trace/live-terminal.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { BashCommandBar } from "./bash-command-bar";
 import { useBashStream } from "./use-bash-stream";
 import {
   renderAnsiToHtml,
@@ -60,15 +61,16 @@ export function LiveTerminalOutput({
         className,
       )}
     >
-      {command && (
-        <div className="flex items-start gap-1.5 border-b border-white/8 px-2 py-1">
-          <span className="shrink-0 select-none text-emerald-400">$</span>
-          <span className="text-foreground/90 whitespace-pre-wrap break-all flex-1">{command}</span>
-          {isRunning && (
-            <Loader2 className="size-3.5 animate-spin text-sky-400 shrink-0 mt-0.5" />
-          )}
-        </div>
-      )}
+      {command ? (
+        <BashCommandBar
+          command={command}
+          trailing={
+            isRunning ? (
+              <Loader2 className="mt-0.5 size-3.5 shrink-0 animate-spin text-sky-400" />
+            ) : undefined
+          }
+        />
+      ) : null}
       {hasOutput ? (
         <div className="max-h-64 overflow-y-auto px-3 py-2 space-y-1">
           {stdoutHtml && (

--- a/components/features/run-trace/project-run-details.tsx
+++ b/components/features/run-trace/project-run-details.tsx
@@ -1,0 +1,1217 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  FileText,
+  Hash,
+  Layers,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
+
+import { Markdown } from "@/components/features/chat/markdown";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Disclosure } from "@/components/shared/disclosure";
+import { ErrorBanner } from "@/components/shared/feedback-states";
+import { TerminalOutput } from "@/components/features/run-trace/terminal-output";
+import type { BashOutput } from "@/components/features/run-trace/terminal-utils";
+import {
+  formatDuration,
+  groupTimelineItemsByStep,
+  harnessStepDisplayNumber,
+  runIdFromEventId,
+  type TimelineStepGroup,
+} from "@/components/features/run-trace/trace-data";
+import {
+  StatusPill,
+  TraceLogBlock,
+  TraceThreadChildren,
+  TraceThreadHeaderRow,
+  TraceThreadNode,
+  TraceThreadRoot,
+  TraceTimelineRow,
+  timelineEventMeta,
+} from "@/components/features/run-trace/trace-timeline-ui";
+import {
+  contextCompositionSections,
+  contextCompositionTotalTokens,
+} from "@/src/lib/context-composition";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectRunDetailsApproval,
+  ProjectRunDetailsEvent,
+  ProjectRunDetailsSummary,
+  ProjectRunDetailsToolCall,
+} from "@/src/lib/api-types";
+import { getJson } from "@/src/lib/client-fetch";
+
+export function ProjectRunDetails({
+  projectId,
+  runId,
+  refreshToken,
+}: {
+  projectId: string;
+  runId: string;
+  refreshToken: number;
+}) {
+  const [details, setDetails] = useState<ProjectRunDetailsSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("trace");
+  const [copied, setCopied] = useState(false);
+
+  const fetchDetails = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getJson<{ details: ProjectRunDetailsSummary }>(
+        `/api/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}`,
+      );
+      setDetails(data.details);
+    } catch (err) {
+      setDetails(null);
+      setError(
+        err instanceof Error ? err.message : "Failed to load run details",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId, runId]);
+
+  useEffect(() => {
+    // Details load after the panel opens; parent key remounts on run changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchDetails();
+  }, [fetchDetails, refreshToken]);
+
+  if (loading && !details) {
+    return (
+      <div className="mt-3 flex items-center gap-2 border-l-2 border-border/60 pl-3 text-xs text-muted-foreground">
+        <Loader2 className="size-3.5 animate-spin text-sky-400" />
+        Loading run details...
+      </div>
+    );
+  }
+
+  if (error && !details) {
+    return (
+      <div className="mt-3 space-y-2 border-l-2 border-destructive/40 pl-3">
+        <ErrorBanner message={error} />
+        <Button
+          type="button"
+          size="xs"
+          variant="outline"
+          onClick={() => void fetchDetails()}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (!details) return null;
+
+  const { run, events, toolCalls, approvals, context } = details;
+  const traceEventCount = events.filter(
+    (event) =>
+      event.kind !== "approval" && !isStaleTokenBudgetTraceEvent(event),
+  ).length;
+
+  const copyRunSummary = async () => {
+    try {
+      await navigator.clipboard.writeText(buildRunSummaryText(details));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 space-y-3 border-l-2 border-border/50 pl-3">
+      {error ? (
+        <div className="space-y-2">
+          <ErrorBanner message={error} />
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => void fetchDetails()}
+          >
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      <RunMetaStrip
+        run={run}
+        segmentCount={details.segmentCount}
+        copied={copied}
+        onCopy={() => void copyRunSummary()}
+      />
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0 gap-0">
+        <div className="border-b border-border pb-1.5">
+          <TabsList className="w-full gap-1">
+            <TabsTrigger value="usage" className="h-6 flex-1 px-2 py-0 text-[11px]">
+              Usage
+            </TabsTrigger>
+            <TabsTrigger value="trace" className="h-6 flex-1 px-2 py-0 text-[11px]">
+              Trace
+              {traceEventCount > 0 ? (
+                <span className="ml-1 font-mono text-[9px] text-muted-foreground">
+                  {traceEventCount}
+                </span>
+              ) : null}
+            </TabsTrigger>
+            <TabsTrigger value="context" className="h-6 flex-1 px-2 py-0 text-[11px]">
+              Context
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="usage" className="m-0 pt-2">
+          <TokenUsagePanel run={run} />
+        </TabsContent>
+
+        <TabsContent value="trace" className="m-0 pt-2">
+          {traceEventCount === 0 ? (
+            <EmptyHint>No events recorded.</EmptyHint>
+          ) : (
+            <TraceTimeline
+              run={run}
+              segmentCount={details.segmentCount}
+              events={events}
+              toolCalls={toolCalls}
+              approvals={approvals}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="context" className="m-0 pt-2">
+          {context ? (
+            <ContextPanel
+              context={context}
+              toolCalls={toolCalls}
+              hideTools={toolCalls.length > 0}
+            />
+          ) : (
+            <EmptyHint>No context summary persisted for this run.</EmptyHint>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {loading ? (
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <RefreshCw className="size-3 animate-spin" />
+          Refreshing...
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RunMetaStrip({
+  run,
+  segmentCount,
+  copied,
+  onCopy,
+}: {
+  run: ProjectRunDetailsSummary["run"];
+  segmentCount?: number;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
+      {run.provider ? (
+        <MetaChip>{run.provider}</MetaChip>
+      ) : null}
+      {run.finishReason ? (
+        <MetaChip accent="muted">finish: {run.finishReason}</MetaChip>
+      ) : null}
+      {run.stepCount !== null ? (
+        <MetaChip accent="muted">
+          {run.stepCount} steps
+          {segmentCount && segmentCount > 1 ? ` · ${segmentCount} segments` : ""}
+        </MetaChip>
+      ) : null}
+      <Button
+        type="button"
+        size="xs"
+        variant="ghost"
+        className="ml-auto h-6 gap-1 px-2 text-[10px] text-muted-foreground"
+        onClick={onCopy}
+      >
+        {copied ? (
+          <Check className="size-3 text-emerald-400" />
+        ) : (
+          <Copy className="size-3" />
+        )}
+        {copied ? "Copied" : "Copy summary"}
+      </Button>
+    </div>
+  );
+}
+
+function MetaChip({
+  children,
+  accent = "default",
+}: {
+  children: ReactNode;
+  accent?: "default" | "muted";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 font-mono ring-1",
+        accent === "default"
+          ? "bg-secondary/60 text-foreground/85 ring-border/70"
+          : "bg-background/40 text-muted-foreground ring-border/50",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function TraceTimeline({
+  run,
+  segmentCount,
+  events,
+  toolCalls,
+  approvals,
+}: {
+  run: ProjectRunDetailsSummary["run"];
+  segmentCount?: number;
+  events: ProjectRunDetailsEvent[];
+  toolCalls: ProjectRunDetailsToolCall[];
+  approvals: ProjectRunDetailsApproval[];
+}) {
+  const [expandedEventId, setExpandedEventId] = useState<string | null>(null);
+  const displayEvents = events.filter(
+    (event) =>
+      event.kind !== "approval" && !isStaleTokenBudgetTraceEvent(event),
+  );
+
+  const runGroups = buildStatusTraceRunGroups(displayEvents, run, segmentCount);
+  const runMeta = timelineEventMeta("progress", run.status === "error" ? "error" : "completed");
+  const stepMeta = timelineEventMeta("step", "completed");
+
+  return (
+    <TraceThreadRoot className="space-y-2">
+      {runGroups.map((group) => (
+        <TraceThreadNode key={group.runId}>
+          <TraceThreadHeaderRow
+            icon={Layers}
+            iconClass={runMeta.iconClass}
+            dotClass={runMeta.dotClass}
+            label={group.label}
+            durationMs={group.durationMs}
+            status={run.status === "error" ? "error" : "completed"}
+          />
+          <TraceThreadChildren>
+            {group.steps.map((step) => (
+              <TraceThreadNode key={step.id}>
+                <TraceThreadHeaderRow
+                  icon={Hash}
+                  iconClass={stepMeta.iconClass}
+                  dotClass={stepMeta.dotClass}
+                  label={step.label}
+                  durationMs={step.durationMs}
+                  subdued
+                />
+                {step.items.length > 0 ? (
+                  <TraceThreadChildren>
+                    {step.items.map((event) => {
+                      const toolCall = findToolCallForEvent(
+                        event,
+                        toolCalls,
+                        group.runId,
+                      );
+                      const approval = toolCall
+                        ? findApprovalForToolCall(toolCall, approvals)
+                        : undefined;
+                      const expandable =
+                        event.kind === "tool" && toolCall !== undefined;
+                      const expanded = expandedEventId === event.id;
+
+                      return (
+                        <TraceThreadNode key={event.id}>
+                          <TraceTimelineRow
+                            kind={event.kind}
+                            status={event.status}
+                            label={event.label}
+                            durationMs={event.durationMs}
+                            expandable={expandable}
+                            expanded={expanded}
+                            summary={
+                              !expandable ? (event.summary ?? undefined) : undefined
+                            }
+                            onToggle={
+                              expandable
+                                ? () =>
+                                    setExpandedEventId((current) =>
+                                      current === event.id ? null : event.id,
+                                    )
+                                : undefined
+                            }
+                          >
+                            {expandable && expanded && toolCall ? (
+                              <ToolCallExpandPanel
+                                toolCall={toolCall}
+                                approval={approval}
+                              />
+                            ) : null}
+                          </TraceTimelineRow>
+                        </TraceThreadNode>
+                      );
+                    })}
+                  </TraceThreadChildren>
+                ) : null}
+              </TraceThreadNode>
+            ))}
+          </TraceThreadChildren>
+        </TraceThreadNode>
+      ))}
+    </TraceThreadRoot>
+  );
+}
+
+type StatusTraceTimelineEvent = Omit<ProjectRunDetailsEvent, "durationMs"> & {
+  durationMs?: number;
+};
+
+function buildStatusTraceRunGroups(
+  events: ProjectRunDetailsEvent[],
+  run: ProjectRunDetailsSummary["run"],
+  segmentCount?: number,
+): Array<{
+  runId: string;
+  label: string;
+  durationMs?: number;
+  steps: TimelineStepGroup<StatusTraceTimelineEvent>[];
+}> {
+  const byRunId = new Map<string, ProjectRunDetailsEvent[]>();
+  for (const event of events) {
+    const id = runIdFromEventId(event.id);
+    const bucket = byRunId.get(id) ?? [];
+    bucket.push(event);
+    byRunId.set(id, bucket);
+  }
+
+  const runIds = Array.from(byRunId.keys());
+  const segmentTotal = Math.max(segmentCount ?? 1, runIds.length);
+
+  return runIds.map((runId, index) => {
+    const segmentEvents = byRunId.get(runId) ?? [];
+    const segmentLabel =
+      segmentTotal > 1
+        ? `Segment ${index + 1}/${segmentTotal}${index > 0 ? " · continued" : ""}`
+        : "Run";
+    const finishLabel =
+      index === runIds.length - 1 && run.finishReason
+        ? run.finishReason.replace(/_/g, " ")
+        : undefined;
+    const label = [segmentLabel, finishLabel]
+      .filter((part): part is string => part !== undefined)
+      .join(" · ");
+
+    return {
+      runId,
+      label,
+      durationMs:
+        index === runIds.length - 1 ? (run.durationMs ?? undefined) : undefined,
+      steps: groupTimelineItemsByStep<StatusTraceTimelineEvent>(
+        segmentEvents.map((event) => ({
+          ...event,
+          durationMs: event.durationMs ?? undefined,
+          startedAt: event.startedAt,
+        })),
+      ),
+    };
+  });
+}
+
+function PermissionLabel({ label }: { label: string }) {
+  return (
+    <span className="rounded bg-secondary/60 px-1 py-px font-mono text-[9px] text-muted-foreground ring-1 ring-border/50">
+      {label}
+    </span>
+  );
+}
+
+function ToolCallExpandPanel({
+  toolCall,
+  approval,
+}: {
+  toolCall: ProjectRunDetailsToolCall;
+  approval: ProjectRunDetailsApproval | undefined;
+}) {
+  const errored = toolCall.status === "error";
+  const denied = toolCall.status === "denied";
+  const showApproval = approval !== undefined;
+  const showIo = Boolean(
+    toolCall.inputSummary || toolCall.outputSummary || toolCall.error,
+  );
+
+  return (
+    <div
+      className={cn(
+        "mt-1.5 rounded-md border border-border/50 bg-background/30 px-2 py-1.5 text-[10px]",
+        errored && "border-destructive/25 bg-destructive/[0.03]",
+        denied && "border-border/40 bg-secondary/15",
+      )}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <span className="inline-flex min-w-0 items-center gap-1.5 font-mono text-[10px] font-medium text-foreground/90">
+          {toolCall.toolName}
+          {toolCall.permissionLabel ? (
+            <PermissionLabel label={toolCall.permissionLabel} />
+          ) : null}
+        </span>
+        {toolCall.status !== "completed" ? (
+          <StatusPill status={toolCall.status} />
+        ) : null}
+        {toolCall.stepNumber !== null ? (
+          <span className="text-[10px] text-muted-foreground">
+            step {harnessStepDisplayNumber(toolCall.stepNumber)}
+          </span>
+        ) : null}
+        {toolCall.approvalDecision &&
+        (toolCall.approvalDecision === "pending" ||
+          toolCall.approvalDecision === "denied") ? (
+          <StatusPill status={toolCall.approvalDecision} />
+        ) : null}
+        {toolCall.exitCode !== null && toolCall.exitCode !== 0 ? (
+          <span className="font-mono text-[10px] text-muted-foreground">
+            exit {toolCall.exitCode}
+          </span>
+        ) : null}
+      </div>
+
+      {showApproval && approval ? (
+        <div className="mt-1.5 space-y-1 border-t border-border/30 pt-1.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <ShieldCheck className="size-3 shrink-0 text-sky-400/90" />
+            <span className="min-w-0 flex-1 truncate text-[10px] font-medium text-foreground/85">
+              {approval.title}
+            </span>
+            {approval.decision === "pending" || approval.decision === "denied" ? (
+              <StatusPill status={approval.decision} />
+            ) : null}
+          </div>
+          <p className="break-words text-[10px] leading-snug text-muted-foreground">
+            {approval.summary}
+          </p>
+          {approval.riskCategories.filter(
+            (category) => category !== toolCall.permissionLabel,
+          ).length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {approval.riskCategories
+                .filter((category) => category !== toolCall.permissionLabel)
+                .map((category) => (
+                  <span
+                    key={category}
+                    className="rounded bg-amber-400/10 px-1.5 py-px font-mono text-[9px] text-amber-400 ring-1 ring-amber-400/20"
+                  >
+                    {category}
+                  </span>
+                ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {showIo ? (
+        <div className="mt-1.5 border-t border-border/30 pt-1.5">
+          <ToolCallIoPanel toolCall={toolCall} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolCallIoPanel({ toolCall }: { toolCall: ProjectRunDetailsToolCall }) {
+  if (toolCall.toolName === "bash" && toolCall.inputSummary) {
+    return (
+      <TerminalOutput
+        command={toolCall.inputSummary}
+        output={bashOutputFromToolCall(toolCall)}
+        className="text-[10px]"
+      />
+    );
+  }
+
+  const outputText =
+    toolCall.outputSummary &&
+    toolCall.outputSummary !== toolCall.error
+      ? toolCall.outputSummary
+      : undefined;
+
+  return (
+    <div className="space-y-1.5">
+      {toolCall.inputSummary ? (
+        <TraceLogBlock title="Input">{toolCall.inputSummary}</TraceLogBlock>
+      ) : null}
+      {outputText ? (
+        <TraceLogBlock title="Output">{outputText}</TraceLogBlock>
+      ) : null}
+      {toolCall.error ? (
+        <TraceLogBlock title="Error" tone="error">
+          {toolCall.error}
+        </TraceLogBlock>
+      ) : null}
+    </div>
+  );
+}
+
+function bashOutputFromToolCall(
+  toolCall: ProjectRunDetailsToolCall,
+): BashOutput {
+  const failedReason = parseFailedReason(
+    toolCall.outputSummary ?? toolCall.error ?? undefined,
+  );
+  const stdout =
+    toolCall.outputSummary &&
+    toolCall.outputSummary !== toolCall.error &&
+    failedReason === undefined
+      ? toolCall.outputSummary
+      : undefined;
+  const stderr =
+    toolCall.error &&
+    toolCall.error !== failedReason &&
+    !isFailedReasonLabel(toolCall.error)
+      ? toolCall.error
+      : undefined;
+
+  return {
+    ...(stdout ? { stdout } : {}),
+    ...(stderr ? { stderr } : {}),
+    exitCode: toolCall.exitCode,
+    ...(failedReason === "timeout" ? { timedOut: true, failedReason } : {}),
+    ...(failedReason && failedReason !== "timeout" ? { failedReason } : {}),
+  };
+}
+
+function parseFailedReason(
+  value: string | undefined,
+): BashOutput["failedReason"] {
+  if (!value) return undefined;
+  if (value === "timeout" || value === "killed" || value === "max_buffer") {
+    return value;
+  }
+  if (value === "error") return "error";
+  return undefined;
+}
+
+function isFailedReasonLabel(value: string): boolean {
+  return (
+    value === "timeout" ||
+    value === "killed" ||
+    value === "max_buffer" ||
+    value === "error"
+  );
+}
+
+function findToolCallForEvent(
+  event: Pick<ProjectRunDetailsEvent, "toolCallId">,
+  toolCalls: ProjectRunDetailsToolCall[],
+  runId: string,
+): ProjectRunDetailsToolCall | undefined {
+  if (!event.toolCallId) return undefined;
+  return (
+    toolCalls.find((call) => call.toolCallId === event.toolCallId) ??
+    toolCalls.find((call) => call.id === `${runId}:tool:${event.toolCallId}`) ??
+    toolCalls.find((call) => call.id.endsWith(`:tool:${event.toolCallId}`))
+  );
+}
+
+function isStaleTokenBudgetTraceEvent(event: ProjectRunDetailsEvent): boolean {
+  return (
+    event.kind === "progress" &&
+    event.label === "Token budget reached" &&
+    event.status === "waiting"
+  );
+}
+
+function findApprovalForToolCall(
+  toolCall: ProjectRunDetailsToolCall,
+  approvals: ProjectRunDetailsApproval[],
+): ProjectRunDetailsApproval | undefined {
+  return approvals.find((approval) => approval.toolCallId === toolCall.id);
+}
+
+function TokenUsagePanel({
+  run,
+}: {
+  run: ProjectRunDetailsSummary["run"];
+}) {
+  const usage = run.tokenUsage;
+  const composition = run.contextComposition;
+  const sections = composition
+    ? contextCompositionSections(composition)
+    : [];
+  const compositionTotal = composition
+    ? contextCompositionTotalTokens(composition)
+    : 0;
+  const providerInput = run.inputTokens ?? usage?.rawInputTokens;
+
+  const billingNotes = [
+    usage?.cachedInputTokens !== undefined && usage.cachedInputTokens > 0
+      ? `${formatCompactCount(usage.cachedInputTokens)} cached read`
+      : null,
+    usage?.reasoningTokens !== undefined && usage.reasoningTokens > 0
+      ? `${formatCompactCount(usage.reasoningTokens)} reasoning`
+      : null,
+    usage?.providerEffectiveTokens !== undefined
+      ? `${formatCompactCount(usage.providerEffectiveTokens)} provider billed`
+      : null,
+  ].filter((note): note is string => note !== null);
+
+  return (
+    <div className="space-y-3">
+      {sections.length > 0 ? (
+        <section className="space-y-2">
+          <div className="flex items-baseline justify-between gap-2">
+            <h4 className="text-[11px] font-medium text-foreground/90">
+              Context
+            </h4>
+            <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+              ~{formatCompactCount(compositionTotal)} tokens
+            </span>
+          </div>
+
+          {compositionTotal > 0 ? (
+            <div className="flex h-2 overflow-hidden rounded-full bg-muted/30">
+              {sections.map((section) => (
+                <div
+                  key={section.key}
+                  className={contextSectionColor(section.key)}
+                  style={{
+                    width: `${(section.tokens / compositionTotal) * 100}%`,
+                  }}
+                  title={`${section.label}: ${formatCompactCount(section.tokens)}`}
+                />
+              ))}
+            </div>
+          ) : null}
+
+          <ul className="space-y-1">
+            {sections.map((section) => (
+              <li
+                key={section.key}
+                className="flex min-w-0 items-center gap-2 text-[11px]"
+              >
+                <span
+                  className={cn(
+                    "size-2 shrink-0 rounded-sm",
+                    contextSectionColor(section.key),
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate text-foreground/85">
+                  {section.label}
+                </span>
+                <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
+                  {formatCompactCount(section.tokens)}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="text-[10px] leading-snug text-muted-foreground">
+            Estimated from prompt size at run start. Provider-reported input was{" "}
+            {formatCount(providerInput)} across all steps
+            {run.stepCount !== null ? ` (${run.stepCount} steps)` : ""}.
+          </p>
+        </section>
+      ) : (
+        <EmptyHint>
+          Context breakdown is available for new runs. Older runs only store
+          provider totals.
+        </EmptyHint>
+      )}
+
+      {billingNotes.length > 0 ? (
+        <section className="space-y-1 border-t border-border/30 pt-2">
+          <h4 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Billing notes
+          </h4>
+          <ul className="space-y-0.5 text-[10px] text-muted-foreground">
+            {billingNotes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function contextSectionColor(key: string): string {
+  switch (key) {
+    case "system":
+      return "bg-zinc-400/80";
+    case "tools":
+      return "bg-violet-500/75";
+    case "memory":
+      return "bg-emerald-500/70";
+    case "skills":
+      return "bg-orange-400/75";
+    case "mcp":
+      return "bg-fuchsia-400/70";
+    case "profile":
+      return "bg-sky-500/70";
+    case "prior-context":
+      return "bg-pink-400/70";
+    case "conversation":
+      return "bg-amber-600/65";
+    default:
+      return "bg-muted-foreground/50";
+  }
+}
+
+function formatCompactCount(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  if (value >= 1000) {
+    const compact = value / 1000;
+    return compact >= 10
+      ? `${Math.round(compact)}K`
+      : `${compact.toFixed(1).replace(/\.0$/, "")}K`;
+  }
+  return value.toLocaleString();
+}
+
+function ContextPanel({
+  context,
+  toolCalls,
+  hideTools = false,
+}: {
+  context: NonNullable<ProjectRunDetailsSummary["context"]>;
+  toolCalls: ProjectRunDetailsToolCall[];
+  hideTools?: boolean;
+}) {
+  const parsed = parseContextSummary(context.summary);
+  const toolPaths = collectToolCallPaths(toolCalls);
+  const visibleFiles = context.files.filter(
+    (file) => !isPathCoveredByToolCalls(file.path, toolPaths),
+  );
+  const visibleFacts = dedupeContextFacts(
+    context.facts,
+    context.summary,
+    parsed.finalAnswer,
+  );
+  const commandItems = context.commands
+    .map((command) => {
+      const status = command.ok
+        ? "ok"
+        : command.timedOut
+          ? "timeout"
+          : "failed";
+      const exit =
+        command.exitCode !== null ? ` · exit ${command.exitCode}` : "";
+      return `${command.command} (${status}${exit})`;
+    })
+    .filter((item) => !isCommandCoveredByToolCalls(item, toolCalls));
+
+  return (
+    <div className="space-y-2.5">
+      {parsed.metaLines.length > 0 ? (
+        <div className="space-y-0.5 text-[10px] text-muted-foreground">
+          {parsed.metaLines.map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </div>
+      ) : null}
+
+      {parsed.finalAnswer ? (
+        <Disclosure
+          defaultOpen={false}
+          trigger={({ open }) => (
+            <span className="inline-flex max-w-full items-center gap-1 text-[10px] font-medium text-foreground/85 hover:text-foreground">
+              Final answer
+              {open ? (
+                <ChevronDown className="size-3 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="size-3 text-muted-foreground" />
+              )}
+            </span>
+          )}
+        >
+          <div className="mt-1.5 rounded-md border border-border/50 bg-background/25 px-2.5 py-2">
+            <Markdown className="text-[10px] leading-relaxed text-foreground/85 [&_p]:text-[10px] [&_li]:text-[10px] [&_h1]:text-xs [&_h2]:text-[11px] [&_h3]:text-[11px] [&_code]:text-[9px] [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto">
+              {parsed.finalAnswer}
+            </Markdown>
+          </div>
+        </Disclosure>
+      ) : null}
+
+      {visibleFiles.length > 0 ? (
+        <ContextGroup title="Files touched" count={visibleFiles.length}>
+          <ul className="space-y-0.5 border-l border-border/50 pl-2.5">
+            {visibleFiles.map((file) => (
+              <li
+                key={`${file.action}-${file.path}`}
+                className="flex min-w-0 items-start gap-1.5 break-words font-mono text-[10px] leading-snug text-foreground/80"
+              >
+                <FileText className="mt-0.5 size-2.5 shrink-0 text-muted-foreground" />
+                <span>
+                  <span className="text-muted-foreground">{file.action}</span>{" "}
+                  {file.path}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ContextGroup>
+      ) : null}
+
+      {visibleFacts.length > 0 ? (
+        <CollapsibleContextGroup title="Facts" items={visibleFacts} structured />
+      ) : null}
+
+      {commandItems.length > 0 ? (
+        <CollapsibleContextGroup title="Commands" items={commandItems} />
+      ) : null}
+
+      {!hideTools && context.tools.length > 0 ? (
+        <CollapsibleContextGroup
+          title="Tools"
+          items={context.tools.map((tool) => {
+            const parts = [tool.name, tool.status];
+            if (tool.input) parts.push(`in: ${tool.input}`);
+            if (tool.output) parts.push(`out: ${tool.output}`);
+            if (tool.error) parts.push(tool.error);
+            return parts.join(" · ");
+          })}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function CollapsibleContextGroup({
+  title,
+  items,
+  structured = false,
+}: {
+  title: string;
+  items: string[];
+  structured?: boolean;
+}) {
+  if (items.length <= 3) {
+    return (
+      <ContextGroup title={title} count={items.length}>
+        {structured ? (
+          <StructuredFactList facts={items} />
+        ) : (
+          <ContextItemList items={items} />
+        )}
+      </ContextGroup>
+    );
+  }
+
+  return (
+    <Disclosure
+      trigger={({ open }) => (
+        <span className="inline-flex max-w-full items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground/80">
+          {title}
+          <span className="rounded-full bg-secondary px-1.5 py-px font-mono text-[9px] normal-case">
+            {items.length}
+          </span>
+          {open ? (
+            <ChevronDown className="size-3" />
+          ) : (
+            <ChevronRight className="size-3" />
+          )}
+        </span>
+      )}
+    >
+      {structured ? (
+        <StructuredFactList facts={items} />
+      ) : (
+        <ContextItemList items={items} />
+      )}
+    </Disclosure>
+  );
+}
+
+function ContextGroup({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+        {count !== undefined ? (
+          <span className="rounded-full bg-secondary px-1.5 py-px font-mono text-[9px] normal-case">
+            {count}
+          </span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ContextItemList({ items }: { items: string[] }) {
+  return (
+    <ul className="space-y-1 border-l border-border/50 pl-2.5">
+      {items.map((item, index) => (
+        <li
+          key={`${index}-${item.slice(0, 24)}`}
+          className="break-words font-mono text-[10px] leading-snug text-muted-foreground/90"
+        >
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function StructuredFactList({ facts }: { facts: string[] }) {
+  return (
+    <ul className="space-y-1.5 border-l border-border/50 pl-2.5">
+      {facts.map((fact, index) => (
+        <StructuredFactRow key={`${index}-${fact.slice(0, 24)}`} fact={fact} />
+      ))}
+    </ul>
+  );
+}
+
+function StructuredFactRow({ fact }: { fact: string }) {
+  const colonIndex = fact.indexOf(":");
+  if (colonIndex > 0 && colonIndex < 48) {
+    const label = fact.slice(0, colonIndex).trim();
+    const value = fact.slice(colonIndex + 1).trim();
+    const chips = value.split(",").map((part) => part.trim()).filter(Boolean);
+
+    if (chips.length > 1 && chips.length <= 24) {
+      return (
+        <li className="space-y-1">
+          <div className="text-[10px] font-medium text-muted-foreground">
+            {label}
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {chips.map((chip) => (
+              <span
+                key={`${label}-${chip}`}
+                className="rounded bg-secondary/60 px-1.5 py-px font-mono text-[9px] text-foreground/80 ring-1 ring-border/40"
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+        </li>
+      );
+    }
+
+    return (
+      <li className="break-words text-[10px] leading-snug">
+        <span className="font-medium text-muted-foreground">{label}:</span>{" "}
+        <span className="font-mono text-foreground/85">{value}</span>
+      </li>
+    );
+  }
+
+  return (
+    <li className="break-words font-mono text-[10px] leading-snug text-muted-foreground/90">
+      {fact}
+    </li>
+  );
+}
+
+function parseContextSummary(summary: string): {
+  metaLines: string[];
+  finalAnswer: string | null;
+} {
+  const lines = summary.split("\n");
+  const metaLines: string[] = [];
+  const answerLines: string[] = [];
+  let inFinalAnswer = false;
+
+  for (const line of lines) {
+    if (line.startsWith("Final answer:")) {
+      inFinalAnswer = true;
+      const rest = line.slice("Final answer:".length).trim();
+      if (rest) answerLines.push(rest);
+      continue;
+    }
+    if (
+      line.startsWith("Facts:") ||
+      line.startsWith("Commands:") ||
+      line.startsWith("Files:")
+    ) {
+      inFinalAnswer = false;
+      continue;
+    }
+    if (inFinalAnswer) {
+      answerLines.push(line);
+      continue;
+    }
+    if (line.startsWith("Run status:") || line.startsWith("Run error:")) {
+      metaLines.push(line);
+    }
+  }
+
+  const finalAnswer = answerLines.join("\n").trim();
+  if (finalAnswer.length > 0) {
+    return { metaLines, finalAnswer };
+  }
+
+  const bodyLines = lines.filter(
+    (line) =>
+      line.trim().length > 0 &&
+      !line.startsWith("Run status:") &&
+      !line.startsWith("Run error:") &&
+      !line.startsWith("Facts:") &&
+      !line.startsWith("Commands:") &&
+      !line.startsWith("Files:"),
+  );
+  const body = bodyLines.join("\n").trim();
+
+  return {
+    metaLines,
+    finalAnswer: body.length > 0 ? body : null,
+  };
+}
+
+function dedupeContextFacts(
+  facts: string[],
+  summary: string,
+  finalAnswer: string | null,
+): string[] {
+  const haystack = `${summary}\n${finalAnswer ?? ""}`.toLowerCase();
+  return facts.filter((fact) => {
+    const normalized = fact.trim().toLowerCase();
+    if (!normalized) return false;
+    if (haystack.includes(normalized)) return false;
+
+    const label = fact.split(":")[0]?.trim().toLowerCase();
+    if (label && haystack.includes(`${label}:`)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function collectToolCallPaths(
+  toolCalls: ProjectRunDetailsToolCall[],
+): Set<string> {
+  const paths = new Set<string>();
+  for (const toolCall of toolCalls) {
+    if (toolCall.inputSummary) {
+      paths.add(normalizeContextPath(toolCall.inputSummary));
+    }
+    if (toolCall.outputSummary) {
+      paths.add(normalizeContextPath(toolCall.outputSummary));
+    }
+  }
+  return paths;
+}
+
+function normalizeContextPath(value: string): string {
+  return value.trim().toLowerCase().replace(/\\/g, "/");
+}
+
+function isPathCoveredByToolCalls(
+  path: string,
+  toolPaths: Set<string>,
+): boolean {
+  const normalized = normalizeContextPath(path);
+  if (toolPaths.has(normalized)) return true;
+  for (const toolPath of toolPaths) {
+    if (
+      toolPath.endsWith(normalized) ||
+      normalized.endsWith(toolPath) ||
+      toolPath.includes(normalized) ||
+      normalized.includes(toolPath)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isCommandCoveredByToolCalls(
+  commandItem: string,
+  toolCalls: ProjectRunDetailsToolCall[],
+): boolean {
+  const command = commandItem.replace(/\s+\([^)]*\)$/, "").trim().toLowerCase();
+  if (!command) return false;
+  return toolCalls.some((toolCall) => {
+    const input = toolCall.inputSummary?.toLowerCase() ?? "";
+    return (
+      toolCall.toolName === "bash" &&
+      (input === command || input.includes(command) || command.includes(input))
+    );
+  });
+}
+
+function EmptyHint({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[11px] italic text-muted-foreground/80">{children}</p>
+  );
+}
+
+function formatCount(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  return value.toLocaleString();
+}
+
+function buildRunSummaryText(details: ProjectRunDetailsSummary): string {
+  const { run, events, toolCalls, context } = details;
+  const lines: string[] = [
+    `Run ${run.status} · ${run.model}`,
+    ...(run.provider ? [`Provider: ${run.provider}`] : []),
+    ...(run.finishReason ? [`Finish: ${run.finishReason}`] : []),
+    ...(run.durationMs !== null
+      ? [`Duration: ${formatDuration(run.durationMs)}`]
+      : []),
+    ...(run.stepCount !== null ? [`Steps: ${run.stepCount}`] : []),
+    `Tokens: ${formatCount(run.totalTokens)} (in ${formatCount(run.inputTokens)} / out ${formatCount(run.outputTokens)})`,
+    ...(run.costUsd !== null ? [`Cost: $${run.costUsd.toFixed(4)}`] : []),
+    "",
+    `Timeline (${events.length}):`,
+    ...events.map(
+      (event) =>
+        `  ${event.sequence}. [${event.kind}] ${event.label}${
+          event.durationMs !== null ? ` (${formatDuration(event.durationMs)})` : ""
+        }`,
+    ),
+    "",
+    `Tool calls (${toolCalls.length}):`,
+    ...toolCalls.map((toolCall) => {
+      const parts = [`  ${toolCall.toolName} · ${toolCall.status}`];
+      if (toolCall.stepNumber !== null) {
+        parts.push(`step ${harnessStepDisplayNumber(toolCall.stepNumber)}`);
+      }
+      if (toolCall.approvalDecision) parts.push(toolCall.approvalDecision);
+      if (toolCall.durationMs !== null) {
+        parts.push(formatDuration(toolCall.durationMs));
+      }
+      if (toolCall.inputSummary) parts.push(`in: ${toolCall.inputSummary}`);
+      if (toolCall.outputSummary) parts.push(`out: ${toolCall.outputSummary}`);
+      if (toolCall.error) parts.push(`error: ${toolCall.error}`);
+      return parts.join(" · ");
+    }),
+  ];
+
+  if (context?.summary.trim()) {
+    lines.push("", "Context:", context.summary.trim());
+  }
+
+  return lines.join("\n");
+}

--- a/components/features/run-trace/project-status-panel.tsx
+++ b/components/features/run-trace/project-status-panel.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useState, type ReactNode } from "react";
 import {
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Clock,
   Copy,
   ExternalLink,
@@ -18,6 +20,7 @@ import {
   LoadingState,
 } from "@/components/shared/feedback-states";
 import { BackgroundCommandsPanel } from "@/components/features/projects/background-commands-panel";
+import { ProjectRunDetails } from "@/components/features/run-trace/project-run-details";
 import { cn } from "@/lib/utils";
 import type { ProjectStatusSummary, ProjectSummary } from "@/src/lib/api-types";
 import { notifyProjectGitChanged, useProjectStatus } from "@/components/features/projects/hooks";
@@ -30,6 +33,7 @@ export function ProjectStatusPanel({
   const { status, loading, error, refresh } = useProjectStatus(
     project?.status === "ready" ? project.id : null,
   );
+  const [detailsRefreshToken, setDetailsRefreshToken] = useState(0);
 
   if (!project) {
     return (
@@ -58,7 +62,9 @@ export function ProjectStatusPanel({
             variant="ghost"
             onClick={() => {
               notifyProjectGitChanged(project.id);
-              void refresh();
+              void refresh().then(() => {
+                setDetailsRefreshToken((value) => value + 1);
+              });
             }}
             disabled={loading}
             aria-label="Refresh project status"
@@ -97,9 +103,13 @@ export function ProjectStatusPanel({
 
           <BackgroundCommandsPanel projectId={project.id} status={status} />
 
-          <StatusSection title="Last run">
+          <StatusSection title="Last project run">
             {status.lastRun ? (
-              <LastRunCard lastRun={status.lastRun} />
+              <LastRunCard
+                projectId={project.id}
+                lastRun={status.lastRun}
+                detailsRefreshToken={detailsRefreshToken}
+              />
             ) : (
               <p className="text-xs text-muted-foreground">
                 No agent runs recorded for this project yet.
@@ -173,11 +183,18 @@ function Metric({ label, value }: { label: string; value: string | number }) {
 }
 
 function LastRunCard({
+  projectId,
   lastRun,
+  detailsRefreshToken,
 }: {
+  projectId: string;
   lastRun: NonNullable<ProjectStatusSummary["lastRun"]>;
+  detailsRefreshToken: number;
 }) {
-  const statusMeta = runStatusMeta(lastRun.status);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [detailsEverOpened, setDetailsEverOpened] = useState(false);
+  const statusMeta = runStatusMeta(lastRun);
+  const budgetReached = lastRun.finishReason === "token_budget_limit";
   return (
     <>
       <div className="flex flex-wrap items-center gap-2">
@@ -188,7 +205,7 @@ function LastRunCard({
           )}
         >
           <statusMeta.Icon className="size-3" />
-          {statusMeta.label}
+          {budgetReached ? "Budget reached" : statusMeta.label}
         </span>
         <span className="font-mono text-[10px] text-muted-foreground">
           {lastRun.model}
@@ -212,23 +229,72 @@ function LastRunCard({
           }
         />
       </div>
-      <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground">
-        <Clock className="size-3" />
-        {new Date(lastRun.startedAt).toLocaleString()}
-        <Link
-          href={`/s/${lastRun.sessionId}`}
-          className="ml-auto inline-flex items-center gap-1 text-foreground hover:underline"
-        >
-          Open session
-          <ExternalLink className="size-3" />
-        </Link>
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground">
+        <Clock className="size-3 shrink-0" />
+        <span>{new Date(lastRun.startedAt).toLocaleString()}</span>
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button
+            type="button"
+            size="xs"
+            variant={detailsOpen ? "secondary" : "outline"}
+            className={cn(
+              "h-5 min-h-0 gap-0.5 px-1.5 py-0 text-[9px]",
+              detailsOpen && "ring-1 ring-border/80",
+            )}
+            onClick={() => {
+              setDetailsEverOpened(true);
+              setDetailsOpen((open) => !open);
+            }}
+            aria-expanded={detailsOpen}
+          >
+            {detailsOpen ? (
+              <ChevronDown className="size-2.5" />
+            ) : (
+              <ChevronRight className="size-2.5" />
+            )}
+            Details
+          </Button>
+          <Link
+            href={`/s/${lastRun.sessionId}`}
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-foreground transition-colors hover:bg-secondary/60 hover:underline"
+          >
+            Open session
+            <ExternalLink className="size-3" />
+          </Link>
+        </div>
       </div>
+      {detailsEverOpened ? (
+        <div
+          className={cn(
+            "grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none",
+            detailsOpen
+              ? "grid-rows-[1fr] opacity-100"
+              : "grid-rows-[0fr] opacity-0",
+          )}
+        >
+          <div className="min-h-0 overflow-hidden">
+            <ProjectRunDetails
+              key={`${lastRun.runId}:${detailsRefreshToken}`}
+              projectId={projectId}
+              runId={lastRun.runId}
+              refreshToken={detailsRefreshToken}
+            />
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }
 
-function runStatusMeta(status: NonNullable<ProjectStatusSummary["lastRun"]>["status"]) {
-  switch (status) {
+function runStatusMeta(lastRun: NonNullable<ProjectStatusSummary["lastRun"]>) {
+  if (lastRun.finishReason === "token_budget_limit") {
+    return {
+      Icon: Clock,
+      label: "Budget reached",
+      className: "text-amber-400 ring-amber-400/30 bg-amber-400/10",
+    };
+  }
+  switch (lastRun.status) {
     case "completed":
       return {
         Icon: CheckCircle2,

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -15,8 +15,10 @@ import {
   getMessageRunDurationMs,
   getRunData,
   hasPendingToolApproval,
+  messageHasBudgetLimit,
   type AntonUIMessage,
   type AntonRunStatus,
+  type TokenBudgetMultiplierOption,
 } from "@/src/lib/trace";
 import { Disclosure } from "@/components/shared/disclosure";
 
@@ -51,6 +53,10 @@ interface RunTraceAccordionProps {
   status: "submitted" | "streaming" | "ready" | "error";
   todoDisplay?: TodoTraceDisplay;
   onApproval: ChatAddToolApproveResponseFunction;
+  onExtendTokenBudget?: (
+    runId: string,
+    multiplier: TokenBudgetMultiplierOption,
+  ) => void;
 }
 
 export function RunTraceAccordion({
@@ -58,6 +64,7 @@ export function RunTraceAccordion({
   status,
   todoDisplay,
   onApproval,
+  onExtendTokenBudget,
 }: RunTraceAccordionProps) {
   const run = getRunData(message);
   const metadata = message.metadata;
@@ -67,6 +74,7 @@ export function RunTraceAccordion({
     transportRunning,
   );
   const isRunning = runStatus === "running";
+  const budgetLimited = messageHasBudgetLimit(message);
 
   const pendingApproval = useMemo(
     () => hasPendingToolApproval(message),
@@ -138,6 +146,7 @@ export function RunTraceAccordion({
                 key={`step-${item.group.stepNumber}`}
                 group={item.group}
                 runStatus={runStatus}
+                budgetLimited={budgetLimited}
                 onApproval={onApproval}
               />
             ) : (
@@ -145,6 +154,14 @@ export function RunTraceAccordion({
                 <TraceRowView
                   row={item.row}
                   runStatus={runStatus}
+                  budgetLimited={budgetLimited}
+                  budgetGateDisabled={
+                    isRunning ||
+                    pendingApproval ||
+                    (item.row.kind === "budget-gate" &&
+                      item.row.gate.status !== "open")
+                  }
+                  onExtendTokenBudget={onExtendTokenBudget}
                   onApproval={onApproval}
                 />
               </div>

--- a/components/features/run-trace/terminal-output.tsx
+++ b/components/features/run-trace/terminal-output.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 
 import { cn } from "@/lib/utils";
+import { BashCommandBar } from "./bash-command-bar";
 import {
   parseBashOutput,
   renderAnsiToHtml,
@@ -38,12 +39,7 @@ export function TerminalOutput({ command, output, className }: TerminalOutputPro
         className,
       )}
     >
-      {command && (
-        <div className="flex items-start gap-1.5 border-b border-white/8 px-2 py-1">
-          <span className="shrink-0 select-none text-emerald-400">$</span>
-          <span className="text-foreground/90 whitespace-pre-wrap break-all">{command}</span>
-        </div>
-      )}
+      {command ? <BashCommandBar command={command} /> : null}
       {hasOutput ? (
         <div className="max-h-64 overflow-y-auto px-3 py-2 space-y-1">
           {stdoutHtml && (

--- a/components/features/run-trace/tool-display.tsx
+++ b/components/features/run-trace/tool-display.tsx
@@ -168,12 +168,18 @@ export function effectiveToolState(entry: ToolTraceEntry): ToolState {
 }
 
 export function isFailedToolOutput(output: unknown): boolean {
-  return (
-    typeof output === "object" &&
-    output !== null &&
-    "ok" in output &&
-    (output as { ok: unknown }).ok === false
-  );
+  if (typeof output !== "object" || output === null) return false;
+  const record = output as Record<string, unknown>;
+  if (record.ok === false) return true;
+  if (record.timedOut === true) return true;
+  if (
+    typeof record.failedReason === "string" &&
+    record.failedReason.length > 0
+  ) {
+    return true;
+  }
+  const exitCode = record.exitCode;
+  return typeof exitCode === "number" && exitCode !== 0;
 }
 
 export function toolStateBadge(state: ToolState): {

--- a/components/features/run-trace/tool-trace-row.tsx
+++ b/components/features/run-trace/tool-trace-row.tsx
@@ -34,13 +34,15 @@ import { DiffView } from "./diff-view";
 export function ToolTraceRow({
   entry,
   runStatus,
+  budgetLimited = false,
   onApproval,
 }: {
   entry: ToolTraceEntry;
   runStatus: AntonRunStatus;
+  budgetLimited?: boolean;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
-  const displayState = displayToolState(entry, runStatus);
+  const displayState = displayToolState(entry, runStatus, budgetLimited);
   const meta = traceToolStateMeta(displayState);
   const approvalId =
     entry.state === "approval-requested" &&
@@ -166,6 +168,7 @@ export function ToolTraceRow({
 function displayToolState(
   entry: ToolTraceEntry,
   runStatus: AntonRunStatus,
+  budgetLimited: boolean,
 ): ToolState {
   const effectiveState = effectiveToolState(entry);
   if (
@@ -173,7 +176,7 @@ function displayToolState(
     entry.activity?.status === "running" &&
     (effectiveState === "input-streaming" || effectiveState === "input-available")
   ) {
-    return "output-error";
+    return budgetLimited ? effectiveState : "output-error";
   }
   return effectiveState;
 }

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -1,13 +1,21 @@
 import {
   getActivityEvents,
   getAssistantTextDisplay,
+  getLatestBudgetGate,
   getRunData,
+  getRunDataList,
   getTodoSnapshots,
+  type AntonRunData,
   getToolTraceEntries,
   hasFailedToolOutput,
   hasPendingToolApproval,
+  isAssistantTurnActive,
   isReasoningPart,
   isTodosDataPart,
+  normalizeTodoSnapshotForDisplay,
+  type AntonActivityKind,
+  type AntonActivityStatus,
+  type AntonBudgetGateData,
   type AntonRunStatus,
   type AntonActivityEvent,
   type AntonTodoSnapshot,
@@ -53,11 +61,485 @@ export type TraceRow =
   | {
       id: string;
       order: number;
+      kind: "budget-gate";
+      gate: AntonBudgetGateData;
+    }
+  | {
+      id: string;
+      order: number;
       kind: "tool";
       tool: ToolTraceEntry;
     };
 
 export type TodoTraceDisplay = ReadonlyMap<string, AntonTodoSnapshot>;
+
+export type SessionTimelineItem = {
+  id: string;
+  order: number;
+  startedAt: number;
+  runId: string;
+  kind: AntonActivityKind | "progress" | "todos";
+  label: string;
+  summary?: string;
+  durationMs?: number;
+  status: AntonActivityStatus;
+  expandable: boolean;
+  tool?: ToolTraceEntry;
+  reasoningText?: string;
+  todoSnapshot?: AntonTodoSnapshot;
+  messageId: string;
+  runStatus: AntonRunStatus;
+};
+
+export type TimelineStepGroup<T extends TimelineStepBoundaryItem> = {
+  id: string;
+  label: string;
+  durationMs?: number;
+  items: T[];
+};
+
+export type TimelineStepBoundaryItem = {
+  kind: string;
+  id: string;
+  label: string;
+  startedAt?: number;
+  durationMs?: number | null;
+};
+
+export type SessionTimelineStepGroup = TimelineStepGroup<SessionTimelineItem>;
+
+export type SessionTimelineRunGroup = {
+  runId: string;
+  messageId: string;
+  run: AntonRunData;
+  segmentIndex: number;
+  segmentCount: number;
+  items: SessionTimelineItem[];
+  steps: SessionTimelineStepGroup[];
+};
+
+export function groupTimelineItemsByStep<T extends TimelineStepBoundaryItem>(
+  items: readonly T[],
+  options?: { tailLabel?: string; activityLabel?: string },
+): TimelineStepGroup<T>[] {
+  const activityLabel = options?.activityLabel ?? "Activity";
+  const tailLabel = options?.tailLabel ?? "In progress";
+
+  if (items.length === 0) return [];
+
+  const stepEvents = items
+    .filter((item) => item.kind === "step")
+    .slice()
+    .sort(
+      (left, right) =>
+        (left.startedAt ?? 0) - (right.startedAt ?? 0) ||
+        left.id.localeCompare(right.id),
+    );
+  const nonStepItems = items.filter((item) => item.kind !== "step");
+
+  if (stepEvents.length === 0) {
+    return [
+      {
+        id: `activity:${items[0]?.id ?? "unknown"}`,
+        label: activityLabel,
+        items: nonStepItems.slice(),
+      },
+    ];
+  }
+
+  const steps: TimelineStepGroup<T>[] = stepEvents.map((step, index) => {
+    const stepStart = step.startedAt ?? 0;
+    const nextStepStart = stepEvents[index + 1]?.startedAt ?? Number.POSITIVE_INFINITY;
+    const stepItems = nonStepItems
+      .filter(
+        (item) =>
+          (item.startedAt ?? 0) >= stepStart &&
+          (item.startedAt ?? 0) < nextStepStart,
+      )
+      .slice()
+      .sort(
+        (left, right) =>
+          (left.startedAt ?? 0) - (right.startedAt ?? 0) ||
+          left.id.localeCompare(right.id),
+      );
+
+    return {
+      id: step.id,
+      label: step.label,
+      durationMs: stepDisplayDurationMs(step, stepItems),
+      items: stepItems,
+    };
+  });
+
+  const assigned = new Set(steps.flatMap((step) => step.items));
+  const leading = nonStepItems
+    .filter((item) => !assigned.has(item))
+    .filter((item) => (item.startedAt ?? 0) < (stepEvents[0]?.startedAt ?? 0));
+  if (leading.length > 0) {
+    steps.unshift({
+      id: `leading:${leading[0]?.id ?? "unknown"}`,
+      label: activityLabel,
+      items: leading,
+    });
+  }
+
+  const leadingIds = new Set(leading.map((item) => item.id));
+  const trailing = nonStepItems.filter(
+    (item) => !assigned.has(item) && !leadingIds.has(item.id),
+  );
+  if (trailing.length > 0) {
+    steps.push({
+      id: `tail:${trailing[0]?.id ?? "unknown"}`,
+      label: tailLabel,
+      items: trailing,
+    });
+  }
+
+  return steps;
+}
+
+function stepDisplayDurationMs(
+  step: TimelineStepBoundaryItem,
+  items: readonly TimelineStepBoundaryItem[],
+): number | undefined {
+  const stepStart = step.startedAt;
+  const harnessDuration =
+    typeof step.durationMs === "number" && Number.isFinite(step.durationMs)
+      ? step.durationMs
+      : undefined;
+
+  if (stepStart === undefined) return harnessDuration;
+
+  let envelopeEnd = stepStart + (harnessDuration ?? 0);
+  for (const item of items) {
+    const itemStart = item.startedAt;
+    if (itemStart === undefined) continue;
+    const itemEnd =
+      typeof item.durationMs === "number" && Number.isFinite(item.durationMs)
+        ? itemStart + item.durationMs
+        : itemStart;
+    envelopeEnd = Math.max(envelopeEnd, itemEnd);
+  }
+
+  const envelopeDuration = Math.max(0, envelopeEnd - stepStart);
+  if (harnessDuration === undefined) {
+    return envelopeDuration > 0 ? envelopeDuration : undefined;
+  }
+  return Math.max(harnessDuration, envelopeDuration);
+}
+
+export function getSessionTimelineRunGroups(
+  messages: AntonUIMessage[],
+): SessionTimelineRunGroup[] {
+  const groups: SessionTimelineRunGroup[] = [];
+
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+
+    const runs = getRunsForTimelineMessage(message);
+    runs.forEach((run, index) => {
+      const items = buildRunTimelineItems(message, run);
+      if (items.length === 0) return;
+      groups.push({
+        runId: run.runId,
+        messageId: message.id,
+        run,
+        segmentIndex: index + 1,
+        segmentCount: runs.length,
+        items,
+        steps: groupTimelineItemsByStep(items),
+      });
+    });
+  }
+
+  return groups;
+}
+
+export function getSessionTimelineItems(
+  messages: AntonUIMessage[],
+): SessionTimelineItem[] {
+  return getSessionTimelineRunGroups(messages).flatMap((group) => group.items);
+}
+
+function getRunsForTimelineMessage(message: AntonUIMessage): AntonRunData[] {
+  const fromParts = getRunDataList(message);
+  if (fromParts.length > 0) {
+    return fromParts.slice().sort((left, right) => left.startedAt - right.startedAt);
+  }
+
+  const fallbackStartedAt = new Map<string, number>();
+  for (const event of getActivityEvents(message)) {
+    const current = fallbackStartedAt.get(event.runId);
+    if (current === undefined || event.startedAt < current) {
+      fallbackStartedAt.set(event.runId, event.startedAt);
+    }
+  }
+
+  return Array.from(fallbackStartedAt.entries())
+    .sort((left, right) => left[1] - right[1])
+    .map(([runId, startedAt]) => ({
+      runId,
+      model: message.metadata?.model ?? "unknown",
+      status: message.metadata?.status ?? "completed",
+      startedAt,
+    }));
+}
+
+function buildRunTimelineItems(
+  message: AntonUIMessage,
+  run: AntonRunData,
+): SessionTimelineItem[] {
+  const runStatus = run.status;
+  const toolByCallId = new Map(
+    getToolTraceEntries([message])
+      .filter((tool) => tool.activity?.runId === run.runId)
+      .map((tool) => [tool.id, tool]),
+  );
+  const seenToolIds = new Set<string>();
+  const items: SessionTimelineItem[] = [];
+
+  const events = getActivityEvents(message)
+    .filter(
+      (event) =>
+        event.runId === run.runId &&
+        event.kind !== "approval" &&
+        !isTokenBudgetActivity(event),
+    )
+    .sort(compareTimelineEvents);
+
+  for (const event of events) {
+    const base = {
+      id: event.id,
+      order: event.sequence,
+      startedAt: event.startedAt,
+      runId: run.runId,
+      messageId: message.id,
+      runStatus,
+    };
+
+    if (event.kind === "tool" && event.toolCallId) {
+      const tool = toolByCallId.get(event.toolCallId);
+      if (!tool) continue;
+      seenToolIds.add(tool.id);
+      items.push({
+        ...base,
+        kind: "tool",
+        label: event.label,
+        summary: event.summary,
+        durationMs: event.durationMs,
+        status: event.status,
+        tool,
+        expandable: true,
+      });
+      continue;
+    }
+
+    if (event.kind === "reasoning") {
+      const reasoningText = reasoningTextForEvent(message, event);
+      items.push({
+        ...base,
+        kind: "reasoning",
+        label:
+          event.durationMs !== undefined
+            ? `Thought for ${formatDuration(event.durationMs)}`
+            : event.label,
+        durationMs: event.durationMs,
+        status: event.status,
+        reasoningText,
+        expandable: Boolean(reasoningText),
+      });
+      continue;
+    }
+
+    if (event.kind === "progress" && eventHasTodos(event)) {
+      const todoSnapshot = todoSnapshotFromEventDetails(event.details?.todos);
+      items.push({
+        ...base,
+        kind: "todos",
+        label: event.label || "Todos updated",
+        summary: event.summary,
+        durationMs: event.durationMs,
+        status: event.status,
+        todoSnapshot,
+        expandable: Boolean(todoSnapshot),
+      });
+      continue;
+    }
+
+    items.push({
+      ...base,
+      kind: event.kind,
+      label: event.label,
+      summary: event.summary,
+      durationMs: event.durationMs,
+      status: event.status,
+      expandable:
+        (event.kind === "error" && Boolean(event.summary)) ||
+        (event.kind === "progress" && Boolean(event.summary)),
+    });
+  }
+
+  for (const tool of toolByCallId.values()) {
+    if (seenToolIds.has(tool.id)) continue;
+    const title = toolTitle(tool, runStatus);
+    const label = title.target ? `${title.verb} ${title.target}` : title.verb;
+    items.push({
+      id: tool.activity?.id ?? tool.id,
+      order: tool.activity?.sequence ?? items.length,
+      startedAt: tool.activity?.startedAt ?? run.startedAt,
+      runId: run.runId,
+      kind: "tool",
+      label: tool.activity?.label ?? label,
+      durationMs: tool.activity?.durationMs,
+      status:
+        tool.activity?.status ??
+        (runStatus === "running" ? "running" : "completed"),
+      tool,
+      expandable: true,
+      messageId: message.id,
+      runStatus,
+    });
+  }
+
+  return items.sort(compareTimelineItems);
+}
+
+function compareTimelineEvents(
+  left: AntonActivityEvent,
+  right: AntonActivityEvent,
+): number {
+  if (left.startedAt !== right.startedAt) {
+    return left.startedAt - right.startedAt;
+  }
+  if (left.sequence !== right.sequence) {
+    return left.sequence - right.sequence;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function compareTimelineItems(
+  left: SessionTimelineItem,
+  right: SessionTimelineItem,
+): number {
+  if (left.startedAt !== right.startedAt) {
+    return left.startedAt - right.startedAt;
+  }
+  if (left.order !== right.order) {
+    return left.order - right.order;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function reasoningTextForEvent(
+  message: AntonUIMessage,
+  event: AntonActivityEvent,
+): string | undefined {
+  const marker = ":reasoning:";
+  const markerIndex = event.id.indexOf(marker);
+  if (markerIndex !== -1) {
+    const partId = event.id.slice(markerIndex + marker.length);
+    for (const part of message.parts) {
+      if (!isReasoningPart(part)) continue;
+      if ("id" in part && typeof part.id === "string" && part.id === partId) {
+        const text = part.text.trim();
+        if (text.length > 0) return text;
+      }
+    }
+  }
+
+  const reasoningEvents = getActivityEvents(message)
+    .filter((candidate) => candidate.kind === "reasoning")
+    .sort(compareTimelineEvents);
+  const reasoningTexts = message.parts.flatMap((part) =>
+    isReasoningPart(part) && part.text.trim().length > 0
+      ? [part.text.trim()]
+      : [],
+  );
+  const eventIndex = reasoningEvents.findIndex(
+    (candidate) => candidate.id === event.id,
+  );
+  if (eventIndex === -1 || eventIndex >= reasoningTexts.length) return undefined;
+  return reasoningTexts[eventIndex];
+}
+
+function todoSnapshotFromEventDetails(
+  value: unknown,
+): AntonTodoSnapshot | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const runId = record.runId;
+  const updatedAt = record.updatedAt;
+  const items = record.items;
+  if (
+    typeof runId !== "string" ||
+    typeof updatedAt !== "number" ||
+    !Array.isArray(items)
+  ) {
+    return undefined;
+  }
+
+  const parsedItems = items.flatMap((item): AntonTodoSnapshot["items"] => {
+    if (typeof item !== "object" || item === null) return [];
+    const row = item as Record<string, unknown>;
+    const id = row.id;
+    const text = row.text;
+    const status = row.status;
+    if (
+      typeof id !== "string" ||
+      typeof text !== "string" ||
+      (status !== "pending" &&
+        status !== "in_progress" &&
+        status !== "completed")
+    ) {
+      return [];
+    }
+    return [{ id, text, status }];
+  });
+
+  if (parsedItems.length === 0) return undefined;
+  return { runId, updatedAt, items: parsedItems };
+}
+
+export function runIdFromEventId(eventId: string): string {
+  const match = eventId.match(
+    /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+  );
+  return match?.[1] ?? eventId;
+}
+
+/** Harness / AI SDK step indices are 0-based; step timeline headers use 1-based labels. */
+export function harnessStepDisplayNumber(stepNumber: number): number {
+  return stepNumber + 1;
+}
+
+export function isTimelineHarnessStepGroup(stepId: string): boolean {
+  return !stepId.startsWith("leading:") && !stepId.startsWith("tail:");
+}
+
+export function runTimelineGroupLabel(group: SessionTimelineRunGroup): string {
+  const { run, segmentIndex, segmentCount } = group;
+  const segmentLabel =
+    segmentCount > 1 ? `Segment ${segmentIndex}/${segmentCount}` : "Run";
+  const duration =
+    run.durationMs !== undefined ? formatDuration(run.durationMs) : undefined;
+  const finishLabel =
+    run.finishReason === "token_budget_limit"
+      ? "budget reached"
+      : run.finishReason === "max_step_limit"
+        ? "step limit"
+        : run.finishReason === "cost_budget_limit"
+          ? "cost limit"
+          : undefined;
+
+  return [
+    segmentLabel,
+    segmentIndex > 1 ? "continued" : undefined,
+    duration,
+    finishLabel,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" · ");
+}
 
 export function getTodoTraceDisplay(
   messages: AntonUIMessage[],
@@ -72,6 +554,7 @@ export function getTodoTraceDisplay(
     }
   >();
   let userTurn = 0;
+  const lastAssistantByTurn = new Map<number, AntonUIMessage>();
 
   const updateTurnSnapshot = (
     turn: number,
@@ -101,7 +584,10 @@ export function getTodoTraceDisplay(
 
   messages.forEach((message, messageIndex) => {
     if (message.role === "user") userTurn += 1;
-    const messageHasFailedTool = hasFailedToolOutput(message);
+    if (message.role === "assistant") {
+      lastAssistantByTurn.set(userTurn, message);
+    }
+    const firstFailedToolIndex = message.parts.findIndex(isFailedToolPart);
     const firstTodoPartIndex = message.parts.findIndex(isTodosDataPart);
     const firstTodoPartKey =
       firstTodoPartIndex === -1
@@ -109,7 +595,7 @@ export function getTodoTraceDisplay(
         : todoPartKey(message, firstTodoPartIndex);
     message.parts.forEach((part, partIndex) => {
       if (!isTodosDataPart(part)) return;
-      if (messageHasFailedTool) return;
+      if (firstFailedToolIndex !== -1 && partIndex > firstFailedToolIndex) return;
       const order = messageIndex * 10_000 + partIndex;
       updateTurnSnapshot(userTurn, part.data, order, todoPartKey(message, partIndex));
     });
@@ -135,8 +621,13 @@ export function getTodoTraceDisplay(
     }
   });
 
-  for (const item of turnTodos.values()) {
-    displayByFirstPart.set(item.firstPartKey, item.latestSnapshot);
+  for (const [turn, item] of turnTodos.entries()) {
+    const lastAssistant = lastAssistantByTurn.get(turn);
+    const active = lastAssistant ? isAssistantTurnActive(lastAssistant) : false;
+    displayByFirstPart.set(
+      item.firstPartKey,
+      normalizeTodoSnapshotForDisplay(item.latestSnapshot, active),
+    );
   }
 
   return displayByFirstPart;
@@ -230,11 +721,22 @@ export function getTraceRows(
     if (event.kind === "tool" || event.kind === "reasoning") continue;
     if (event.kind === "step") continue;
     if (event.kind === "progress" && eventHasTodos(event)) continue;
+    if (isTokenBudgetActivity(event)) continue;
     rows.push({
       id: event.id,
       order: 10_000 + event.sequence,
       kind: "activity",
       event,
+    });
+  }
+
+  const budgetGate = getLatestBudgetGate(message);
+  if (budgetGate && budgetGate.status !== "resolved") {
+    rows.push({
+      id: `${budgetGate.runId}:budget-gate`,
+      order: 20_000,
+      kind: "budget-gate",
+      gate: budgetGate,
     });
   }
 
@@ -285,6 +787,16 @@ function eventHasTodos(event: AntonActivityEvent): boolean {
     event.details !== null &&
     "todos" in event.details
   );
+}
+
+function isTokenBudgetActivity(event: AntonActivityEvent): boolean {
+  return event.label === "Token budget reached";
+}
+
+function isFailedToolPart(part: AntonUIMessage["parts"][number]): boolean {
+  if (!("toolCallId" in part)) return false;
+  if ("state" in part && part.state === "output-error") return true;
+  return "output" in part && isFailedToolOutput(part.output);
 }
 
 function toolCallIdForPart(
@@ -416,6 +928,7 @@ export function getTraceDurationMs(rows: TraceRow[]): number | undefined {
       if (row.kind === "reasoning") return row.event?.durationMs;
       if (row.kind === "progress") return undefined;
       if (row.kind === "todos") return undefined;
+      if (row.kind === "budget-gate") return undefined;
       return row.tool.activity?.durationMs;
     })
     .filter((duration): duration is number => duration !== undefined);
@@ -447,7 +960,23 @@ export function getSessionTodoSnapshots(
   let latest: AntonTodoSnapshot | undefined;
 
   for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isTodosDataPart(part)) continue;
+      snapshots.push(part.data);
+      if (
+        !latest ||
+        part.data.updatedAt > latest.updatedAt ||
+        (part.data.updatedAt === latest.updatedAt &&
+          snapshots.indexOf(part.data) > snapshots.indexOf(latest))
+      ) {
+        latest = part.data;
+      }
+    }
+
     for (const snapshot of getTodoSnapshots(message)) {
+      if (snapshots.some((existing) => existing.updatedAt === snapshot.updatedAt && existing.runId === snapshot.runId)) {
+        continue;
+      }
       snapshots.push(snapshot);
       if (
         !latest ||
@@ -462,6 +991,20 @@ export function getSessionTodoSnapshots(
     if (latest && hasOpenTodos(latest) && isSuccessfulCompletionMessage(message)) {
       latest = completedTodoSnapshot(latest, message);
       snapshots.push(latest);
+    }
+  }
+
+  const lastAssistant = messages.findLast((message) => message.role === "assistant");
+  const active = lastAssistant ? isAssistantTurnActive(lastAssistant) : false;
+  if (latest) {
+    latest = normalizeTodoSnapshotForDisplay(latest, active);
+    const latestIndex = snapshots.findLastIndex(
+      (snapshot) =>
+        snapshot.updatedAt === latest?.updatedAt &&
+        snapshot.runId === latest.runId,
+    );
+    if (latestIndex !== -1) {
+      snapshots[latestIndex] = latest;
     }
   }
 

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -21,21 +21,33 @@ import {
 import { formatDuration, type TraceRow, type StepGroup } from "./trace-data";
 import { ToolTraceRow } from "./tool-trace-row";
 import { TodoCard } from "./todo-card";
+import { BudgetGateCard } from "@/components/features/chat/budget-gate-card";
+import type { TokenBudgetMultiplierOption } from "@/src/lib/trace";
 
 export function TraceRowView({
   row,
   runStatus,
   onApproval,
+  budgetGateDisabled,
+  onExtendTokenBudget,
+  budgetLimited = false,
 }: {
   row: TraceRow;
   runStatus: AntonRunStatus;
   onApproval: ChatAddToolApproveResponseFunction;
+  budgetGateDisabled?: boolean;
+  onExtendTokenBudget?: (
+    runId: string,
+    multiplier: TokenBudgetMultiplierOption,
+  ) => void;
+  budgetLimited?: boolean;
 }) {
   if (row.kind === "tool") {
     return (
       <ToolTraceRow
         entry={row.tool}
         runStatus={runStatus}
+        budgetLimited={budgetLimited}
         onApproval={onApproval}
       />
     );
@@ -50,6 +62,17 @@ export function TraceRowView({
   }
   if (row.kind === "todos") {
     return <TodoCard snapshot={row.snapshot} compact />;
+  }
+  if (row.kind === "budget-gate") {
+    if (!onExtendTokenBudget) return null;
+    return (
+      <BudgetGateCard
+        gate={row.gate}
+        compact
+        disabled={budgetGateDisabled}
+        onExtend={onExtendTokenBudget}
+      />
+    );
   }
   return <ActivityRow event={row.event} runStatus={runStatus} />;
 }
@@ -172,10 +195,12 @@ export function StepGroupView({
   group,
   runStatus,
   onApproval,
+  budgetLimited = false,
 }: {
   group: StepGroup;
   runStatus: AntonRunStatus;
   onApproval: ChatAddToolApproveResponseFunction;
+  budgetLimited?: boolean;
 }) {
   const hasPendingApproval = group.toolRows.some(
     (row) => row.kind === "tool" && row.tool.state === "approval-requested",
@@ -203,6 +228,7 @@ export function StepGroupView({
                 <ToolTraceRow
                   entry={row.tool}
                   runStatus={runStatus}
+                  budgetLimited={budgetLimited}
                   onApproval={onApproval}
                 />
               </li>

--- a/components/features/run-trace/trace-timeline-ui.tsx
+++ b/components/features/run-trace/trace-timeline-ui.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  AlertCircle,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Hash,
+  Layers,
+  ListTodo,
+  Loader2,
+  ShieldCheck,
+  TerminalSquare,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type {
+  AntonActivityKind,
+  AntonActivityStatus,
+  AntonRunStatus,
+} from "@/src/lib/trace";
+
+export function TraceTimelineList({
+  children,
+  showLine = true,
+}: {
+  children: ReactNode;
+  showLine?: boolean;
+}) {
+  return (
+    <ol className="relative space-y-0">
+      {showLine ? (
+        <div
+          aria-hidden
+          className="absolute top-2 bottom-2 left-[7px] w-px bg-border/60"
+        />
+      ) : null}
+      {children}
+    </ol>
+  );
+}
+
+export function TraceThreadRoot({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("space-y-3", className)}>{children}</div>;
+}
+
+export function TraceThreadNode({ children }: { children: ReactNode }) {
+  return <div className="py-0.5">{children}</div>;
+}
+
+// Icon column is 0.875rem (14px); thread line aligns to its horizontal center (7px).
+const THREAD_ICON_COL = "0.875rem";
+const THREAD_ICON_CENTER = "7px";
+
+export function TraceThreadChildren({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative border-l border-border/60 pl-2"
+      style={{ marginLeft: THREAD_ICON_CENTER }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function TraceThreadHeaderRow({
+  icon: Icon,
+  iconClass,
+  dotClass,
+  label,
+  durationMs,
+  status,
+  subdued = false,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  iconClass: string;
+  dotClass: string;
+  label: string;
+  durationMs?: number | null;
+  status?: AntonRunStatus;
+  subdued?: boolean;
+}) {
+  return (
+    <div
+      className="grid min-w-0 items-center gap-1.5 py-0.5"
+      style={{ gridTemplateColumns: `${THREAD_ICON_COL} minmax(0, 1fr)` }}
+    >
+      <div className="flex justify-center">
+        <span
+          className={cn(
+            "flex size-3.5 shrink-0 items-center justify-center rounded-full ring-2 ring-background",
+            dotClass,
+          )}
+        >
+          <Icon className={cn("size-2.5", iconClass)} />
+        </span>
+      </div>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-[11px]",
+            subdued
+              ? "font-medium text-foreground/85"
+              : "font-semibold text-foreground/95",
+          )}
+        >
+          {label}
+        </span>
+        {status === "running" ? (
+          <Loader2 className="size-3 shrink-0 animate-spin text-sky-400" />
+        ) : status === "error" ? (
+          <AlertCircle className="size-3 shrink-0 text-destructive/80" />
+        ) : null}
+        {durationMs != null ? (
+          <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+            {formatTimelineDuration(durationMs)}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function formatTimelineDuration(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`;
+}
+
+export function TraceTimelineRow({
+  kind,
+  status,
+  label,
+  durationMs,
+  expandable,
+  expanded,
+  onToggle,
+  summary,
+  children,
+}: {
+  kind: AntonActivityKind | "progress" | "todos";
+  status: AntonActivityStatus | "completed" | "error";
+  label: string;
+  durationMs?: number | null;
+  expandable: boolean;
+  expanded: boolean;
+  onToggle?: () => void;
+  summary?: string;
+  children?: ReactNode;
+}) {
+  const meta = timelineEventMeta(kind, status);
+  const isCompact = kind === "tool" || (kind === "error" && status !== "running");
+
+  const rowContent = (
+    <>
+      <span className="min-w-0 flex-1 truncate text-[11px] text-foreground/90">
+        {label}
+      </span>
+      {status !== "completed" &&
+      !(kind === "error" && summary) &&
+      !expandable ? (
+        <StatusPill status={status} />
+      ) : null}
+      {durationMs != null ? (
+        <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+          {formatTimelineDuration(durationMs)}
+        </span>
+      ) : null}
+      {expandable ? (
+        expanded ? (
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-3 shrink-0 text-muted-foreground" />
+        )
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className={cn("relative min-w-0", isCompact ? "py-px" : "py-0.5")}>
+      <div
+        className="grid gap-1.5"
+        style={{ gridTemplateColumns: `${THREAD_ICON_COL} minmax(0, 1fr)` }}
+      >
+        <div className="relative z-10 flex justify-center pt-0.5">
+          <span
+            className={cn(
+              "flex items-center justify-center rounded-full ring-2 ring-background",
+              isCompact ? "size-3" : "size-3.5",
+              meta.dotClass,
+            )}
+          >
+            <meta.Icon
+              className={cn(isCompact ? "size-2" : "size-2.5", meta.iconClass)}
+            />
+          </span>
+        </div>
+        <div className="min-w-0 pb-0.5">
+          {expandable ? (
+            <button
+              type="button"
+              className="flex min-w-0 w-full items-center gap-2 text-left transition-colors hover:text-foreground"
+              onClick={onToggle}
+              aria-expanded={expanded}
+            >
+              {rowContent}
+            </button>
+          ) : (
+            <div className="flex min-w-0 items-center gap-2">{rowContent}</div>
+          )}
+
+          {!expandable && summary ? (
+            <p
+              className={cn(
+                "mt-0.5 line-clamp-2 break-words font-mono text-[10px] leading-snug",
+                kind === "error"
+                  ? "text-destructive/90"
+                  : "text-muted-foreground/90",
+              )}
+            >
+              {summary}
+            </p>
+          ) : null}
+
+          {expandable && expanded && children ? (
+            <div className="mt-1.5">{children}</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TraceExpandPanel({
+  errored,
+  denied,
+  children,
+}: {
+  errored?: boolean;
+  denied?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border/50 bg-background/30 px-2 py-1.5 text-[10px]",
+        errored && "border-destructive/25 bg-destructive/[0.03]",
+        denied && "border-border/40 bg-secondary/15",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function TraceLogBlock({
+  title,
+  tone,
+  children,
+}: {
+  title: string;
+  tone?: "error";
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <div
+        className={cn(
+          "text-[9px] font-medium uppercase tracking-wide text-muted-foreground",
+          tone === "error" && "text-destructive/80",
+        )}
+      >
+        {title}
+      </div>
+      <pre className="max-h-40 overflow-auto rounded-md bg-background/70 px-2 py-1.5 font-mono text-[10px] leading-relaxed text-foreground/90 whitespace-pre-wrap break-words ring-1 ring-border/40">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+export function PermissionLabel({ label }: { label: string }) {
+  return (
+    <span className="rounded bg-secondary/60 px-1 py-px font-mono text-[9px] text-muted-foreground ring-1 ring-border/50">
+      {label}
+    </span>
+  );
+}
+
+export function StatusPill({ status }: { status: string }) {
+  const label = statusLabel(status);
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide ring-1",
+        status === "completed" &&
+          "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20",
+        status === "running" && "bg-sky-500/10 text-sky-400 ring-sky-500/20",
+        status === "error" &&
+          "bg-destructive/10 text-destructive ring-destructive/20",
+        status === "denied" &&
+          "bg-secondary text-muted-foreground ring-border/50",
+        status === "pending" &&
+          "bg-amber-500/10 text-amber-400 ring-amber-500/20",
+        status === "approved" &&
+          "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20",
+        status === "waiting" &&
+          "bg-amber-500/10 text-amber-400 ring-amber-500/20",
+        ![
+          "completed",
+          "running",
+          "error",
+          "denied",
+          "pending",
+          "approved",
+          "waiting",
+        ].includes(status) &&
+          "bg-secondary text-muted-foreground ring-border/50",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function timelineEventMeta(
+  kind: AntonActivityKind | "progress" | "todos",
+  status: AntonActivityStatus | "completed" | "error",
+) {
+  const running = status === "running";
+  const errored = status === "error" || kind === "error";
+
+  if (errored) {
+    return {
+      Icon: AlertCircle,
+      iconClass: "text-destructive",
+      dotClass: "bg-destructive/15",
+    };
+  }
+  if (running) {
+    return {
+      Icon: Loader2,
+      iconClass: "animate-spin text-sky-400",
+      dotClass: "bg-sky-400/15",
+    };
+  }
+
+  switch (kind) {
+    case "reasoning":
+      return {
+        Icon: Brain,
+        iconClass: "text-violet-400/90",
+        dotClass: "bg-violet-400/15",
+      };
+    case "tool":
+      return {
+        Icon: TerminalSquare,
+        iconClass: "text-amber-400/90",
+        dotClass: "bg-amber-400/15",
+      };
+    case "approval":
+      return {
+        Icon: ShieldCheck,
+        iconClass: "text-sky-400/90",
+        dotClass: "bg-sky-400/15",
+      };
+    case "step":
+      return {
+        Icon: Hash,
+        iconClass: "text-muted-foreground",
+        dotClass: "bg-secondary",
+      };
+    case "todos":
+      return {
+        Icon: ListTodo,
+        iconClass: "text-sky-400/90",
+        dotClass: "bg-sky-400/15",
+      };
+    default:
+      return {
+        Icon: Layers,
+        iconClass: "text-emerald-400/90",
+        dotClass: "bg-emerald-400/15",
+      };
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "error":
+      return "failed";
+    case "completed":
+      return "done";
+    default:
+      return status.replace(/_/g, " ");
+  }
+}

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ChatAddToolApproveResponseFunction } from "ai";
+import {
+  CheckCircle2,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  getApprovalMetadata,
+  messageHasBudgetLimit,
+  type AntonUIMessage,
+  type ToolTraceEntry,
+} from "@/src/lib/trace";
+import type { BashOutput } from "@/components/features/run-trace/terminal-utils";
+import { TerminalOutput } from "@/components/features/run-trace/terminal-output";
+import { LiveTerminalOutput } from "@/components/features/run-trace/live-terminal";
+import { ApprovalDetails } from "@/components/features/run-trace/approval-details";
+import { DiffView } from "@/components/features/run-trace/diff-view";
+import { TodoCard } from "@/components/features/run-trace/todo-card";
+import {
+  effectiveToolState,
+  isOkEditFileOutput,
+  isOkWriteFileOutput,
+  pickString,
+  riskCategoryBadge,
+  safeStringify,
+} from "@/components/features/run-trace/tool-display";
+import type { WriteFileOkOutput } from "@/components/features/run-trace/tool-display";
+import {
+  getSessionTimelineRunGroups,
+  harnessStepDisplayNumber,
+  runTimelineGroupLabel,
+  type SessionTimelineItem,
+  type SessionTimelineRunGroup,
+} from "@/components/features/run-trace/trace-data";
+import {
+  Hash,
+  Layers,
+} from "lucide-react";
+import {
+  PermissionLabel,
+  StatusPill,
+  TraceExpandPanel,
+  TraceLogBlock,
+  TraceThreadChildren,
+  TraceThreadHeaderRow,
+  TraceThreadNode,
+  TraceThreadRoot,
+  TraceTimelineRow,
+  timelineEventMeta,
+} from "@/components/features/run-trace/trace-timeline-ui";
+
+export function WorklogTimeline({
+  messages,
+  onApproval,
+}: {
+  messages: AntonUIMessage[];
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const groups = useMemo(
+    () => getSessionTimelineRunGroups(messages),
+    [messages],
+  );
+  const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
+        Tool activity will appear here when Anton reads, searches, edits, or
+        runs commands.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+      <TraceThreadRoot>
+        {groups.map((group) => {
+          const message =
+            messages.find((candidate) => candidate.id === group.messageId) ??
+            messages.at(-1)!;
+          const budgetLimited = messageHasBudgetLimit(message);
+          const runMeta = timelineEventMeta(
+            "progress",
+            group.run.status === "running"
+              ? "running"
+              : group.run.status === "error"
+                ? "error"
+                : "completed",
+          );
+
+          return (
+            <TraceThreadNode key={group.runId}>
+              <TraceThreadHeaderRow
+                icon={Layers}
+                iconClass={runMeta.iconClass}
+                dotClass={runMeta.dotClass}
+                label={runTimelineGroupLabel(group)}
+                durationMs={group.run.durationMs}
+                status={group.run.status}
+              />
+              <TraceThreadChildren>
+                {group.steps.map((step) => {
+                  const stepMeta = timelineEventMeta("step", "completed");
+                  return (
+                    <TraceThreadNode key={step.id}>
+                      <TraceThreadHeaderRow
+                        icon={Hash}
+                        iconClass={stepMeta.iconClass}
+                        dotClass={stepMeta.dotClass}
+                        label={step.label}
+                        durationMs={step.durationMs}
+                        subdued
+                      />
+                      {step.items.length > 0 ? (
+                        <TraceThreadChildren>
+                          {step.items.map((item) =>
+                            renderTimelineItem({
+                              item,
+                              budgetLimited,
+                              expandedItemId,
+                              setExpandedItemId,
+                              onApproval,
+                            }),
+                          )}
+                        </TraceThreadChildren>
+                      ) : null}
+                    </TraceThreadNode>
+                  );
+                })}
+              </TraceThreadChildren>
+            </TraceThreadNode>
+          );
+        })}
+      </TraceThreadRoot>
+    </div>
+  );
+}
+
+function renderTimelineItem({
+  item,
+  budgetLimited,
+  expandedItemId,
+  setExpandedItemId,
+  onApproval,
+}: {
+  item: SessionTimelineItem;
+  budgetLimited: boolean;
+  expandedItemId: string | null;
+  setExpandedItemId: (value: string | null | ((current: string | null) => string | null)) => void;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const expandable = item.expandable;
+  const itemExpanded = expandedItemId === item.id;
+
+  return (
+    <TraceThreadNode key={item.id}>
+      <TraceTimelineRow
+        kind={item.kind}
+        status={displayItemStatus(item, budgetLimited)}
+        label={item.label}
+        durationMs={item.durationMs}
+        expandable={expandable}
+        expanded={itemExpanded}
+        summary={!expandable ? item.summary : undefined}
+        onToggle={
+          expandable
+            ? () =>
+                setExpandedItemId((current) =>
+                  current === item.id ? null : item.id,
+                )
+            : undefined
+        }
+      >
+        {item.kind === "tool" && item.tool ? (
+          <ToolEntryExpandPanel
+            entry={item.tool}
+            runStatus={item.runStatus}
+            onApproval={onApproval}
+          />
+        ) : item.kind === "reasoning" && item.reasoningText ? (
+          <TraceExpandPanel>
+            <pre className="max-h-48 overflow-y-auto font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
+              {item.reasoningText}
+            </pre>
+          </TraceExpandPanel>
+        ) : item.kind === "todos" && item.todoSnapshot ? (
+          <TodoCard snapshot={item.todoSnapshot} compact />
+        ) : item.summary ? (
+          <TraceExpandPanel errored={item.status === "error"}>
+            <p className="break-words font-mono text-[10px] leading-snug text-muted-foreground">
+              {item.summary}
+            </p>
+          </TraceExpandPanel>
+        ) : null}
+      </TraceTimelineRow>
+    </TraceThreadNode>
+  );
+}
+
+function displayItemStatus(
+  item: SessionTimelineItem,
+  budgetLimited: boolean,
+): SessionTimelineItem["status"] {
+  if (item.kind !== "tool" || !item.tool) return item.status;
+  const effectiveState = effectiveToolState(item.tool);
+  if (
+    item.runStatus !== "running" &&
+    item.tool.activity?.status === "running" &&
+    (effectiveState === "input-streaming" ||
+      effectiveState === "input-available")
+  ) {
+    return budgetLimited ? "completed" : "error";
+  }
+  if (effectiveState === "output-error") return "error";
+  return item.status;
+}
+
+function ToolEntryExpandPanel({
+  entry,
+  runStatus,
+  onApproval,
+}: {
+  entry: ToolTraceEntry;
+  runStatus: SessionTimelineRunGroup["run"]["status"];
+  budgetLimited?: boolean;
+  onApproval: ChatAddToolApproveResponseFunction;
+}) {
+  const displayState = effectiveToolState(entry);
+  const errored =
+    displayState === "output-error" ||
+    (entry.state === "output-available" &&
+      typeof entry.output === "object" &&
+      entry.output !== null &&
+      "ok" in entry.output &&
+      (entry.output as { ok: unknown }).ok === false);
+  const denied = displayState === "output-denied";
+  const approvalMeta =
+    entry.state === "approval-requested"
+      ? getApprovalMetadata(entry)
+      : undefined;
+  const permissionLabel = approvalMeta?.riskCategories[0];
+  const streamToken = pickString(entry.activity?.details, "streamToken");
+  const showWriteDiff =
+    entry.name === "write_file" &&
+    entry.state === "output-available" &&
+    isOkWriteFileOutput(entry.output) &&
+    pickString(entry.input, "content") !== undefined;
+  const editOutput = isOkEditFileOutput(entry.output) ? entry.output : undefined;
+  const showEditDiff =
+    entry.name === "edit_file" &&
+    entry.state === "output-available" &&
+    typeof editOutput?.previousContent === "string" &&
+    typeof editOutput.nextContent === "string";
+
+  return (
+    <TraceExpandPanel errored={errored} denied={denied}>
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+        <span className="inline-flex min-w-0 items-center gap-1.5 font-mono text-[10px] font-medium text-foreground/90">
+          {entry.name}
+          {permissionLabel ? (
+            <PermissionLabel label={permissionLabel} />
+          ) : null}
+        </span>
+        {displayState !== "output-available" || errored ? (
+          <StatusPill
+            status={
+              errored
+                ? "error"
+                : denied
+                  ? "denied"
+                  : displayState === "approval-requested"
+                    ? "pending"
+                    : "running"
+            }
+          />
+        ) : null}
+        {entry.activity?.details &&
+        typeof entry.activity.details === "object" &&
+        "stepNumber" in entry.activity.details &&
+        typeof entry.activity.details.stepNumber === "number" ? (
+          <span className="text-[10px] text-muted-foreground">
+            step {harnessStepDisplayNumber(entry.activity.details.stepNumber)}
+          </span>
+        ) : null}
+      </div>
+
+      {approvalMeta ? (
+        <div className="mt-1.5 space-y-1 border-t border-border/30 pt-1.5">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <ShieldCheck className="size-3 shrink-0 text-sky-400/90" />
+            <span className="min-w-0 flex-1 truncate text-[10px] font-medium text-foreground/85">
+              {approvalMeta.title}
+            </span>
+            {entry.state === "approval-requested" ? (
+              <StatusPill status="pending" />
+            ) : null}
+          </div>
+          <ApprovalDetails approval={approvalMeta} compact />
+          {approvalMeta.riskCategories.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {approvalMeta.riskCategories.map((category) => {
+                const badge = riskCategoryBadge(category);
+                return (
+                  <span
+                    key={category}
+                    className={cn(
+                      "rounded px-1.5 py-px font-mono text-[9px] uppercase tracking-wide",
+                      badge.baseClass,
+                    )}
+                  >
+                    {badge.label}
+                  </span>
+                );
+              })}
+            </div>
+          ) : null}
+          {entry.state === "approval-requested" && entry.approvalId ? (
+            <div className="flex items-center gap-1 pt-0.5">
+              <button
+                type="button"
+                className="inline-flex size-6 items-center justify-center rounded hover:bg-emerald-500/15"
+                title="Approve"
+                onClick={() =>
+                  onApproval({ id: entry.approvalId as string, approved: true })
+                }
+              >
+                <CheckCircle2 className="size-4 text-emerald-400" />
+              </button>
+              <button
+                type="button"
+                className="inline-flex size-6 items-center justify-center rounded hover:bg-destructive/15"
+                title="Deny"
+                onClick={() =>
+                  onApproval({ id: entry.approvalId as string, approved: false })
+                }
+              >
+                <XCircle className="size-4 text-destructive" />
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {approvalMeta?.diffPreview ? (
+        <div className="mt-1.5 border-t border-border/30 pt-1.5">
+          <DiffView
+            previous={approvalMeta.diffPreview.previous}
+            next={approvalMeta.diffPreview.next}
+            newFile={approvalMeta.diffPreview.previous.length === 0}
+          />
+        </div>
+      ) : null}
+
+      <div className="mt-1.5 border-t border-border/30 pt-1.5">
+        {showWriteDiff ? (
+          <DiffView
+            previous={(entry.output as WriteFileOkOutput).previousContent ?? ""}
+            next={pickString(entry.input, "content") ?? ""}
+            newFile={(entry.output as WriteFileOkOutput).existed === false}
+            filename={pickString(entry.input, "path")}
+          />
+        ) : showEditDiff ? (
+          <DiffView
+            previous={editOutput?.previousContent ?? ""}
+            next={editOutput?.nextContent ?? ""}
+            filename={pickString(entry.input, "path")}
+          />
+        ) : entry.name === "bash" &&
+          runStatus === "running" &&
+          entry.activity?.status === "running" &&
+          entry.activity?.toolCallId ? (
+          <LiveTerminalOutput
+            command={pickString(entry.input, "command")}
+            streamId={entry.activity.toolCallId}
+            streamToken={streamToken}
+            initialOutput={
+              typeof entry.output === "object" && entry.output !== null
+                ? (entry.output as {
+                    stdout?: string;
+                    stderr?: string;
+                    exitCode?: number | null;
+                    timedOut?: boolean;
+                    killed?: boolean;
+                    failedReason?:
+                      | "timeout"
+                      | "killed"
+                      | "max_buffer"
+                      | "error";
+                  })
+                : undefined
+            }
+          />
+        ) : entry.name === "bash" ? (
+          <TerminalOutput
+            command={
+              pickString(entry.input, "command") ?? safeStringify(entry.input)
+            }
+            output={bashOutputFromEntry(entry)}
+            className="text-[10px]"
+          />
+        ) : (
+          <ToolIoBlocks entry={entry} />
+        )}
+      </div>
+    </TraceExpandPanel>
+  );
+}
+
+function ToolIoBlocks({ entry }: { entry: ToolTraceEntry }) {
+  const inputText = safeStringify(entry.input);
+  const outputText =
+    entry.state === "output-error" && entry.errorText
+      ? undefined
+      : entry.output !== undefined
+        ? safeStringify(entry.output)
+        : undefined;
+
+  return (
+    <div className="space-y-1.5">
+      {inputText ? (
+        <TraceLogBlock title="Input">{inputText}</TraceLogBlock>
+      ) : null}
+      {outputText ? (
+        <TraceLogBlock title="Output">{outputText}</TraceLogBlock>
+      ) : null}
+      {entry.errorText ? (
+        <TraceLogBlock title="Error" tone="error">
+          {entry.errorText}
+        </TraceLogBlock>
+      ) : null}
+    </div>
+  );
+}
+
+function bashOutputFromEntry(entry: ToolTraceEntry): BashOutput {
+  const failedReason = parseFailedReason(
+    entry.errorText ?? pickString(entry.output as Record<string, unknown>, "failedReason"),
+  );
+  const stdout =
+    typeof entry.output === "object" &&
+    entry.output !== null &&
+    typeof (entry.output as Record<string, unknown>).stdout === "string"
+      ? ((entry.output as Record<string, unknown>).stdout as string)
+      : undefined;
+  const stderr =
+    entry.errorText && entry.errorText !== failedReason
+      ? entry.errorText
+      : typeof entry.output === "object" &&
+          entry.output !== null &&
+          typeof (entry.output as Record<string, unknown>).stderr === "string"
+        ? ((entry.output as Record<string, unknown>).stderr as string)
+        : undefined;
+
+  return {
+    ...(stdout ? { stdout } : {}),
+    ...(stderr ? { stderr } : {}),
+    exitCode:
+      typeof entry.output === "object" &&
+      entry.output !== null &&
+      typeof (entry.output as Record<string, unknown>).exitCode === "number"
+        ? ((entry.output as Record<string, unknown>).exitCode as number)
+        : entry.state === "output-error"
+          ? 1
+          : null,
+    ...(failedReason === "timeout" ? { timedOut: true, failedReason } : {}),
+    ...(failedReason && failedReason !== "timeout" ? { failedReason } : {}),
+  };
+}
+
+function parseFailedReason(
+  value: string | undefined,
+): BashOutput["failedReason"] {
+  if (!value) return undefined;
+  if (value === "timeout" || value === "killed" || value === "max_buffer") {
+    return value;
+  }
+  if (value === "error") return "error";
+  return undefined;
+}

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
-  CheckCircle2,
   FileText,
   GitBranch,
   GitCompareArrows,
@@ -15,36 +14,20 @@ import {
   Plus,
   TerminalSquare,
   X,
-  XCircle,
 } from "lucide-react";
 
 import {
   getAssistantTextDisplay,
   getPlanMessages,
   getToolTraceEntries,
-  getApprovalMetadata,
   type AntonUIMessage,
   type ToolTraceEntry,
 } from "@/src/lib/trace";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Markdown } from "@/components/features/chat/markdown";
-import { DiffView } from "./diff-view";
-import {
-  isOkWriteFileOutput,
-  isOkEditFileOutput,
-  effectiveToolState,
-  pickString,
-  previewToolInput,
-  riskCategoryBadge,
-  safeStringify,
-  toolStateMeta,
-  type WriteFileOkOutput,
-} from "./tool-display";
-import { TerminalOutput } from "./terminal-output";
-import { LiveTerminalOutput } from "./live-terminal";
-import { ApprovalDetails } from "./approval-details";
 import { TodoCard } from "./todo-card";
+import { WorklogTimeline } from "./worklog-timeline";
 import { getSessionTodoSnapshots } from "./trace-data";
 import { PullRequestEmptyPanel, PullRequestPanel } from "./pr-sidebar";
 import { ProjectFilesPanel } from "./project-files-panel";
@@ -344,39 +327,7 @@ function WorklogPanel({
   messages: AntonUIMessage[];
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const entries = getWorklogEntries(messages);
-  const latest = entries.at(-1);
-  const selected =
-    entries.find((entry) => entry.id === selectedId) ?? latest ?? null;
-
-  return (
-    <>
-      {entries.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center px-4 text-center text-xs text-muted-foreground">
-          Tool activity will appear here when Anton reads, searches, edits, or
-          runs commands.
-        </div>
-      ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          <ol className="border-b border-border px-2 py-2">
-            {entries.map((entry) => (
-              <li key={entry.id}>
-                <WorklogRow
-                  entry={entry}
-                  active={entry.id === selected?.id}
-                  onSelect={() => setSelectedId(entry.id)}
-                />
-              </li>
-            ))}
-          </ol>
-          {selected && (
-            <WorklogDetail entry={selected} onApproval={onApproval} />
-          )}
-        </div>
-      )}
-    </>
-  );
+  return <WorklogTimeline messages={messages} onApproval={onApproval} />;
 }
 export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
   return getToolTraceEntries(messages);
@@ -645,218 +596,3 @@ function useProjectPullRequest(
   };
 }
 
-function WorklogRow({
-  entry,
-  active,
-  onSelect,
-}: {
-  entry: WorklogEntry;
-  active: boolean;
-  onSelect: () => void;
-}) {
-  const state = toolStateMeta(effectiveToolState(entry));
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={cn(
-        "grid w-full grid-cols-[0.875rem_1fr] gap-1.5 rounded-md px-1.5 py-1 text-left text-xs transition-colors",
-        active ? "bg-accent/70" : "hover:bg-accent/40",
-      )}
-      aria-pressed={active}
-    >
-      <state.Icon
-        className={cn("mt-0.5 size-3", state.iconClass)}
-        aria-hidden
-      />
-      <div className="min-w-0">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate font-mono text-[11px] text-foreground">
-            {entry.name}
-          </span>
-          {state.label.length > 0 && (
-            <span className={cn("shrink-0 text-[10px]", state.textClass)}>
-              {state.label}
-            </span>
-          )}
-        </div>
-        <p className="truncate font-mono text-[10px] text-muted-foreground">
-          {previewToolInput(entry.input)}
-        </p>
-      </div>
-    </button>
-  );
-}
-function WorklogDetail({
-  entry,
-  onApproval,
-}: {
-  entry: WorklogEntry;
-  onApproval: ChatAddToolApproveResponseFunction;
-}) {
-  const state = toolStateMeta(effectiveToolState(entry));
-  const showWriteDiff =
-    entry.name === "write_file" &&
-    entry.state === "output-available" &&
-    isOkWriteFileOutput(entry.output) &&
-    pickString(entry.input, "content") !== undefined;
-  const editOutput = isOkEditFileOutput(entry.output) ? entry.output : undefined;
-  const showEditDiff =
-    entry.name === "edit_file" &&
-    entry.state === "output-available" &&
-    typeof editOutput?.previousContent === "string" &&
-    typeof editOutput.nextContent === "string";
-  const streamToken = pickString(entry.activity?.details, "streamToken");
-  const approvalMeta =
-    entry.state === "approval-requested"
-      ? getApprovalMetadata(entry)
-      : undefined;
-
-  return (
-    <section className="space-y-2.5 px-3 py-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <state.Icon className={cn("size-3.5", state.iconClass)} />
-            {state.label.length > 0 && <span>{state.label}</span>}
-          </div>
-          <h2 className="mt-0.5 truncate font-mono text-xs font-semibold">
-            {entry.name}
-          </h2>
-        </div>
-        {entry.state === "approval-requested" && entry.approvalId && (
-          <div className="flex shrink-0 items-center gap-0.5">
-            <button
-              type="button"
-              className="inline-flex items-center justify-center size-6 rounded hover:bg-emerald-500/15"
-              title="Approve"
-              onClick={() =>
-                onApproval({ id: entry.approvalId as string, approved: true })
-              }
-            >
-              <CheckCircle2 className="size-4 text-emerald-400" />
-            </button>
-            <button
-              type="button"
-              className="inline-flex items-center justify-center size-6 rounded hover:bg-destructive/15"
-              title="Deny"
-              onClick={() =>
-                onApproval({ id: entry.approvalId as string, approved: false })
-              }
-            >
-              <XCircle className="size-4 text-destructive" />
-            </button>
-          </div>
-        )}
-        {approvalMeta && (
-          <div className="flex flex-wrap items-center gap-1">
-            {approvalMeta.riskCategories.map((cat) => {
-              const badge = riskCategoryBadge(cat);
-              return (
-                <span
-                  key={cat}
-                  className={cn(
-                    "rounded px-1.5 py-px font-mono text-[10px] uppercase",
-                    badge.baseClass,
-                  )}
-                >
-                  {badge.label}
-                </span>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {approvalMeta && (
-        <ApprovalDetails approval={approvalMeta} />
-      )}
-
-      {approvalMeta?.diffPreview && (
-        <DiffView
-          previous={approvalMeta.diffPreview.previous}
-          next={approvalMeta.diffPreview.next}
-          newFile={approvalMeta.diffPreview.previous.length === 0}
-        />
-      )}
-
-      {entry.name !== "bash" && (
-        <LogBlock title="Input">{safeStringify(entry.input)}</LogBlock>
-      )}
-
-      {showWriteDiff ? (
-        <DiffView
-          previous={(entry.output as WriteFileOkOutput).previousContent ?? ""}
-          next={pickString(entry.input, "content") ?? ""}
-          newFile={(entry.output as WriteFileOkOutput).existed === false}
-          filename={pickString(entry.input, "path")}
-        />
-      ) : showEditDiff ? (
-        <DiffView
-          previous={editOutput?.previousContent ?? ""}
-          next={editOutput?.nextContent ?? ""}
-          filename={pickString(entry.input, "path")}
-        />
-      ) : entry.name === "bash" && entry.activity?.status === "running" && entry.activity?.toolCallId ? (
-        <LiveTerminalOutput
-          command={pickString(entry.input, "command")}
-          streamId={entry.activity.toolCallId}
-          streamToken={streamToken}
-          initialOutput={
-            typeof entry.output === "object" && entry.output !== null
-              ? (entry.output as {
-                  stdout?: string;
-                  stderr?: string;
-                  exitCode?: number | null;
-                  timedOut?: boolean;
-                  killed?: boolean;
-                  failedReason?: "timeout" | "killed" | "max_buffer" | "error";
-                })
-              : undefined
-          }
-        />
-      ) : entry.name === "bash" ? (
-        <TerminalOutput
-          command={pickString(entry.input, "command") ?? safeStringify(entry.input)}
-          output={
-            entry.state === "output-error" && entry.errorText
-              ? { stderr: entry.errorText, exitCode: 1 }
-              : entry.output
-          }
-        />
-      ) : entry.state === "output-error" && entry.errorText ? (
-        <LogBlock title="Error" tone="error">
-          {entry.errorText}
-        </LogBlock>
-      ) : entry.output !== undefined ? (
-        <LogBlock title="Output">{safeStringify(entry.output)}</LogBlock>
-      ) : null}
-    </section>
-  );
-}
-
-function LogBlock({
-  title,
-  tone,
-  children,
-}: {
-  title: string;
-  tone?: "error";
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="space-y-1">
-      <div
-        className={cn(
-          "text-[10px] font-medium uppercase text-muted-foreground",
-          tone === "error" && "text-destructive",
-        )}
-      >
-        {title}
-      </div>
-      <pre className="max-h-56 overflow-auto rounded-md bg-background/70 p-2.5 font-mono text-[10px] leading-relaxed text-foreground/90 whitespace-pre-wrap">
-        {children}
-      </pre>
-    </div>
-  );
-}

--- a/components/features/settings/agent-settings-panel.tsx
+++ b/components/features/settings/agent-settings-panel.tsx
@@ -184,7 +184,7 @@ export function AgentSettingsPanel() {
                 placeholder="Profile default"
                 onChange={(event) => {
                   const next = event.target.value.replace(/\D/g, "");
-                  if (next === "" || Number(next) <= 50) {
+                  if (next === "" || Number(next) <= 64) {
                     setMaxSteps(next);
                   }
                 }}

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -4,6 +4,11 @@ import {
   upsertRunContextSummary,
 } from "@/src/db/queries";
 import { redactText } from "@/src/lib/redaction";
+import {
+  outputExitCode,
+  summarizeToolInput,
+  summarizeToolOutput,
+} from "@/src/lib/tool-summaries";
 
 const RECENT_CONTEXT_COUNT = 5;
 const DEFAULT_CONTEXT_BUDGET_CHARS = 6_000;
@@ -59,8 +64,13 @@ export class RunContextCollector {
   }): void {
     const error = toolError(event.success, event.output, event.error);
     const status = error ? "error" : "completed";
-    const inputSummary = summarizeInput(event.input);
-    const outputSummary = summarizeOutput(event.output, event.error);
+    const inputSummary = summarizeToolInput(event.input, compactLine);
+    const outputSummary = summarizeToolOutput(
+      event.toolName,
+      event.output,
+      event.error,
+      compactLine,
+    );
     const exitCode = outputExitCode(event.output);
 
     this.tools.push({
@@ -181,28 +191,6 @@ export class RunContextCollector {
     }
     if (finalText?.trim()) {
       lines.push(`Final answer: ${compactBlock(finalText, MAX_SUMMARY_CHARS)}`);
-    }
-    const facts = Array.from(this.facts).slice(0, 8);
-    if (facts.length > 0) lines.push(`Facts: ${facts.join("; ")}`);
-    if (this.commands.length > 0) {
-      lines.push(
-        `Commands: ${this.commands
-          .slice(-5)
-          .map((command) => {
-            const status =
-              command.exitCode === null ? "no exit" : `exit ${command.exitCode}`;
-            return `${command.command} (${status})`;
-          })
-          .join("; ")}`,
-      );
-    }
-    if (this.files.size > 0) {
-      lines.push(
-        `Files: ${Array.from(this.files.values())
-          .slice(-12)
-          .map((file) => `${file.action} ${file.path}`)
-          .join("; ")}`,
-      );
     }
     return compactBlock(lines.join("\n"), MAX_SUMMARY_CHARS);
   }
@@ -350,27 +338,6 @@ function readPath(input: unknown): string | undefined {
   return path || undefined;
 }
 
-function summarizeInput(input: unknown): string | undefined {
-  if (!isRecord(input)) return undefined;
-  for (const key of ["command", "path", "sourcePath", "pattern", "slug", "task"]) {
-    const value = stringValue(input[key]);
-    if (value) return compactLine(value, 500);
-  }
-  return undefined;
-}
-
-function summarizeOutput(output: unknown, error: unknown): string | undefined {
-  const message = errorMessageOrUndefined(error);
-  if (message) return compactLine(message, 500);
-  if (!isRecord(output)) return undefined;
-  for (const key of ["error", "failedReason", "path", "summary", "stdout"]) {
-    const value = stringValue(output[key]);
-    if (value) return compactLine(value, 500);
-  }
-  const exitCode = outputExitCode(output);
-  return exitCode !== undefined ? `exit ${exitCode}` : undefined;
-}
-
 function toolError(
   success: boolean,
   output: unknown,
@@ -387,14 +354,6 @@ function toolError(
   const exitCode = outputExitCode(output);
   if (exitCode !== undefined && exitCode !== 0) return `exit ${exitCode}`;
   return undefined;
-}
-
-function outputExitCode(output: unknown): number | undefined {
-  if (!isRecord(output)) return undefined;
-  const exitCode = output.exitCode;
-  return typeof exitCode === "number" && Number.isInteger(exitCode)
-    ? exitCode
-    : undefined;
 }
 
 function commandArray(value: unknown): RunContextCommand[] {
@@ -445,7 +404,7 @@ function optionalString<K extends string>(
   return text ? ({ [key]: text } as Partial<Record<K, string>>) : {};
 }
 
-function compactLine(value: string, maxLength: number): string {
+function compactLine(value: string, maxLength = 500): string {
   return truncate(redactText(value).replace(/\s+/g, " ").trim(), maxLength);
 }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -16,10 +16,17 @@ import {
   buildTokenUsageMetrics,
   openRouterCostFromMetadata,
 } from "@/src/lib/token-usage";
+import {
+  estimateTokensFromBytes,
+  estimateTokensFromText,
+  estimateToolDefinitionsTokens,
+  type ContextCompositionAudit,
+} from "@/src/lib/context-composition";
 import { listMemories } from "@/src/db/queries";
 import {
   budgetForProfile,
   capRunBudget,
+  applyTokenBudgetMultiplier,
   costBudgetStopCondition,
   tokenBudgetStopCondition,
   type RunBudget,
@@ -63,6 +70,7 @@ export type TokenAudit = {
     activeCount: number;
   };
   budget: RunBudgetAudit;
+  contextComposition: ContextCompositionAudit;
   usage?: UsageAudit;
   steps: StepUsageAudit[];
 };
@@ -169,19 +177,25 @@ const PROFILE_NATIVE_TOOLS = {
   "approval-continuation": NATIVE_ANTON_TOOL_NAMES,
 } as const satisfies Record<AgentRunProfile, readonly NativeAntonToolName[]>;
 
-function systemPrompt(
-  mcpTools: LoadedMcpTools,
-  workspaceRoot?: string,
-  mode: AgentRunMode = "ask",
-  profile: AgentRunProfile = profileForMode(mode),
-): string {
-  if (profile === "pure-chat") return pureChatSystemPrompt();
+type SystemPromptParts = {
+  base: string;
+  mcp: string;
+  memory: string;
+  skills: string;
+  profile: string;
+};
 
+function buildSystemPromptParts(
+  mcpTools: LoadedMcpTools,
+  workspaceRoot: string | undefined,
+  mode: AgentRunMode,
+  profile: AgentRunProfile,
+): SystemPromptParts {
   const root = workspaceRoot
     ? ensureWorkspaceRootAt(workspaceRoot)
     : ensureWorkspaceRoot();
   const rel = workspaceRoot ? workspaceRelativeTo(root, root) : workspaceRelative(root);
-  return [
+  const base = [
     "You are Anton, a minimal coding-agent harness. Your job is to explore, read,",
     "and modify code inside a sandboxed workspace directory on the user's machine.",
     "",
@@ -209,15 +223,39 @@ function systemPrompt(
     "- When you finish, report changed files, verification results, and unresolved risks or skipped checks. If the run reaches the max step limit, stop and say what remains instead of implying completion.",
     "- Do not guess file contents - read them first.",
     "- Model-only prior run context may appear as an assistant message before the latest user request. Use it for continuity, but re-read files or rerun commands when exact current state matters.",
-    "",
-    ...mcpToolPromptLines(mcpTools),
-    "",
-    ...projectMemoryPromptLines(),
-    "",
-    ...projectSkillPromptLines(workspaceRoot),
-    "",
-    ...runProfilePromptLines(mode, profile),
   ].join("\n");
+
+  return {
+    base,
+    mcp: mcpToolPromptLines(mcpTools).join("\n"),
+    memory: projectMemoryPromptLines().join("\n"),
+    skills: projectSkillPromptLines(workspaceRoot).join("\n"),
+    profile: runProfilePromptLines(mode, profile).join("\n"),
+  };
+}
+
+function buildContextCompositionAudit({
+  systemParts,
+  tools,
+  messageBytes,
+  priorRunContextBytes,
+}: {
+  systemParts: SystemPromptParts;
+  tools: ToolSet;
+  messageBytes: number;
+  priorRunContextBytes: number;
+}): ContextCompositionAudit {
+  return {
+    systemPromptTokens: estimateTokensFromText(systemParts.base),
+    toolDefinitionsTokens: estimateToolDefinitionsTokens(tools),
+    memoryTokens: estimateTokensFromText(systemParts.memory),
+    skillsTokens: estimateTokensFromText(systemParts.skills),
+    mcpPromptTokens: estimateTokensFromText(systemParts.mcp),
+    runProfileTokens: estimateTokensFromText(systemParts.profile),
+    priorRunContextTokens: estimateTokensFromBytes(priorRunContextBytes),
+    conversationTokens: estimateTokensFromBytes(messageBytes),
+    source: "estimated",
+  };
 }
 
 function pureChatSystemPrompt(): string {
@@ -358,6 +396,9 @@ export async function runAgent({
   maxStepsCap,
   requestBodyBytes,
   contextBudget,
+  tokenBudgetMultiplier = 1,
+  priorTokensUsed = 0,
+  priorCostUsd = 0,
   onStepStart,
   onStepFinish,
   onToolCallStart,
@@ -378,6 +419,9 @@ export async function runAgent({
   maxStepsCap?: number | null;
   requestBodyBytes?: number;
   contextBudget?: ContextBudgetAudit;
+  tokenBudgetMultiplier?: number;
+  priorTokensUsed?: number;
+  priorCostUsd?: number;
   onStepStart?: (event: { stepNumber: number }) => void;
   onStepFinish?: (event: { stepNumber: number }) => void;
   onToolCallStart?: (event: {
@@ -407,14 +451,18 @@ export async function runAgent({
     stepCount: number;
     maxSteps: number;
     maxTotalTokens: number;
+    baseMaxTotalTokens: number;
     maxCostUsd: number;
+    priorTokensUsed: number;
+    priorCostUsd: number;
     maxStepLimitReached: boolean;
     tokenBudgetReached: boolean;
     costBudgetReached: boolean;
     tokenAudit: TokenAudit;
   }) => void;
 }) {
-  const budget = capRunBudget(budgetForProfile(profile), maxStepsCap);
+  const baseBudget = capRunBudget(budgetForProfile(profile), maxStepsCap);
+  const budget = applyTokenBudgetMultiplier(baseBudget, tokenBudgetMultiplier);
   const nativeToolNames = PROFILE_NATIVE_TOOLS[profile];
   const allowMcpTools = profileAllowsMcp(profile);
   const mcpTools = allowMcpTools
@@ -446,18 +494,39 @@ export async function runAgent({
     includeMcpTools: allowMcpTools,
     executionCache,
   });
-  const system = systemPrompt(
-    mcpTools,
-    workspaceRoot,
-    mode,
-    profile,
-  );
+  const systemParts =
+    profile === "pure-chat"
+      ? {
+          base: pureChatSystemPrompt(),
+          mcp: "",
+          memory: "",
+          skills: "",
+          profile: "",
+        }
+      : buildSystemPromptParts(mcpTools, workspaceRoot, mode, profile);
+  const system =
+    profile === "pure-chat"
+      ? systemParts.base
+      : [
+          systemParts.base,
+          systemParts.mcp,
+          systemParts.memory,
+          systemParts.skills,
+          systemParts.profile,
+        ].join("\n\n");
   const activeTools = Object.keys(tools);
+  const messageBytes = utf8Bytes(stableJson(messages));
+  const contextComposition = buildContextCompositionAudit({
+    systemParts,
+    tools,
+    messageBytes,
+    priorRunContextBytes: contextBudget?.contextDigestBytes ?? 0,
+  });
   const tokenAuditBase = {
     profile,
     mode,
     ...(requestBodyBytes !== undefined ? { requestBytes: requestBodyBytes } : {}),
-    messageBytes: utf8Bytes(stableJson(messages)),
+    messageBytes,
     systemPromptBytes: utf8Bytes(system),
     tools: {
       nativeCount: nativeToolNames.length,
@@ -476,6 +545,7 @@ export async function runAgent({
       priorRunContextChars: budget.priorRunContextChars,
       workspaceContextChars: budget.workspaceContextChars,
     },
+    contextComposition,
     ...(contextBudget ? { contextBudget } : {}),
   };
 
@@ -488,8 +558,8 @@ export async function runAgent({
     activeTools,
     stopWhen: [
       stepCountIs(budget.maxSteps),
-      tokenBudgetStopCondition(budget.maxTotalTokens),
-      costBudgetStopCondition(budget.maxCostUsd),
+      tokenBudgetStopCondition(budget.maxTotalTokens, priorTokensUsed),
+      costBudgetStopCondition(budget.maxCostUsd, priorCostUsd),
     ],
     providerOptions: {
       openrouter: openRouterProviderOptions(profile, thinkingEnabled),
@@ -586,6 +656,9 @@ export async function runAgent({
         usage: usageAudit(totalUsage, providerMetadata),
         steps: stepUsage,
       };
+      const segmentTokens = finiteNumber(totalUsage.totalTokens) ?? 0;
+      const segmentCost =
+        openRouterCostFromMetadata(undefined, stepProviderMetadata) ?? 0;
       onFinish?.({
         totalUsage,
         finishReason,
@@ -594,15 +667,17 @@ export async function runAgent({
         stepCount: observedStepCount,
         maxSteps: budget.maxSteps,
         maxTotalTokens: budget.maxTotalTokens,
+        baseMaxTotalTokens: baseBudget.maxTotalTokens,
         maxCostUsd: budget.maxCostUsd,
+        priorTokensUsed,
+        priorCostUsd,
         maxStepLimitReached:
           observedStepCount >= budget.maxSteps && finishReason === "tool-calls",
         tokenBudgetReached:
-          finiteNumber(totalUsage.totalTokens) !== undefined &&
-          (totalUsage.totalTokens ?? 0) >= budget.maxTotalTokens,
+          priorTokensUsed + segmentTokens >= budget.maxTotalTokens,
         costBudgetReached:
-          (openRouterCostFromMetadata(undefined, stepProviderMetadata) ?? 0) >=
-          budget.maxCostUsd,
+          priorCostUsd + segmentCost >= budget.maxCostUsd &&
+          segmentCost > 0,
         tokenAudit,
       });
       await closeMcpTools();

--- a/src/agent/run-budget.ts
+++ b/src/agent/run-budget.ts
@@ -1,4 +1,9 @@
-import type { StopCondition, ToolSet } from "ai";
+import {
+  stepCountIs,
+  type ProviderMetadata,
+  type StopCondition,
+  type ToolSet,
+} from "ai";
 
 import { openRouterCostFromMetadata } from "@/src/lib/token-usage";
 import type { AgentRunProfile } from "./loop";
@@ -38,7 +43,7 @@ const RUN_BUDGETS = {
     workspaceContextChars: 4_000,
   },
   plan: {
-    maxSteps: 8,
+    maxSteps: 16,
     maxOutputTokens: 4_096,
     maxInputTokens: 48_000,
     maxTotalTokens: 64_000,
@@ -47,7 +52,7 @@ const RUN_BUDGETS = {
     workspaceContextChars: 5_000,
   },
   "accepted-plan-simple": {
-    maxSteps: 8,
+    maxSteps: 16,
     maxOutputTokens: 4_096,
     maxInputTokens: 32_000,
     maxTotalTokens: 48_000,
@@ -56,7 +61,7 @@ const RUN_BUDGETS = {
     workspaceContextChars: 3_000,
   },
   "accepted-plan-general": {
-    maxSteps: 16,
+    maxSteps: 32,
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
@@ -74,7 +79,7 @@ const RUN_BUDGETS = {
     workspaceContextChars: 2_500,
   },
   "general-chat": {
-    maxSteps: 20,
+    maxSteps: 32,
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
@@ -83,7 +88,7 @@ const RUN_BUDGETS = {
     workspaceContextChars: 6_000,
   },
   "approval-continuation": {
-    maxSteps: 20,
+    maxSteps: 32,
     maxOutputTokens: 8_192,
     maxInputTokens: 64_000,
     maxTotalTokens: 96_000,
@@ -118,26 +123,67 @@ export function capRunBudget(
   };
 }
 
+export function applyTokenBudgetMultiplier(
+  budget: RunBudget,
+  multiplier: number,
+): RunBudget {
+  const scale = Math.max(1, Math.floor(multiplier));
+  return {
+    ...budget,
+    maxTotalTokens: budget.maxTotalTokens * scale,
+    maxCostUsd: budget.maxCostUsd * scale,
+  };
+}
+
+export const TOKEN_BUDGET_MULTIPLIER_OPTIONS = [2, 3, 5] as const;
+
+export type TokenBudgetMultiplierOption =
+  (typeof TOKEN_BUDGET_MULTIPLIER_OPTIONS)[number];
+
+export function availableTokenBudgetMultipliers(
+  currentMultiplier: number,
+): TokenBudgetMultiplierOption[] {
+  return TOKEN_BUDGET_MULTIPLIER_OPTIONS.filter(
+    (option) => option > currentMultiplier,
+  );
+}
+
 export function tokenBudgetStopCondition(
   maxTotalTokens: number,
+  priorTokensUsed = 0,
 ): StopCondition<ToolSet> {
   return ({ steps }) => {
-    return totalStepTokens(steps) >= maxTotalTokens;
+    return priorTokensUsed + totalStepTokens(steps) >= maxTotalTokens;
   };
 }
 
 export function costBudgetStopCondition(
   maxCostUsd: number,
+  priorCostUsd = 0,
 ): StopCondition<ToolSet> {
   return ({ steps }) => {
-    const costUsd = openRouterCostFromMetadata(
-      undefined,
-      steps
-        .map((step) => step.providerMetadata)
-        .filter((metadata) => metadata !== undefined),
+    const segmentCost = totalStepCostUsd(steps);
+    return (
+      segmentCost !== undefined && priorCostUsd + segmentCost >= maxCostUsd
     );
-    return costUsd !== undefined && costUsd >= maxCostUsd;
   };
+}
+
+export function remainingStepsStopCondition(
+  maxSteps: number,
+  priorStepCount: number,
+): StopCondition<ToolSet> {
+  const remaining = Math.max(1, maxSteps - priorStepCount);
+  return stepCountIs(remaining);
+}
+
+function totalStepCostUsd(
+  steps: readonly { providerMetadata?: ProviderMetadata }[],
+): number | undefined {
+  const stepProviderMetadata = steps.flatMap((step) =>
+    step.providerMetadata ? [step.providerMetadata] : [],
+  );
+  return openRouterCostFromMetadata(undefined, stepProviderMetadata);
 }
 
 function totalStepTokens(

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -14,13 +14,14 @@ import {
 import { redactText } from "@/src/lib/redaction";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_TIMEOUT_MS = 300_000;
+const SEARCH_COMMAND_TIMEOUT_MS = 240_000;
 
 export function createBashTool(workspaceRoot?: string) {
   return tool({
     description:
-      "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. `sudo` is forbidden. Requires user approval.",
+      "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. Prefer the `grep` tool for workspace text search instead of shell `grep`. `sudo` is forbidden. Requires user approval.",
     inputSchema: z.object({
       command: z.string().describe("Shell command to execute via `bash -lc`."),
       timeoutMs: z
@@ -51,7 +52,11 @@ export function createBashTool(workspaceRoot?: string) {
         };
       }
 
-      const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const timeout =
+        timeoutMs ??
+        (looksLikeSearchCommand(command)
+          ? SEARCH_COMMAND_TIMEOUT_MS
+          : DEFAULT_TIMEOUT_MS);
       const classification = policy.classification;
 
       return executeWithStreaming(command, root, timeout, toolCallId, classification);
@@ -100,7 +105,7 @@ async function executeWithStreaming(
   timeout: number,
   streamId: string,
   classification: ReturnType<typeof classifyBashCommand>,
-): Promise<BashToolOkOutput | BashToolErrorOutput> {
+): Promise<BashToolOutput | BashToolErrorOutput> {
   bashProgress.startStream(streamId);
 
   const stdoutChunks: string[] = [];
@@ -149,8 +154,11 @@ async function executeWithStreaming(
     });
     sentExit = true;
 
+    const commandFailed =
+      failedReason !== undefined ||
+      (exitCode !== null && exitCode !== 0);
     return {
-      ok: true as const,
+      ok: !commandFailed,
       classification,
       riskCategories: classification.categories as string[],
       exitCode,
@@ -160,6 +168,13 @@ async function executeWithStreaming(
       stdout: truncate(stdoutChunks.join("")),
       stderr: truncate(stderrChunks.join("")),
       streamId,
+      ...(commandFailed
+        ? {
+            error:
+              failedReason ??
+              (exitCode !== null ? `Command exited with code ${exitCode}.` : "Command failed"),
+          }
+        : {}),
     };
   } catch (err) {
     const error = redactText(errorMessage(err));
@@ -201,8 +216,8 @@ async function executeWithStreaming(
   }
 }
 
-type BashToolOkOutput = {
-  ok: true;
+type BashToolOutput = {
+  ok: boolean;
   classification: ReturnType<typeof classifyBashCommand>;
   riskCategories: string[];
   exitCode: number | null;
@@ -212,6 +227,7 @@ type BashToolOkOutput = {
   stdout: string;
   stderr: string;
   streamId: string;
+  error?: string;
 };
 
 type BashToolErrorOutput = {
@@ -241,6 +257,11 @@ function failedReasonForResult({
   if (killed) return "killed";
   if (isMaxBuffer) return "max_buffer";
   return undefined;
+}
+
+function looksLikeSearchCommand(command: string): boolean {
+  const trimmed = command.trim();
+  return /^(grep|rg|find)\b/.test(trimmed);
 }
 
 function errorMessage(err: unknown): string {

--- a/src/db/migrations/0012_rich_red_ghost.sql
+++ b/src/db/migrations/0012_rich_red_ghost.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `token_budget_multiplier` integer DEFAULT 1 NOT NULL;

--- a/src/db/migrations/meta/0012_snapshot.json
+++ b/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1481 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d083b074-c3de-47cc-8a2f-3e9219792c0e",
+  "prevId": "6ab2699e-6843-4a26-b910-86d4039c0737",
+  "tables": {
+    "background_command_sessions": {
+      "name": "background_command_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_kind": {
+          "name": "command_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stdout_tail": {
+          "name": "stdout_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stderr_tail": {
+          "name": "stderr_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "detected_urls": {
+          "name": "detected_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "background_command_sessions_project_id_idx": {
+          "name": "background_command_sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_status_idx": {
+          "name": "background_command_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_project_started_idx": {
+          "name": "background_command_sessions_project_started_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "background_command_sessions_project_id_projects_id_fk": {
+          "name": "background_command_sessions_project_id_projects_id_fk",
+          "tableFrom": "background_command_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_budget_multiplier": {
+          "name": "token_budget_multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_max_steps": {
+          "name": "default_max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_permission_mode": {
+          "name": "default_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779613188894,
       "tag": "0011_panoramic_hedge_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779694147271,
+      "tag": "0012_rich_red_ghost",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -91,6 +91,7 @@ export function createSession(input: {
   const row: Session = {
     ...input,
     projectId: input.projectId ?? null,
+    tokenBudgetMultiplier: 1,
     tokensTotal: 0,
     createdAt: now,
     updatedAt: now,
@@ -221,6 +222,97 @@ export function getLastRunForProject(projectId: string): Run | undefined {
     .orderBy(desc(runs.startedAt))
     .limit(1)
     .get();
+}
+
+export function getRunById(id: string): Run | undefined {
+  return db.select().from(runs).where(eq(runs.id, id)).get();
+}
+
+export function setSessionTokenBudgetMultiplier(
+  sessionId: string,
+  multiplier: number,
+): Session | undefined {
+  db
+    .update(sessions)
+    .set({ tokenBudgetMultiplier: multiplier, updatedAt: new Date() })
+    .where(eq(sessions.id, sessionId))
+    .run();
+  return getSession(sessionId);
+}
+
+export function listAssistantTurnRunIds(
+  sessionId: string,
+  anchorRunId: string,
+): string[] {
+  const sessionRuns = db
+    .select({ id: runs.id, finishReason: runs.finishReason })
+    .from(runs)
+    .where(eq(runs.sessionId, sessionId))
+    .orderBy(asc(runs.startedAt))
+    .all();
+
+  const anchorIndex = sessionRuns.findIndex((run) => run.id === anchorRunId);
+  if (anchorIndex === -1) return [anchorRunId];
+
+  let startIndex = anchorIndex;
+  while (
+    startIndex > 0 &&
+    sessionRuns[startIndex - 1]?.finishReason === "token_budget_limit"
+  ) {
+    startIndex -= 1;
+  }
+
+  return sessionRuns.slice(startIndex, anchorIndex + 1).map((run) => run.id);
+}
+
+export function getRunForProject(
+  projectId: string,
+  runId: string,
+): Run | undefined {
+  const projectSessions = db
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(eq(sessions.projectId, projectId))
+    .all();
+  const sessionIds = projectSessions.map((session) => session.id);
+  if (sessionIds.length === 0) return undefined;
+
+  return db
+    .select()
+    .from(runs)
+    .where(and(eq(runs.id, runId), inArray(runs.sessionId, sessionIds)))
+    .get();
+}
+
+export function listRunEventsForRun(runId: string): RunEvent[] {
+  return db
+    .select()
+    .from(runEvents)
+    .where(eq(runEvents.runId, runId))
+    .orderBy(asc(runEvents.sequence))
+    .all();
+}
+
+export function getRunContextSummaryByRunId(
+  runId: string,
+): RunContextSummary | undefined {
+  return db
+    .select()
+    .from(runContextSummaries)
+    .where(eq(runContextSummaries.runId, runId))
+    .get();
+}
+
+export function listToolApprovalsForRun(runId: string): ToolApproval[] {
+  const calls = listToolCallsForRun(runId);
+  if (calls.length === 0) return [];
+  const callIds = calls.map((call) => call.id);
+  return db
+    .select()
+    .from(toolApprovals)
+    .where(inArray(toolApprovals.toolCallId, callIds))
+    .orderBy(asc(toolApprovals.requestedAt))
+    .all();
 }
 
 export function listGithubInstallations(): GithubInstallation[] {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -76,6 +76,7 @@ export const sessions = sqliteTable(
     projectId: text("project_id").references(() => projects.id, {
       onDelete: "set null",
     }),
+    tokenBudgetMultiplier: integer("token_budget_multiplier").notNull().default(1),
     tokensTotal: integer("tokens_total").notNull().default(0),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .notNull()

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -82,6 +82,137 @@ export type ProjectLastRunSummary = {
   stepCount: number | null;
   totalTokens: number | null;
   costUsd: number | null;
+  finishReason: string | null;
+};
+
+export type ProjectRunDetailsContextComposition = {
+  systemPromptTokens: number;
+  toolDefinitionsTokens: number;
+  memoryTokens: number;
+  skillsTokens: number;
+  mcpPromptTokens: number;
+  runProfileTokens: number;
+  priorRunContextTokens: number;
+  conversationTokens: number;
+  source: "estimated";
+};
+
+export type ProjectRunDetailsStepUsage = {
+  stepNumber: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+  toolCallCount?: number;
+  finishReason?: string;
+};
+
+export type ProjectRunDetailsTokenUsage = {
+  rawInputTokens?: number;
+  uncachedInputTokens?: number;
+  cachedInputTokens?: number;
+  cacheWriteTokens?: number;
+  effectiveInputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  effectiveTokens?: number;
+  providerEffectiveTokens?: number;
+};
+
+export type ProjectRunDetailsRun = {
+  id: string;
+  sessionId: string;
+  status: "running" | "completed" | "error" | "aborted";
+  model: string;
+  provider: string | null;
+  startedAt: number;
+  finishedAt: number | null;
+  durationMs: number | null;
+  stepCount: number | null;
+  finishReason: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+  costUsd: number | null;
+  tokenUsage?: ProjectRunDetailsTokenUsage;
+  contextComposition?: ProjectRunDetailsContextComposition;
+  stepUsage?: ProjectRunDetailsStepUsage[];
+};
+
+export type ProjectRunDetailsEvent = {
+  id: string;
+  sequence: number;
+  kind: "step" | "reasoning" | "tool" | "approval" | "error" | "progress";
+  status: "running" | "completed" | "waiting" | "error" | "denied";
+  label: string;
+  summary: string | null;
+  startedAt: number;
+  durationMs: number | null;
+  toolCallId: string | null;
+};
+
+export type ProjectRunDetailsToolCall = {
+  id: string;
+  toolCallId: string;
+  toolName: string;
+  stepNumber: number | null;
+  status: "running" | "completed" | "error" | "denied";
+  approvalDecision: "pending" | "approved" | "denied" | null;
+  permissionLabel: string | null;
+  inputSummary: string | null;
+  outputSummary: string | null;
+  exitCode: number | null;
+  error: string | null;
+  durationMs: number | null;
+};
+
+export type ProjectRunDetailsApproval = {
+  toolCallId: string;
+  decision: "pending" | "approved" | "denied";
+  title: string;
+  summary: string;
+  riskCategories: string[];
+  requestedAt: number;
+  respondedAt: number | null;
+};
+
+export type ProjectRunDetailsContextCommand = {
+  command: string;
+  exitCode: number | null;
+  ok: boolean;
+  timedOut: boolean;
+  error?: string;
+};
+
+export type ProjectRunDetailsContextFile = {
+  path: string;
+  action: string;
+};
+
+export type ProjectRunDetailsContextTool = {
+  name: string;
+  status: "completed" | "error";
+  input?: string;
+  output?: string;
+  exitCode?: number | null;
+  error?: string;
+};
+
+export type ProjectRunDetailsContext = {
+  summary: string;
+  facts: string[];
+  files: ProjectRunDetailsContextFile[];
+  commands: ProjectRunDetailsContextCommand[];
+  tools: ProjectRunDetailsContextTool[];
+} | null;
+
+export type ProjectRunDetailsSummary = {
+  run: ProjectRunDetailsRun;
+  events: ProjectRunDetailsEvent[];
+  toolCalls: ProjectRunDetailsToolCall[];
+  approvals: ProjectRunDetailsApproval[];
+  context: ProjectRunDetailsContext;
+  segmentCount?: number;
 };
 
 export type ProjectBranchSummary = {

--- a/src/lib/context-composition.ts
+++ b/src/lib/context-composition.ts
@@ -1,0 +1,79 @@
+import type { ToolSet } from "ai";
+
+export const CONTEXT_BYTES_PER_TOKEN = 4;
+
+export type ContextCompositionAudit = {
+  systemPromptTokens: number;
+  toolDefinitionsTokens: number;
+  memoryTokens: number;
+  skillsTokens: number;
+  mcpPromptTokens: number;
+  runProfileTokens: number;
+  priorRunContextTokens: number;
+  conversationTokens: number;
+  source: "estimated";
+};
+
+export type ContextCompositionSection = {
+  key: string;
+  label: string;
+  tokens: number;
+};
+
+export function estimateTokensFromText(text: string): number {
+  return estimateTokensFromBytes(Buffer.byteLength(text, "utf8"));
+}
+
+export function estimateTokensFromBytes(bytes: number): number {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 0;
+  return Math.max(1, Math.round(bytes / CONTEXT_BYTES_PER_TOKEN));
+}
+
+export function estimateToolDefinitionsTokens(tools: ToolSet): number {
+  const payload = Object.entries(tools).map(([name, tool]) => ({
+    name,
+    description:
+      typeof tool.description === "string" ? tool.description : undefined,
+  }));
+  return estimateTokensFromText(JSON.stringify(payload));
+}
+
+export function contextCompositionSections(
+  composition: ContextCompositionAudit,
+): ContextCompositionSection[] {
+  return [
+    { key: "system", label: "System prompt", tokens: composition.systemPromptTokens },
+    {
+      key: "tools",
+      label: "Tool definitions",
+      tokens: composition.toolDefinitionsTokens,
+    },
+    { key: "memory", label: "Memory", tokens: composition.memoryTokens },
+    { key: "skills", label: "Skills", tokens: composition.skillsTokens },
+    { key: "mcp", label: "MCP", tokens: composition.mcpPromptTokens },
+    {
+      key: "profile",
+      label: "Run profile",
+      tokens: composition.runProfileTokens,
+    },
+    {
+      key: "prior-context",
+      label: "Prior run context",
+      tokens: composition.priorRunContextTokens,
+    },
+    {
+      key: "conversation",
+      label: "Conversation",
+      tokens: composition.conversationTokens,
+    },
+  ].filter((section) => section.tokens > 0);
+}
+
+export function contextCompositionTotalTokens(
+  composition: ContextCompositionAudit,
+): number {
+  return contextCompositionSections(composition).reduce(
+    (sum, section) => sum + section.tokens,
+    0,
+  );
+}

--- a/src/lib/run-details-serializers.ts
+++ b/src/lib/run-details-serializers.ts
@@ -1,0 +1,410 @@
+import type {
+  Run,
+  RunContextSummary,
+  RunEvent,
+  ToolApproval,
+  ToolCall,
+} from "@/src/db/schema";
+import {
+  getNativeToolPermissionMetadata,
+  TOOL_RISK_CATEGORIES,
+  type ToolRiskCategory,
+} from "@/src/agent/permissions";
+import { redactText } from "@/src/lib/redaction";
+import { tokenUsageFromCostMetadata } from "@/src/lib/token-usage";
+import type {
+  ProjectRunDetailsApproval,
+  ProjectRunDetailsContext,
+  ProjectRunDetailsContextCommand,
+  ProjectRunDetailsContextComposition,
+  ProjectRunDetailsContextFile,
+  ProjectRunDetailsContextTool,
+  ProjectRunDetailsEvent,
+  ProjectRunDetailsRun,
+  ProjectRunDetailsStepUsage,
+  ProjectRunDetailsSummary,
+  ProjectRunDetailsToolCall,
+} from "./api-types";
+
+export function serializeProjectRunDetails(input: {
+  run: Run;
+  events: RunEvent[];
+  toolCalls: ToolCall[];
+  approvals: ToolApproval[];
+  context: RunContextSummary | undefined;
+  segmentRuns?: Run[];
+}): ProjectRunDetailsSummary {
+  const segments =
+    input.segmentRuns && input.segmentRuns.length > 0
+      ? input.segmentRuns
+      : [input.run];
+  const displayRun =
+    segments.length > 1 ? aggregateTurnRunMetrics(input.run, segments) : input.run;
+
+  return {
+    run: serializeProjectRunDetailsRun(displayRun),
+    events: input.events.map(serializeProjectRunDetailsEvent),
+    toolCalls: input.toolCalls.map((toolCall) =>
+      serializeProjectRunDetailsToolCall(
+        toolCall,
+        input.approvals.find((approval) => approval.toolCallId === toolCall.id),
+      ),
+    ),
+    approvals: input.approvals.map(serializeProjectRunDetailsApproval),
+    context: serializeProjectRunDetailsContext(input.context),
+    ...(segments.length > 1 ? { segmentCount: segments.length } : {}),
+  };
+}
+
+function aggregateTurnRunMetrics(anchorRun: Run, segments: readonly Run[]): Run {
+  const startedAt = segments[0]?.startedAt ?? anchorRun.startedAt;
+  const finishedAt =
+    segments.at(-1)?.finishedAt ?? anchorRun.finishedAt ?? null;
+  const durationMs = segments.reduce(
+    (sum, run) => sum + (run.durationMs ?? 0),
+    0,
+  );
+  const stepCount = segments.reduce(
+    (sum, run) => sum + (run.stepCount ?? 0),
+    0,
+  );
+  const inputTokens = segments.reduce(
+    (sum, run) => sum + (run.inputTokens ?? 0),
+    0,
+  );
+  const outputTokens = segments.reduce(
+    (sum, run) => sum + (run.outputTokens ?? 0),
+    0,
+  );
+  const totalTokens = segments.reduce(
+    (sum, run) => sum + (run.totalTokens ?? 0),
+    0,
+  );
+  const costUsd = segments.reduce((sum, run) => sum + (run.costUsd ?? 0), 0);
+
+  return {
+    ...anchorRun,
+    startedAt,
+    finishedAt,
+    durationMs: durationMs > 0 ? durationMs : anchorRun.durationMs,
+    stepCount: stepCount > 0 ? stepCount : anchorRun.stepCount,
+    inputTokens: inputTokens > 0 ? inputTokens : anchorRun.inputTokens,
+    outputTokens: outputTokens > 0 ? outputTokens : anchorRun.outputTokens,
+    totalTokens: totalTokens > 0 ? totalTokens : anchorRun.totalTokens,
+    costUsd: costUsd > 0 ? costUsd : anchorRun.costUsd,
+  };
+}
+
+function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
+  const costMetadata = isRecord(run.costMetadata) ? run.costMetadata : null;
+  const tokenUsage = tokenUsageFromCostMetadata(costMetadata);
+  const tokenAudit = isRecord(costMetadata?.tokenAudit)
+    ? costMetadata.tokenAudit
+    : null;
+  const contextComposition = contextCompositionFromTokenAudit(tokenAudit);
+  const stepUsage = stepUsageFromTokenAudit(tokenAudit);
+  const reasoningTokens = finiteNumber(
+    isRecord(tokenAudit?.usage) ? tokenAudit.usage.reasoningTokens : undefined,
+  );
+
+  return {
+    id: run.id,
+    sessionId: run.sessionId,
+    status: run.status,
+    model: run.model,
+    provider: run.provider ?? null,
+    startedAt: run.startedAt.getTime(),
+    finishedAt: run.finishedAt?.getTime() ?? null,
+    durationMs: run.durationMs ?? null,
+    stepCount: run.stepCount ?? null,
+    finishReason: run.finishReason ?? null,
+    inputTokens: run.inputTokens ?? null,
+    outputTokens: run.outputTokens ?? null,
+    totalTokens: run.totalTokens ?? null,
+    costUsd: run.costUsd ?? null,
+    ...(tokenUsage || reasoningTokens !== undefined
+      ? {
+          tokenUsage: {
+            ...(tokenUsage?.rawInputTokens !== undefined
+              ? { rawInputTokens: tokenUsage.rawInputTokens }
+              : {}),
+            ...(tokenUsage?.uncachedInputTokens !== undefined
+              ? { uncachedInputTokens: tokenUsage.uncachedInputTokens }
+              : {}),
+            ...(tokenUsage?.cachedInputTokens !== undefined
+              ? { cachedInputTokens: tokenUsage.cachedInputTokens }
+              : {}),
+            ...(tokenUsage?.cacheWriteTokens !== undefined
+              ? { cacheWriteTokens: tokenUsage.cacheWriteTokens }
+              : {}),
+            ...(tokenUsage?.effectiveInputTokens !== undefined
+              ? { effectiveInputTokens: tokenUsage.effectiveInputTokens }
+              : {}),
+            ...(tokenUsage?.outputTokens !== undefined
+              ? { outputTokens: tokenUsage.outputTokens }
+              : run.outputTokens !== null
+                ? { outputTokens: run.outputTokens }
+                : {}),
+            ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
+            ...(tokenUsage?.effectiveTokens !== undefined
+              ? { effectiveTokens: tokenUsage.effectiveTokens }
+              : {}),
+            ...(tokenUsage?.providerEffectiveTokens !== undefined
+              ? { providerEffectiveTokens: tokenUsage.providerEffectiveTokens }
+              : {}),
+          },
+        }
+      : {}),
+    ...(contextComposition ? { contextComposition } : {}),
+    ...(stepUsage.length > 0 ? { stepUsage } : {}),
+  };
+}
+
+function serializeProjectRunDetailsEvent(event: RunEvent): ProjectRunDetailsEvent {
+  return {
+    id: event.id,
+    sequence: event.sequence,
+    kind: event.kind,
+    status: event.status,
+    label: redactText(event.label),
+    summary: event.summary ? redactText(event.summary) : null,
+    startedAt: event.startedAt.getTime(),
+    durationMs: event.durationMs ?? null,
+    toolCallId: event.toolCallId ?? null,
+  };
+}
+
+function serializeProjectRunDetailsToolCall(
+  toolCall: ToolCall,
+  approval: ToolApproval | undefined,
+): ProjectRunDetailsToolCall {
+  return {
+    id: toolCall.id,
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    stepNumber: toolCall.stepNumber ?? null,
+    status: toolCall.status,
+    approvalDecision: toolCall.approvalDecision ?? null,
+    permissionLabel: derivePermissionLabel(toolCall.toolName, approval),
+    inputSummary: toolCall.inputSummary ? redactText(toolCall.inputSummary) : null,
+    outputSummary: toolCall.outputSummary
+      ? redactText(toolCall.outputSummary)
+      : null,
+    exitCode: toolCall.exitCode ?? null,
+    error: toolCall.error ? redactText(toolCall.error) : null,
+    durationMs: toolCall.durationMs ?? null,
+  };
+}
+
+function serializeProjectRunDetailsApproval(
+  approval: ToolApproval,
+): ProjectRunDetailsApproval {
+  const riskCategories = Array.isArray(approval.riskCategories)
+    ? approval.riskCategories.filter(
+        (category): category is string => typeof category === "string",
+      )
+    : [];
+
+  return {
+    toolCallId: approval.toolCallId,
+    decision: approval.decision,
+    title: redactText(approval.title),
+    summary: redactText(approval.summary),
+    riskCategories,
+    requestedAt: approval.requestedAt.getTime(),
+    respondedAt: approval.respondedAt?.getTime() ?? null,
+  };
+}
+
+function serializeProjectRunDetailsContext(
+  context: RunContextSummary | undefined,
+): ProjectRunDetailsContext {
+  if (!context) return null;
+
+  const facts = stringArray(context.facts).map(redactText);
+  const files = fileArray(context.files);
+  const commands = commandArray(context.commands);
+  const tools = toolArray(context.tools);
+
+  return {
+    summary: redactText(context.summary),
+    facts,
+    files,
+    commands,
+    tools,
+  };
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function fileArray(value: unknown): ProjectRunDetailsContextFile[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const path = stringValue(item.path);
+    const action = stringValue(item.action);
+    return path && action ? [{ path, action }] : [];
+  });
+}
+
+function commandArray(value: unknown): ProjectRunDetailsContextCommand[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const command = stringValue(item.command);
+    if (!command) return [];
+    return [
+      {
+        command: redactText(command),
+        exitCode:
+          typeof item.exitCode === "number" && Number.isInteger(item.exitCode)
+            ? item.exitCode
+            : null,
+        ok: item.ok === true,
+        timedOut: item.timedOut === true,
+        ...(stringValue(item.error)
+          ? { error: redactText(stringValue(item.error) as string) }
+          : {}),
+      },
+    ];
+  });
+}
+
+function toolArray(value: unknown): ProjectRunDetailsContextTool[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const name = stringValue(item.name);
+    if (!name) return [];
+    const status = item.status === "error" ? "error" : "completed";
+    return [
+      {
+        name,
+        status,
+        ...(stringValue(item.input)
+          ? { input: redactText(stringValue(item.input) as string) }
+          : {}),
+        ...(stringValue(item.output)
+          ? { output: redactText(stringValue(item.output) as string) }
+          : {}),
+        ...(typeof item.exitCode === "number" && Number.isInteger(item.exitCode)
+          ? { exitCode: item.exitCode }
+          : {}),
+        ...(stringValue(item.error)
+          ? { error: redactText(stringValue(item.error) as string) }
+          : {}),
+      },
+    ];
+  });
+}
+
+function derivePermissionLabel(
+  toolName: string,
+  approval: ToolApproval | undefined,
+): string | null {
+  const approvalCategories = Array.isArray(approval?.riskCategories)
+    ? approval.riskCategories.filter(
+        (category): category is string => typeof category === "string",
+      )
+    : [];
+  const permissionFromApproval = approvalCategories.find(isToolRiskCategory);
+  if (permissionFromApproval) return permissionFromApproval;
+
+  const native = getNativeToolPermissionMetadata(toolName);
+  return native?.categories[0] ?? null;
+}
+
+function isToolRiskCategory(value: string): value is ToolRiskCategory {
+  return (TOOL_RISK_CATEGORIES as readonly string[]).includes(value);
+}
+
+function contextCompositionFromTokenAudit(
+  tokenAudit: Record<string, unknown> | null,
+): ProjectRunDetailsContextComposition | undefined {
+  if (!tokenAudit) return undefined;
+  const composition = isRecord(tokenAudit.contextComposition)
+    ? tokenAudit.contextComposition
+    : undefined;
+  if (!composition) return undefined;
+
+  const sections = {
+    systemPromptTokens: finiteNumber(composition.systemPromptTokens),
+    toolDefinitionsTokens: finiteNumber(composition.toolDefinitionsTokens),
+    memoryTokens: finiteNumber(composition.memoryTokens),
+    skillsTokens: finiteNumber(composition.skillsTokens),
+    mcpPromptTokens: finiteNumber(composition.mcpPromptTokens),
+    runProfileTokens: finiteNumber(composition.runProfileTokens),
+    priorRunContextTokens: finiteNumber(composition.priorRunContextTokens),
+    conversationTokens: finiteNumber(composition.conversationTokens),
+  };
+
+  if (
+    Object.values(sections).every(
+      (value) => value === undefined || value === 0,
+    )
+  ) {
+    return undefined;
+  }
+
+  return {
+    systemPromptTokens: sections.systemPromptTokens ?? 0,
+    toolDefinitionsTokens: sections.toolDefinitionsTokens ?? 0,
+    memoryTokens: sections.memoryTokens ?? 0,
+    skillsTokens: sections.skillsTokens ?? 0,
+    mcpPromptTokens: sections.mcpPromptTokens ?? 0,
+    runProfileTokens: sections.runProfileTokens ?? 0,
+    priorRunContextTokens: sections.priorRunContextTokens ?? 0,
+    conversationTokens: sections.conversationTokens ?? 0,
+    source: "estimated",
+  };
+}
+
+function stepUsageFromTokenAudit(
+  tokenAudit: Record<string, unknown> | null,
+): ProjectRunDetailsStepUsage[] {
+  if (!tokenAudit || !Array.isArray(tokenAudit.steps)) return [];
+
+  return tokenAudit.steps.flatMap((step): ProjectRunDetailsStepUsage[] => {
+    if (!isRecord(step)) return [];
+    const stepNumber = finiteNumber(step.stepNumber);
+    if (stepNumber === undefined) return [];
+    return [
+      {
+        stepNumber,
+        ...(finiteNumber(step.inputTokens) !== undefined
+          ? { inputTokens: finiteNumber(step.inputTokens) }
+          : {}),
+        ...(finiteNumber(step.outputTokens) !== undefined
+          ? { outputTokens: finiteNumber(step.outputTokens) }
+          : {}),
+        ...(finiteNumber(step.reasoningTokens) !== undefined
+          ? { reasoningTokens: finiteNumber(step.reasoningTokens) }
+          : {}),
+        ...(finiteNumber(step.cachedInputTokens) !== undefined
+          ? { cachedInputTokens: finiteNumber(step.cachedInputTokens) }
+          : {}),
+        ...(finiteNumber(step.toolCallCount) !== undefined
+          ? { toolCallCount: finiteNumber(step.toolCallCount) }
+          : {}),
+        ...(typeof step.finishReason === "string"
+          ? { finishReason: step.finishReason }
+          : {}),
+      },
+    ];
+  });
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/lib/tool-summaries.ts
+++ b/src/lib/tool-summaries.ts
@@ -1,0 +1,123 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function errorMessageOrUndefined(error: unknown): string | undefined {
+  if (error === undefined || error === null) return undefined;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function summarizeToolInput(
+  input: unknown,
+  compact: (value: string, maxLength?: number) => string,
+): string | undefined {
+  if (!isRecord(input)) return undefined;
+  for (const key of ["command", "path", "sourcePath", "pattern", "slug", "task"]) {
+    const value = stringValue(input[key]);
+    if (value) return compact(value, 500);
+  }
+  return undefined;
+}
+
+export function summarizeToolOutput(
+  toolName: string,
+  output: unknown,
+  error: unknown,
+  compact: (value: string, maxLength?: number) => string,
+): string | undefined {
+  const message = errorMessageOrUndefined(error);
+  if (message) return compact(message, 500);
+  if (!isRecord(output)) return undefined;
+
+  if (toolName === "read_file" && output.ok === true) {
+    const totalLines = numberValue(output.totalLines);
+    const sizeBytes = numberValue(output.sizeBytes);
+    const startLine = numberValue(output.startLine);
+    const endLine = numberValue(output.endLine);
+    const parts: string[] = [];
+    if (totalLines !== undefined) {
+      parts.push(`${totalLines.toLocaleString()} lines`);
+    }
+    if (sizeBytes !== undefined) {
+      parts.push(formatBytes(sizeBytes));
+    }
+    if (
+      startLine !== undefined &&
+      endLine !== undefined &&
+      totalLines !== undefined &&
+      (startLine > 1 || endLine < totalLines)
+    ) {
+      parts.push(`view ${startLine}-${endLine}`);
+    }
+    if (parts.length > 0) return parts.join(" · ");
+  }
+
+  if (toolName === "read_dir" && output.ok === true) {
+    const entries = output.entries;
+    if (Array.isArray(entries)) {
+      return `${entries.length} entries`;
+    }
+  }
+
+  if (
+    (toolName === "write_file" || toolName === "edit_file") &&
+    output.ok === true
+  ) {
+    const bytesWritten = numberValue(output.bytesWritten);
+    if (bytesWritten !== undefined) {
+      return `${bytesWritten.toLocaleString()} bytes written`;
+    }
+    if (output.existed === false) return "created";
+    if (output.existed === true) return "updated";
+  }
+
+  if (toolName === "grep" && output.ok === true) {
+    const matchCount = numberValue(output.matchCount);
+    if (matchCount !== undefined) {
+      return `${matchCount.toLocaleString()} matches`;
+    }
+  }
+
+  if (toolName === "glob" && output.ok === true) {
+    const paths = output.paths;
+    if (Array.isArray(paths)) {
+      return `${paths.length} paths`;
+    }
+  }
+
+  for (const key of ["error", "failedReason", "summary", "stdout"]) {
+    const value = stringValue(output[key]);
+    if (value) return compact(value, 500);
+  }
+
+  if (toolName !== "read_file") {
+    const path = stringValue(output.path);
+    if (path) return compact(path, 500);
+  }
+
+  const exitCode = outputExitCode(output);
+  return exitCode !== undefined ? `exit ${exitCode}` : undefined;
+}
+
+export function outputExitCode(output: unknown): number | undefined {
+  if (!isRecord(output)) return undefined;
+  const exitCode = output.exitCode;
+  return typeof exitCode === "number" && Number.isInteger(exitCode)
+    ? exitCode
+    : undefined;
+}

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -127,10 +127,24 @@ export type AntonTodoSnapshot = {
   updatedAt: number;
 };
 
+export type TokenBudgetMultiplierOption = 2 | 3 | 5;
+
+export type AntonBudgetGateData = {
+  runId: string;
+  status: "open" | "resolved" | "exhausted";
+  tokensUsed: number;
+  baseMaxTotalTokens: number;
+  currentMaxTotalTokens: number;
+  currentMultiplier: number;
+  options: readonly TokenBudgetMultiplierOption[];
+  selectedMultiplier?: TokenBudgetMultiplierOption;
+};
+
 export type AntonDataParts = {
   run: AntonRunData;
   activity: AntonActivityEvent;
   todos: AntonTodoSnapshot;
+  "budget-gate": AntonBudgetGateData;
 };
 
 export type AntonUIMessage = UIMessage<
@@ -311,8 +325,21 @@ export function failedToolOutputMessage(output: unknown): string | undefined {
 function isFailedToolOutput(output: unknown): boolean {
   if (!isRecord(output)) return false;
   if (output.ok === false) return true;
+  if (output.timedOut === true) return true;
+  if (
+    typeof output.failedReason === "string" &&
+    output.failedReason.length > 0
+  ) {
+    return true;
+  }
   const exitCode = output.exitCode;
   return typeof exitCode === "number" && exitCode !== 0;
+}
+
+export function messageHasBudgetLimit(message: AntonUIMessage): boolean {
+  return getRunDataList(message).some(
+    (run) => run.finishReason === "token_budget_limit",
+  );
 }
 
 function stringArray(value: unknown): string[] {
@@ -821,7 +848,13 @@ function stablePartSignature(part: AntonUIMessage["parts"][number]): string {
       item.status,
     ]);
   }
-  if (part.type !== "text" && part.type !== "reasoning" && !isTodosDataPart(part)) {
+  if (isBudgetGateDataPart(part)) {
+    signature.id = part.id;
+    signature.runId = part.data.runId;
+    signature.status = part.data.status;
+    signature.selectedMultiplier = part.data.selectedMultiplier;
+  }
+  if (part.type !== "text" && part.type !== "reasoning" && !isTodosDataPart(part) && !isBudgetGateDataPart(part)) {
     signature.id = typeof record.id === "string" ? record.id : undefined;
   }
 
@@ -1040,6 +1073,99 @@ export function isTodosDataPart(
   part: AntonUIMessage["parts"][number],
 ): part is Extract<AntonUIMessage["parts"][number], { type: "data-todos" }> {
   return isDataUIPart(part) && part.type === "data-todos";
+}
+
+export function isBudgetGateDataPart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-budget-gate" }> {
+  return isDataUIPart(part) && part.type === "data-budget-gate";
+}
+
+export function getBudgetGateData(
+  message: AntonUIMessage,
+  runId?: string,
+): AntonBudgetGateData | undefined {
+  const gates = message.parts.flatMap((part) =>
+    isBudgetGateDataPart(part) ? [part.data] : [],
+  );
+  if (gates.length === 0) return undefined;
+  if (runId) {
+    return gates.find((gate) => gate.runId === runId) ?? gates.at(-1);
+  }
+  return gates.at(-1);
+}
+
+export function getLatestOpenBudgetGate(
+  message: AntonUIMessage,
+): AntonBudgetGateData | undefined {
+  return message.parts
+    .flatMap((part) => (isBudgetGateDataPart(part) ? [part.data] : []))
+    .findLast((gate) => gate.status === "open");
+}
+
+export function getLatestBudgetGate(
+  message: AntonUIMessage,
+): AntonBudgetGateData | undefined {
+  const gates = message.parts.flatMap((part) =>
+    isBudgetGateDataPart(part) ? [part.data] : [],
+  );
+  return gates.at(-1);
+}
+
+export function isAssistantTurnActive(message: AntonUIMessage): boolean {
+  const runs = getRunDataList(message);
+  if (runs.length > 0) {
+    return runs.some((run) => run.status === "running");
+  }
+  const status = getRunData(message)?.status ?? message.metadata?.status;
+  return status === "running";
+}
+
+export function normalizeTodoSnapshotForDisplay(
+  snapshot: AntonTodoSnapshot,
+  active: boolean,
+): AntonTodoSnapshot {
+  if (active) return snapshot;
+  if (!snapshot.items.some((item) => item.status === "in_progress")) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    items: snapshot.items.map((item) =>
+      item.status === "in_progress"
+        ? { ...item, status: "pending" as const }
+        : item,
+    ),
+  };
+}
+
+export function cumulativeRunTokens(message: AntonUIMessage): number {
+  return getRunDataList(message).reduce(
+    (sum, run) => sum + (run.totalTokens ?? 0),
+    0,
+  );
+}
+
+export function cumulativeRunCostUsd(message: AntonUIMessage): number {
+  return getRunDataList(message).reduce(
+    (sum, run) => sum + (run.costUsd ?? 0),
+    0,
+  );
+}
+
+export function priorSegmentUsage(
+  message: AntonUIMessage,
+  excludeRunId?: string,
+): { tokensUsed: number; costUsd: number } {
+  return getRunDataList(message)
+    .filter((run) => run.runId !== excludeRunId)
+    .reduce(
+      (totals, run) => ({
+        tokensUsed: totals.tokensUsed + (run.totalTokens ?? 0),
+        costUsd: totals.costUsd + (run.costUsd ?? 0),
+      }),
+      { tokensUsed: 0, costUsd: 0 },
+    );
 }
 
 export function getTodoSnapshots(message: AntonUIMessage): AntonTodoSnapshot[] {


### PR DESCRIPTION
Closes #115

## Summary

- Add a token budget gate so capped runs finish cleanly and users can extend with 2x/3x/5x multipliers on the same assistant turn via new run segments.
- Replace worklog and status trace views with a Reddit-style thread timeline (run segment → step → events), including multi-segment aggregation for budget continuations.
- Add expandable project run details (Usage/Trace/Context tabs), bash command copy buttons, and migration `0012` for `sessions.token_budget_multiplier`.

## Test plan

- [ ] Run `pnpm db:migrate` on a fresh or existing local DB
- [ ] Run `pnpm typecheck` and `pnpm lint` (verified locally)
- [ ] Trigger a token budget cap, confirm budget gate card appears and 2x/3x/5x continues the same assistant message
- [ ] Verify Worklog and Status → Trace show run/step/event tree in chronological order across continuation segments
- [ ] Expand a bash tool row and confirm copy command works in terminal header
- [ ] Confirm Todos tab shows latest checklist after budget continuation
- [ ] Check Status → Last run → Details (Usage/Trace tabs) for multi-segment runs

Made with [Cursor](https://cursor.com)