### PR TITLE
fix: trace polish, session search, and harness reliability

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -861,6 +861,7 @@ function createTraceWriter({
   let stepCount = 0;
   let finalized = false;
   const events = new Map<string, AntonActivityEvent>();
+  const reasoningBuffers = new Map<string, string>();
 
   const metadata = (
     status: AntonRunStatus,
@@ -1368,6 +1369,12 @@ function createTraceWriter({
       if (todos) writeTodos(todos);
     },
     handleStreamPart(part: TextStreamPart<ToolSet>) {
+      if (part.type === "reasoning-delta") {
+        reasoningBuffers.set(
+          part.id,
+          `${reasoningBuffers.get(part.id) ?? ""}${part.text}`,
+        );
+      }
       if (part.type === "reasoning-start") {
         startEvent({
           id: `${runId}:reasoning:${part.id}`,
@@ -1376,9 +1383,12 @@ function createTraceWriter({
         });
       }
       if (part.type === "reasoning-end") {
+        const summary = reasoningBuffers.get(part.id)?.trim();
+        reasoningBuffers.delete(part.id);
         finishEvent(`${runId}:reasoning:${part.id}`, {
           status: "completed",
           label: "Thought",
+          ...(summary ? { summary: redactText(summary) } : {}),
         });
       }
       if (part.type === "error") {

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -142,20 +142,20 @@ export function PullRequestPanel({
 
       <Tabs defaultValue="changes" className="min-w-0 gap-0">
         <div className="border-b border-border px-2 py-1.5">
-          <TabsList className="gap-1">
-            <TabsTrigger value="changes" className="h-6 px-2 py-0 text-[11px]">
+          <TabsList variant="line" className="h-auto w-full justify-start gap-1 p-0">
+            <TabsTrigger value="changes" className="h-6 flex-none px-2 py-0 text-[11px]">
               Changes
             </TabsTrigger>
-            <TabsTrigger value="description" className="h-6 px-2 py-0 text-[11px]">
+            <TabsTrigger value="description" className="h-6 flex-none px-2 py-0 text-[11px]">
               Description
             </TabsTrigger>
-            <TabsTrigger value="discussion" className="h-6 px-2 py-0 text-[11px]">
+            <TabsTrigger value="discussion" className="h-6 flex-none px-2 py-0 text-[11px]">
               Discussion {pullRequest.discussion.length}
             </TabsTrigger>
-            <TabsTrigger value="commits" className="h-6 px-2 py-0 text-[11px]">
+            <TabsTrigger value="commits" className="h-6 flex-none px-2 py-0 text-[11px]">
               Commits {pullRequest.commitItems.length}
             </TabsTrigger>
-            <TabsTrigger value="checks" className="h-6 px-2 py-0 text-[11px]">
+            <TabsTrigger value="checks" className="h-6 flex-none px-2 py-0 text-[11px]">
               Checks
             </TabsTrigger>
           </TabsList>

--- a/components/features/run-trace/project-run-details.tsx
+++ b/components/features/run-trace/project-run-details.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/features/run-trace/trace-data";
 import {
   StatusPill,
+  TraceExpandPanel,
   TraceLogBlock,
   TraceThreadChildren,
   TraceThreadHeaderRow,
@@ -92,7 +93,7 @@ export function ProjectRunDetails({
 
   if (loading && !details) {
     return (
-      <div className="mt-3 flex items-center gap-2 border-l-2 border-border/60 pl-3 text-xs text-muted-foreground">
+      <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
         <Loader2 className="size-3.5 animate-spin text-sky-400" />
         Loading run details...
       </div>
@@ -101,7 +102,7 @@ export function ProjectRunDetails({
 
   if (error && !details) {
     return (
-      <div className="mt-3 space-y-2 border-l-2 border-destructive/40 pl-3">
+      <div className="mt-3 space-y-2">
         <ErrorBanner message={error} />
         <Button
           type="button"
@@ -134,7 +135,7 @@ export function ProjectRunDetails({
   };
 
   return (
-    <div className="mt-3 space-y-3 border-l-2 border-border/50 pl-3">
+    <div className="mt-3 space-y-3">
       {error ? (
         <div className="space-y-2">
           <ErrorBanner message={error} />
@@ -156,31 +157,25 @@ export function ProjectRunDetails({
         onCopy={() => void copyRunSummary()}
       />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0 gap-0">
-        <div className="border-b border-border pb-1.5">
-          <TabsList className="w-full gap-1">
-            <TabsTrigger value="usage" className="h-6 flex-1 px-2 py-0 text-[11px]">
-              Usage
-            </TabsTrigger>
-            <TabsTrigger value="trace" className="h-6 flex-1 px-2 py-0 text-[11px]">
-              Trace
-              {traceEventCount > 0 ? (
-                <span className="ml-1 font-mono text-[9px] text-muted-foreground">
-                  {traceEventCount}
-                </span>
-              ) : null}
-            </TabsTrigger>
-            <TabsTrigger value="context" className="h-6 flex-1 px-2 py-0 text-[11px]">
-              Context
-            </TabsTrigger>
-          </TabsList>
-        </div>
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0 gap-2">
+        <TabsList size="md" className="w-full">
+          <TabsTrigger value="usage">Usage</TabsTrigger>
+          <TabsTrigger value="trace">
+            Trace
+            {traceEventCount > 0 ? (
+              <span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+                {traceEventCount}
+              </span>
+            ) : null}
+          </TabsTrigger>
+          <TabsTrigger value="context">Context</TabsTrigger>
+        </TabsList>
 
-        <TabsContent value="usage" className="m-0 pt-2">
+        <TabsContent value="usage" className="m-0">
           <TokenUsagePanel run={run} />
         </TabsContent>
 
-        <TabsContent value="trace" className="m-0 pt-2">
+        <TabsContent value="trace" className="m-0">
           {traceEventCount === 0 ? (
             <EmptyHint>No events recorded.</EmptyHint>
           ) : (
@@ -194,7 +189,7 @@ export function ProjectRunDetails({
           )}
         </TabsContent>
 
-        <TabsContent value="context" className="m-0 pt-2">
+        <TabsContent value="context" className="m-0">
           {context ? (
             <ContextPanel
               context={context}
@@ -339,7 +334,9 @@ function TraceTimeline({
                         ? findApprovalForToolCall(toolCall, approvals)
                         : undefined;
                       const expandable =
-                        event.kind === "tool" && toolCall !== undefined;
+                        (event.kind === "tool" && toolCall !== undefined) ||
+                        (event.kind === "reasoning" &&
+                          Boolean(event.summary?.trim()));
                       const expanded = expandedEventId === event.id;
 
                       return (
@@ -368,6 +365,15 @@ function TraceTimeline({
                                 toolCall={toolCall}
                                 approval={approval}
                               />
+                            ) : expandable &&
+                              expanded &&
+                              event.kind === "reasoning" &&
+                              event.summary ? (
+                              <TraceExpandPanel>
+                                <pre className="max-h-48 overflow-y-auto font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
+                                  {event.summary}
+                                </pre>
+                              </TraceExpandPanel>
                             ) : null}
                           </TraceTimelineRow>
                         </TraceThreadNode>

--- a/components/features/run-trace/project-status-panel.tsx
+++ b/components/features/run-trace/project-status-panel.tsx
@@ -233,13 +233,11 @@ function LastRunCard({
         <Clock className="size-3 shrink-0" />
         <span>{new Date(lastRun.startedAt).toLocaleString()}</span>
         <div className="ml-auto flex items-center gap-1.5">
-          <Button
+          <button
             type="button"
-            size="xs"
-            variant={detailsOpen ? "secondary" : "outline"}
             className={cn(
-              "h-5 min-h-0 gap-0.5 px-1.5 py-0 text-[9px]",
-              detailsOpen && "ring-1 ring-border/80",
+              "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] text-foreground transition-colors hover:bg-secondary/60",
+              detailsOpen && "bg-secondary/40",
             )}
             onClick={() => {
               setDetailsEverOpened(true);
@@ -248,15 +246,15 @@ function LastRunCard({
             aria-expanded={detailsOpen}
           >
             {detailsOpen ? (
-              <ChevronDown className="size-2.5" />
+              <ChevronDown className="size-3 shrink-0" />
             ) : (
-              <ChevronRight className="size-2.5" />
+              <ChevronRight className="size-3 shrink-0" />
             )}
             Details
-          </Button>
+          </button>
           <Link
             href={`/s/${lastRun.sessionId}`}
-            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-foreground transition-colors hover:bg-secondary/60 hover:underline"
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] text-foreground transition-colors hover:bg-secondary/60 hover:underline"
           >
             Open session
             <ExternalLink className="size-3" />

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -1,4 +1,5 @@
 import {
+  buildReasoningTextByEventId,
   getActivityEvents,
   getAssistantTextDisplay,
   getLatestBudgetGate,
@@ -13,6 +14,7 @@ import {
   isReasoningPart,
   isTodosDataPart,
   normalizeTodoSnapshotForDisplay,
+  stripLeakedProviderMarkup,
   type AntonActivityKind,
   type AntonActivityStatus,
   type AntonBudgetGateData,
@@ -297,6 +299,7 @@ function buildRunTimelineItems(
   );
   const seenToolIds = new Set<string>();
   const items: SessionTimelineItem[] = [];
+  const reasoningByEventId = buildReasoningTextByEventId(message);
 
   const events = getActivityEvents(message)
     .filter(
@@ -335,7 +338,11 @@ function buildRunTimelineItems(
     }
 
     if (event.kind === "reasoning") {
-      const reasoningText = reasoningTextForEvent(message, event);
+      const reasoningText = reasoningTextForEvent(
+        message,
+        event,
+        reasoningByEventId,
+      );
       items.push({
         ...base,
         kind: "reasoning",
@@ -433,33 +440,10 @@ function compareTimelineItems(
 function reasoningTextForEvent(
   message: AntonUIMessage,
   event: AntonActivityEvent,
+  reasoningByEventId?: ReadonlyMap<string, string>,
 ): string | undefined {
-  const marker = ":reasoning:";
-  const markerIndex = event.id.indexOf(marker);
-  if (markerIndex !== -1) {
-    const partId = event.id.slice(markerIndex + marker.length);
-    for (const part of message.parts) {
-      if (!isReasoningPart(part)) continue;
-      if ("id" in part && typeof part.id === "string" && part.id === partId) {
-        const text = part.text.trim();
-        if (text.length > 0) return text;
-      }
-    }
-  }
-
-  const reasoningEvents = getActivityEvents(message)
-    .filter((candidate) => candidate.kind === "reasoning")
-    .sort(compareTimelineEvents);
-  const reasoningTexts = message.parts.flatMap((part) =>
-    isReasoningPart(part) && part.text.trim().length > 0
-      ? [part.text.trim()]
-      : [],
-  );
-  const eventIndex = reasoningEvents.findIndex(
-    (candidate) => candidate.id === event.id,
-  );
-  if (eventIndex === -1 || eventIndex >= reasoningTexts.length) return undefined;
-  return reasoningTexts[eventIndex];
+  const map = reasoningByEventId ?? buildReasoningTextByEventId(message);
+  return map.get(event.id);
 }
 
 function todoSnapshotFromEventDetails(
@@ -587,7 +571,6 @@ export function getTodoTraceDisplay(
     if (message.role === "assistant") {
       lastAssistantByTurn.set(userTurn, message);
     }
-    const firstFailedToolIndex = message.parts.findIndex(isFailedToolPart);
     const firstTodoPartIndex = message.parts.findIndex(isTodosDataPart);
     const firstTodoPartKey =
       firstTodoPartIndex === -1
@@ -595,7 +578,6 @@ export function getTodoTraceDisplay(
         : todoPartKey(message, firstTodoPartIndex);
     message.parts.forEach((part, partIndex) => {
       if (!isTodosDataPart(part)) return;
-      if (firstFailedToolIndex !== -1 && partIndex > firstFailedToolIndex) return;
       const order = messageIndex * 10_000 + partIndex;
       updateTurnSnapshot(userTurn, part.data, order, todoPartKey(message, partIndex));
     });
@@ -676,7 +658,7 @@ export function getTraceRows(
       lastToolIndex !== -1 &&
       index < lastToolIndex
     ) {
-      const text = part.text.trim();
+      const text = stripLeakedProviderMarkup(part.text);
       if (!text) return;
       rows.push({
         id: `${message.id}:progress:${index}`,
@@ -791,12 +773,6 @@ function eventHasTodos(event: AntonActivityEvent): boolean {
 
 function isTokenBudgetActivity(event: AntonActivityEvent): boolean {
   return event.label === "Token budget reached";
-}
-
-function isFailedToolPart(part: AntonUIMessage["parts"][number]): boolean {
-  if (!("toolCallId" in part)) return false;
-  if ("state" in part && part.state === "output-error") return true;
-  return "output" in part && isFailedToolOutput(part.output);
 }
 
 function toolCallIdForPart(

--- a/components/features/sessions/session-sidebar.tsx
+++ b/components/features/sessions/session-sidebar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   MessageSquare,
   PanelLeftClose,
   Plus,
+  Search,
   Settings,
 } from "lucide-react";
 
@@ -87,6 +88,15 @@ function ExpandedSidebar({
   onOpenSettings: () => void;
   onNewChat: () => void;
 }) {
+  const [query, setQuery] = useState("");
+  const filteredSessions = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return sessions;
+    return sessions.filter((session) =>
+      session.title.toLowerCase().includes(needle),
+    );
+  }, [query, sessions]);
+
   return (
     <div className="flex h-full w-[300px] shrink-0 flex-col">
       <div className="flex h-10 items-center justify-between px-2">
@@ -126,11 +136,26 @@ function ExpandedSidebar({
         </Button>
       </div>
 
+      <div className="px-2 pb-1.5">
+        <div className="grid grid-cols-[0.75rem_1fr] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
+          <Search className="size-3 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search chats"
+            className="min-w-0 bg-transparent text-[11px] outline-none placeholder:text-muted-foreground"
+            aria-label="Search recent chats"
+          />
+        </div>
+      </div>
+
       <SessionList
         activeId={activeId}
         loading={loading}
         error={error}
-        sessions={sessions}
+        sessions={filteredSessions}
+        totalCount={sessions.length}
+        query={query}
       />
 
       <div className="border-t border-sidebar-border p-1.5">
@@ -202,21 +227,29 @@ function SessionList({
   loading,
   error,
   sessions,
+  totalCount,
+  query,
 }: {
   activeId: string | undefined;
   loading: boolean;
   error: string | null;
   sessions: ReturnType<typeof useSessionStore>["sessions"];
+  totalCount: number;
+  query: string;
 }) {
   return (
     <div className="flex-1 overflow-y-auto pb-2">
-      {loading && sessions.length === 0 ? (
+      {loading && totalCount === 0 ? (
         <div className="px-3 py-2 text-xs text-muted-foreground">
           Loading...
         </div>
-      ) : sessions.length === 0 ? (
+      ) : totalCount === 0 ? (
         <div className="px-3 py-2 text-xs text-muted-foreground">
           No sessions yet. Send a message to start one.
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="px-3 py-2 text-xs text-muted-foreground">
+          No chats match &ldquo;{query.trim()}&rdquo;.
         </div>
       ) : (
         <ul className="space-y-0.5 px-2">

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,31 +1,65 @@
 "use client";
 
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 import { Tabs as TabsPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
 function Tabs({
   className,
+  orientation = "horizontal",
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className,
+      )}
       {...props}
     />
   );
 }
 
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center text-muted-foreground group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted dark:bg-card/40",
+        line: "gap-1 bg-transparent",
+      },
+      size: {
+        default:
+          "gap-0.5 rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9",
+        md: "gap-0.5 rounded-md p-0.5 group-data-[orientation=horizontal]/tabs:h-7",
+        sm: "gap-0.5 rounded-md p-px group-data-[orientation=horizontal]/tabs:h-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
 function TabsList({
   className,
+  variant = "default",
+  size = "default",
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
-      className={cn("inline-flex items-center gap-1.5", className)}
+      data-variant={variant}
+      data-size={size}
+      className={cn(tabsListVariants({ variant, size }), className)}
       {...props}
     />
   );
@@ -39,7 +73,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "inline-flex shrink-0 items-center justify-center rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-secondary/70 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-secondary data-[state=active]:text-foreground",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1 rounded-md border border-transparent px-1.5 py-0 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none group-data-[size=default]/tabs-list:gap-1.5 group-data-[size=default]/tabs-list:px-2 group-data-[size=default]/tabs-list:py-1 group-data-[size=md]/tabs-list:gap-0.5 group-data-[size=md]/tabs-list:px-1.5 group-data-[size=md]/tabs-list:text-xs group-data-[size=sm]/tabs-list:gap-0.5 group-data-[size=sm]/tabs-list:px-1 group-data-[size=sm]/tabs-list:text-[11px] dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 group-data-[size=md]/tabs-list:[&_svg:not([class*='size-'])]:size-3.5 group-data-[size=sm]/tabs-list:[&_svg:not([class*='size-'])]:size-3",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-transparent dark:data-[state=active]:bg-accent dark:data-[state=active]:text-foreground dark:group-data-[size=md]/tabs-list:data-[state=active]:shadow-none dark:group-data-[size=sm]/tabs-list:data-[state=active]:shadow-none",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
         className,
       )}
       {...props}
@@ -54,10 +91,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn("min-w-0 outline-none", className)}
+      className={cn("min-w-0 flex-1 outline-none", className)}
       {...props}
     />
   );
 }
 
-export { Tabs, TabsContent, TabsList, TabsTrigger };
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants };

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -111,7 +111,7 @@ export function createVerifyTool(workspaceRoot?: string) {
             ok: false,
             error: "Verification command is empty.",
           });
-          continue;
+          break;
         }
 
         const result = await runWorkspaceProcess(file, args, root, {
@@ -138,6 +138,7 @@ export function createVerifyTool(workspaceRoot?: string) {
                     : "Verification command failed."),
               }),
         });
+        if (!ok) break;
       }
 
       const ranCount = results.filter((result) => !result.skipped).length;

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -270,6 +270,18 @@ export type AssistantTextDisplay = {
   finalText: string;
 };
 
+const LEAKED_MARKUP_BLOCK =
+  /<\|DSML\|[^>]*>[\s\S]*?<\/\|DSML\|[^>]*>/gi;
+const LEAKED_MARKUP_TAG =
+  /<\|(?:DSML|tool_call|tool_calls|function_call|invoke)[^|]*\|[^>]*>/gi;
+
+export function stripLeakedProviderMarkup(text: string): string {
+  let next = text.replace(LEAKED_MARKUP_BLOCK, "");
+  next = next.replace(LEAKED_MARKUP_TAG, "");
+  next = next.replace(/<\|DSML\|[^>]*>[\s\S]*$/gi, "");
+  return next.trim();
+}
+
 export function getAssistantTextDisplay(
   message: AntonUIMessage,
   options: { progressOnly?: boolean } = {},
@@ -280,7 +292,7 @@ export function getAssistantTextDisplay(
 
   for (const [index, part] of message.parts.entries()) {
     if (part.type !== "text") continue;
-    const text = part.text.trim();
+    const text = stripLeakedProviderMarkup(part.text);
     if (!text) continue;
     if (options.progressOnly || (lastToolIndex !== -1 && index < lastToolIndex)) {
       progressText.push(text);
@@ -1049,6 +1061,44 @@ export function getReasoningTexts(message: AntonUIMessage): string[] {
     .filter(isReasoningUIPart)
     .map((part) => part.text.trim())
     .filter((text) => text.length > 0);
+}
+
+export function buildReasoningTextByEventId(
+  message: AntonUIMessage,
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  const reasoningActivities = getActivityEvents(message)
+    .filter((event) => event.kind === "reasoning")
+    .slice()
+    .sort(
+      (left, right) =>
+        left.startedAt - right.startedAt ||
+        left.sequence - right.sequence ||
+        left.id.localeCompare(right.id),
+    );
+  let reasoningIndex = 0;
+
+  for (const part of message.parts) {
+    if (!isReasoningUIPart(part)) continue;
+    const text = part.text.trim();
+    if (!text) continue;
+
+    if ("id" in part && typeof part.id === "string") {
+      for (const event of reasoningActivities) {
+        if (event.id.endsWith(`:reasoning:${part.id}`)) {
+          map.set(event.id, text);
+        }
+      }
+    }
+
+    const event = reasoningActivities[reasoningIndex];
+    if (event && !map.has(event.id)) {
+      map.set(event.id, text);
+    }
+    reasoningIndex += 1;
+  }
+
+  return map;
 }
 
 export function isReasoningPart(

--- a/src/workspace/background-commands.ts
+++ b/src/workspace/background-commands.ts
@@ -36,6 +36,7 @@ const TERMINATION_GRACE_MS = 3_000;
 const TERMINAL_WAIT_MS = 10_000;
 
 const ACTIVE_STATUSES = new Set(["starting", "running", "stopping"]);
+const FINALIZABLE_STATUSES = new Set([...ACTIVE_STATUSES, "stale"]);
 const LOCALHOST_URL_RE =
   /https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(?::\d+)?(?:\/[^\s"'<>]*)?/gi;
 
@@ -46,11 +47,13 @@ type ActiveProcess = {
 const activeProcesses = new Map<string, ActiveProcess>();
 const userStopRequestedSessions = new Set<string>();
 
-let bootstrapped = false;
+const globalForBackgroundCommands = globalThis as typeof globalThis & {
+  __antonBackgroundCommandsBootstrapped?: boolean;
+};
 
 function ensureBootstrapped(): void {
-  if (bootstrapped) return;
-  bootstrapped = true;
+  if (globalForBackgroundCommands.__antonBackgroundCommandsBootstrapped) return;
+  globalForBackgroundCommands.__antonBackgroundCommandsBootstrapped = true;
   markStaleBackgroundCommandSessions();
 }
 
@@ -621,18 +624,21 @@ function finalizeProcess(
     return;
   }
 
-  if (!ACTIVE_STATUSES.has(current.status)) {
+  if (!FINALIZABLE_STATUSES.has(current.status)) {
     userStopRequestedSessions.delete(sessionId);
     return;
   }
+
+  const recoveringStale = current.status === "stale";
 
   const userStopped = userStopRequestedSessions.has(sessionId);
   userStopRequestedSessions.delete(sessionId);
 
   if (
-    userStopped ||
-    current.status === "stopped" ||
-    current.status === "stopping"
+    !recoveringStale &&
+    (userStopped ||
+      current.status === "stopped" ||
+      current.status === "stopping")
   ) {
     updateBackgroundCommandSession(sessionId, {
       status: "stopped",


### PR DESCRIPTION
## Summary

Closes #116.

- Strip leaked DSML/provider markup from assistant final text and trace progress rows
- Persist reasoning summaries and fix thought expansion in worklog and status trace
- Recover background commands marked stale during dev HMR so exit codes finalize correctly
- Add recent chat search filter to the session sidebar
- Keep chat trace todo snapshots in sync after failed tool calls (matches Todos tab)
- Fail-fast `verify` on first failing target instead of running remaining scripts
- Polish status panel Details control and upgrade shadcn tabs with compact `md` sizing

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Session sidebar: type in search box and confirm recent chats filter by title
- [ ] Status panel: expand Details, confirm pill tabs and reasoning rows expand on new runs
- [ ] Agent run with todos: after a failed edit, confirm chat trace todo count matches Todos tab
- [ ] Background command: run `git status` from Commands panel during dev; confirm Exited + exit code (not Stale)
- [ ] Agent run with verify: confirm verify stops after first failing script

## Visual verification

- Status panel Last project run footer: Details + Open session actions aligned; expanded details flush (no left border indent)
- Run details tabs (Usage / Trace / Context): compact shadcn pill bar with subtle active highlight

Made with [Cursor](https://cursor.com)