### PR TITLE
Improve agent harness loop control and cache efficiency

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add resumable runs after tool approval, refresh, or network interruption.
 - [✔️] Add better system prompts for coding workflow: inspect, plan, edit, verify, summarize.
 - [✔️] Add final response structure that reports changed files, verification, and unresolved risks.
+- [✔️] Add task-scale routing, cache-aware loop control, localized edit recovery, and proportional verification (#118).
 
 ## Phase 5: GitHub And Project Workflow
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -17,20 +17,35 @@ import { z } from "zod";
 
 import {
   runAgent,
+  type AgentRunMode,
   type AgentRunProfile,
   type TokenAudit,
 } from "@/src/agent/loop";
 import {
+  classifyRunProfile,
+  executionModelFromCostMetadata,
+  executionProfileFromCostMetadata,
+  runIdFromAssistantMessage,
+} from "@/src/agent/profile-classifier";
+import {
   budgetMessagesForModel,
   type ContextBudgetReport,
 } from "@/src/agent/context-budget";
+import {
+  priorToolRecordsFromAssistantMessage,
+} from "@/src/agent/tool-policy";
+import {
+  promptCacheAuditFromCostMetadata,
+} from "@/src/agent/prompt-cache-audit";
 import {
   buildSessionContextDigest,
   RunContextCollector,
   type RunContextStatus,
 } from "@/src/agent/context";
 import { buildWorkspaceContextDigest } from "@/src/agent/workspace-context";
-import { budgetForProfile, capRunBudget, applyTokenBudgetMultiplier, availableTokenBudgetMultipliers } from "@/src/agent/run-budget";
+import { budgetForProfile, capRunBudget, applyTokenBudgetMultiplier, applyThinkingBudgetAdjustment, availableTokenBudgetMultipliers } from "@/src/agent/run-budget";
+import { compactReadFileForModel } from "@/src/agent/tools/model-output";
+import type { ProfilePromotionEvent } from "@/src/agent/profile-promotion";
 import {
   buildToolApprovalMetadata,
   getNativeToolPermissionMetadata,
@@ -80,6 +95,7 @@ import {
 } from "@/src/lib/token-usage";
 import {
   collapseAssistantContinuationMessages,
+  failedToolOutputMessage,
   getApprovalMetadata,
   getAssistantTextDisplay,
   getBudgetGateData,
@@ -117,7 +133,7 @@ const bodySchema = z.object({
   extendTokenBudget: z
     .object({
       runId: z.string().min(1),
-      multiplier: z.union([z.literal(2), z.literal(3), z.literal(5)]),
+      multiplier: z.union([z.literal(2), z.literal(3)]),
     })
     .optional(),
   messages: z.array(z.unknown()).min(1),
@@ -143,14 +159,37 @@ export async function POST(req: Request) {
   const mode = approvalContinuation
     ? "agent"
     : parsed.data.mode ?? DEFAULT_CHAT_MODE;
-  const profile = runProfileForMessages(mode, incomingHistory);
+  const budgetContinuationRun =
+    isBudgetContinuation && budgetExtension
+      ? getRunById(budgetExtension.runId)
+      : undefined;
+  const profile = resolveRunProfile({
+    mode,
+    messages: incomingHistory,
+    approvalContinuation,
+    budgetContinuationRun,
+  });
   const needsProject = mode !== "chat";
   const requestBodyBytes = byteLength(JSON.stringify(json ?? {}));
   const workspaceSettings = getWorkspaceSettings();
-  const model =
+  const requestedModel =
     parsed.data.model ??
     workspaceSettings.defaultModel ??
     DEFAULT_MODEL;
+  const approvalContinuationRunId = approvalContinuation
+    ? runIdFromAssistantMessage(incomingHistory.at(-1))
+    : undefined;
+  const approvalContinuationRun = approvalContinuationRunId
+    ? getRunById(approvalContinuationRunId)
+    : undefined;
+  const continuationModel =
+    executionModelFromCostMetadata(budgetContinuationRun?.costMetadata) ??
+    executionModelFromCostMetadata(approvalContinuationRun?.costMetadata);
+  const model = continuationModel ?? requestedModel;
+  const modelSelectionNote =
+    continuationModel && continuationModel !== requestedModel
+      ? `UI selected ${requestedModel}, but this continuation reused ${continuationModel} from the originating run.`
+      : undefined;
   if (!isSupportedModelId(model)) {
     return Response.json(
       { error: "unsupported model", model },
@@ -166,7 +205,7 @@ export async function POST(req: Request) {
     if (
       !cappedRun ||
       cappedRun.sessionId !== sessionId ||
-      cappedRun.finishReason !== "token_budget_limit"
+      !runEligibleForBudgetContinuation(cappedRun)
     ) {
       return Response.json(
         { error: "token budget continuation requires a capped run in this session" },
@@ -296,17 +335,54 @@ export async function POST(req: Request) {
     setSessionTokenBudgetMultiplier(sessionId, tokenBudgetMultiplier);
   }
 
-  const baseBudget = capRunBudget(
-    budgetForProfile(profile),
-    workspaceSettings.defaultMaxSteps,
+  const baseBudget = applyThinkingBudgetAdjustment(
+    applyTokenBudgetMultiplier(
+      capRunBudget(budgetForProfile(profile), workspaceSettings.defaultMaxSteps),
+      tokenBudgetMultiplier,
+    ),
+    parsed.data.thinkingEnabled ?? false,
   );
-  const budget = applyTokenBudgetMultiplier(baseBudget, tokenBudgetMultiplier);
+  const budget = baseBudget;
   const continuationAssistant = isBudgetContinuation
     ? incomingHistory.findLast((message) => message.role === "assistant")
     : undefined;
   const priorUsage = continuationAssistant
     ? priorSegmentUsage(continuationAssistant)
-    : { tokensUsed: 0, costUsd: 0 };
+    : { tokensUsed: 0, effectiveTokensUsed: 0, costUsd: 0 };
+  const priorToolHistory = continuationAssistant
+    ? priorToolRecordsFromAssistantMessage(continuationAssistant)
+    : [];
+  const previousPromptCacheAudit = promptCacheAuditFromCostMetadata(
+    budgetContinuationRun?.costMetadata ?? approvalContinuationRun?.costMetadata,
+  );
+  const continuationNote = isBudgetContinuation
+    ? budgetContinuationHandoffNote()
+    : undefined;
+  const userText = latestUserText(uiMessages);
+  const sessionContextDigest =
+    mode === "chat" || isBudgetContinuation
+      ? undefined
+      : buildSessionContextDigest({
+          sessionId,
+          latestUserText: userText,
+          budgetChars: budget.priorRunContextChars,
+        });
+  const workspaceContextDigest =
+    mode === "chat" || isBudgetContinuation
+      ? undefined
+      : buildWorkspaceContextDigest({
+          workspaceRoot: project?.localPath,
+          latestUserText: userText,
+          budgetChars: budget.workspaceContextChars,
+        });
+  const contextDigestBytes = byteLength(
+    isBudgetContinuation
+      ? (continuationNote ?? "")
+      : (modelOnlyContextMessageText({
+          sessionContextDigest,
+          workspaceContextDigest,
+        }) ?? ""),
+  );
   const preservation = modelContextPreservation(
     uiMessages,
     profile,
@@ -316,27 +392,6 @@ export async function POST(req: Request) {
     uiMessages,
     profile,
     isBudgetContinuation,
-  );
-  const userText = latestUserText(uiMessages);
-  const sessionContextDigest = mode === "chat"
-    ? undefined
-    : buildSessionContextDigest({
-        sessionId,
-        latestUserText: userText,
-        budgetChars: budget.priorRunContextChars,
-      });
-  const workspaceContextDigest = mode === "chat"
-    ? undefined
-    : buildWorkspaceContextDigest({
-        workspaceRoot: project?.localPath,
-        latestUserText: userText,
-        budgetChars: budget.workspaceContextChars,
-      });
-  const contextDigestBytes = byteLength(
-    modelOnlyContextMessageText({
-      sessionContextDigest,
-      workspaceContextDigest,
-    }) ?? "",
   );
   const contextBudget = budgetMessagesForModel({
     messages: preparedMessages,
@@ -364,15 +419,27 @@ export async function POST(req: Request) {
     status: "running",
     startedAt: new Date(startedAt),
     stepCount: 0,
+    costMetadata: {
+      execution: {
+        profile,
+        mode,
+        model,
+        tokenBudgetMultiplier,
+      },
+    },
   });
 
-  const modelMessages = addModelOnlyContextMessage(
-    await convertMessagesForRun(contextBudget.messages, runId, startedAt),
-    {
-      sessionContextDigest,
-      workspaceContextDigest,
-    },
+  const convertedMessages = await convertMessagesForRun(
+    contextBudget.messages,
+    runId,
+    startedAt,
   );
+  const modelMessages = isBudgetContinuation
+    ? appendModelOnlyContextMessage(convertedMessages, continuationNote ?? "")
+    : addModelOnlyContextMessage(convertedMessages, {
+        sessionContextDigest,
+        workspaceContextDigest,
+      });
   const contextCollector = new RunContextCollector(runId, sessionId);
   let contextTerminalStatus: RunContextStatus = "completed";
   let contextTerminalError: unknown;
@@ -405,17 +472,25 @@ export async function POST(req: Request) {
         writer,
         runId,
         model,
+        profile,
+        mode,
         startedAt,
         workspaceRoot: project?.localPath,
         responseKind: mode === "plan" ? "plan" : undefined,
+        tokenBudgetMultiplier,
         tokenBudgetContext: {
           baseMaxTotalTokens: baseBudget.maxTotalTokens,
+          baseMaxEffectiveTokens: baseBudget.maxEffectiveTokens,
           tokenBudgetMultiplier,
           priorTokensUsed: priorUsage.tokensUsed,
+          priorEffectiveTokensUsed: priorUsage.effectiveTokensUsed,
         },
       });
       trace.writeRun("running");
       trace.noteContextBudget(contextBudget.report);
+      if (modelSelectionNote) {
+        trace.noteModelSelection(modelSelectionNote);
+      }
 
       try {
         const result = await runAgent({
@@ -430,18 +505,24 @@ export async function POST(req: Request) {
           maxStepsCap: workspaceSettings.defaultMaxSteps,
           tokenBudgetMultiplier,
           priorTokensUsed: priorUsage.tokensUsed,
+          priorEffectiveTokens: priorUsage.effectiveTokensUsed,
           priorCostUsd: priorUsage.costUsd,
+          priorToolHistory,
+          previousPromptCacheAudit,
           permissionMode: parsed.data.permissionMode as
             | PermissionMode
             | undefined,
           enabledMcpServerIds: parsed.data.enabledMcpServerIds,
           onStepStart: ({ stepNumber }) => trace.startStep(stepNumber),
           onStepFinish: ({ stepNumber }) => trace.finishStep(stepNumber),
+          onStepUsageUpdate: (steps) => trace.updateStepUsage(steps),
           onToolCallStart: (event) => trace.startTool(event),
           onToolCallFinish: (event) => {
             contextCollector.addTool(event);
             trace.finishTool(event);
           },
+          onLoopGuard: (event) => trace.noteLoopGuard(event),
+          onProfilePromotion: (event) => trace.noteProfilePromotion(event),
           onStreamPart: (part) => trace.handleStreamPart(part),
           onAbort: () => {
             contextTerminalStatus = "aborted";
@@ -461,31 +542,49 @@ export async function POST(req: Request) {
             stepProviderMetadata,
             maxSteps,
             maxTotalTokens,
+            maxEffectiveTokens,
             baseMaxTotalTokens,
+            baseMaxEffectiveTokens,
             maxCostUsd,
             priorTokensUsed,
             maxStepLimitReached,
             tokenBudgetReached,
             costBudgetReached,
+            loopGuardIncomplete,
+            unverifiedEdit,
+            verificationFailed,
             tokenAudit,
           }) => {
             const hardLimitReached = maxStepLimitReached || costBudgetReached;
-            contextTerminalStatus = hardLimitReached ? "error" : "completed";
+            const incompleteRun =
+              loopGuardIncomplete === true ||
+              unverifiedEdit === true ||
+              verificationFailed === true;
+            contextTerminalStatus = hardLimitReached || incompleteRun ? "error" : "completed";
             trace.finalize(
-              tokenBudgetReached ? "completed" : hardLimitReached ? "error" : "completed",
+              tokenBudgetReached
+                ? "completed"
+                : hardLimitReached || incompleteRun
+                  ? "error"
+                  : "completed",
               totalUsage,
               providerMetadata,
               finishReason,
               {
                 maxSteps,
                 maxTotalTokens,
+                maxEffectiveTokens,
                 baseMaxTotalTokens,
+                baseMaxEffectiveTokens,
                 maxCostUsd,
                 priorTokensUsed,
                 tokenBudgetMultiplier,
                 maxStepLimitReached,
                 tokenBudgetReached,
                 costBudgetReached,
+                loopGuardIncomplete: incompleteRun,
+                unverifiedEdit,
+                verificationFailed,
                 tokenAudit,
                 stepProviderMetadata,
               },
@@ -717,6 +816,34 @@ async function convertMessagesForRun(
   }
 }
 
+function appendModelOnlyContextMessage(
+  messages: ModelMessage[],
+  continuationNote: string,
+): ModelMessage[] {
+  const text = continuationNote.trim();
+  if (!text) return messages;
+  return [
+    ...messages,
+    {
+      role: "assistant",
+      content: [
+        "Model-only continuation note:",
+        text,
+      ].join("\n"),
+    },
+  ];
+}
+
+function budgetContinuationHandoffNote(): string {
+  return [
+    "Budget continuation preserves the prior transcript prefix for prompt-cache reuse.",
+    "Reuse the originating effective profile, tool history, and edit state from the prior segment.",
+    "If verify failed in the prior segment, fix the reported syntax/lint error with edit_text on the edited file, then run verify again — do not re-explore with bash, grep, or glob.",
+    "If a file edit succeeded and verify has not run yet, run verify once before answering.",
+    "Prefer edit_text for remaining surgical edits; use replace_lines or replace_text only when text anchors fail.",
+  ].join(" ");
+}
+
 function addModelOnlyContextMessage(
   messages: ModelMessage[],
   context: {
@@ -840,26 +967,40 @@ function createTraceWriter({
   writer,
   runId,
   model,
+  profile,
+  mode,
   startedAt,
   workspaceRoot,
   responseKind,
+  tokenBudgetMultiplier,
   tokenBudgetContext,
 }: {
   writer: UIMessageStreamWriter<AntonUIMessage>;
   runId: string;
   model: string;
+  profile: AgentRunProfile;
+  mode: AgentRunMode;
   startedAt: number;
   workspaceRoot?: string;
   responseKind?: "plan";
+  tokenBudgetMultiplier: number;
   tokenBudgetContext: {
     baseMaxTotalTokens: number;
+    baseMaxEffectiveTokens: number;
     tokenBudgetMultiplier: number;
     priorTokensUsed: number;
+    priorEffectiveTokensUsed: number;
   };
 }) {
   let sequence = 0;
+  let loopGuardCount = 0;
+  let verificationSummary: string | undefined;
   let stepCount = 0;
   let finalized = false;
+  let stateChangingEditSucceeded = false;
+  let latestFailedToolReason: string | undefined;
+  let promotionReason: string | undefined;
+  let effectiveProfile: AgentRunProfile = profile;
   const events = new Map<string, AntonActivityEvent>();
   const reasoningBuffers = new Map<string, string>();
 
@@ -1024,8 +1165,10 @@ function createTraceWriter({
     if (!success) return "Tool execution failed";
     if (typeof output !== "object" || output === null) return null;
     const record = output as Record<string, unknown>;
-    if (record.ok === false && typeof record.error === "string") {
-      return auditSummary(record.error);
+    if (record.ok === false) {
+      if (typeof record.error === "string") return auditSummary(record.error);
+      if (typeof record.message === "string") return auditSummary(record.message);
+      return "Tool returned ok: false";
     }
     if (typeof record.failedReason === "string") {
       return auditSummary(record.failedReason);
@@ -1048,6 +1191,10 @@ function createTraceWriter({
     if (name === "glob" && summary) return `Listed ${summary}`;
     if (name === "write_file" && summary) return `Edited ${summary}`;
     if (name === "edit_file" && summary) return `Patched ${summary}`;
+    if (name === "edit_text" && summary) return `Edited ${summary}`;
+    if (name === "replace_text" && summary) return `Replaced text in ${summary}`;
+    if (name === "replace_lines" && summary) return `Replaced lines in ${summary}`;
+    if (name === "multi_replace_text" && summary) return `Replaced text in ${summary}`;
     if (name === "mkdir" && summary) return `Created directory ${summary}`;
     if (name === "delete" && summary) return `Deleted ${summary}`;
     if (name === "rename" && summary) return `Renamed ${summary}`;
@@ -1063,13 +1210,18 @@ function createTraceWriter({
     limits: {
       maxSteps?: number;
       maxTotalTokens?: number;
+      maxEffectiveTokens?: number;
       baseMaxTotalTokens?: number;
+      baseMaxEffectiveTokens?: number;
       maxCostUsd?: number;
       priorTokensUsed?: number;
       tokenBudgetMultiplier?: number;
       maxStepLimitReached?: boolean;
       tokenBudgetReached?: boolean;
       costBudgetReached?: boolean;
+      loopGuardIncomplete?: boolean;
+      unverifiedEdit?: boolean;
+      verificationFailed?: boolean;
       tokenAudit?: TokenAudit;
       stepProviderMetadata?: ProviderMetadata[];
     } = {},
@@ -1105,11 +1257,32 @@ function createTraceWriter({
         observedCostUsd: costUsd,
         reached: limits.costBudgetReached === true,
       },
+      {
+        profile,
+        mode,
+        model,
+        tokenBudgetMultiplier,
+        loopGuardCount:
+          limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
+        verificationSummary,
+        cacheHitRate: limits.tokenAudit?.promptCache?.cacheHitRate,
+        promotionReason:
+          limits.tokenAudit?.promotionReason ?? promotionReason,
+        effectiveProfile:
+          limits.tokenAudit?.effectiveProfile ?? effectiveProfile,
+        hadSuccessfulEdit: stateChangingEditSucceeded,
+      },
     );
     const storedFinishReason = limits.maxStepLimitReached
       ? "max_step_limit"
       : limits.tokenBudgetReached
         ? "token_budget_limit"
+      : limits.verificationFailed
+        ? "verification_failed"
+      : limits.unverifiedEdit
+        ? "unverified_edit"
+      : limits.loopGuardIncomplete
+        ? "loop_guard_incomplete"
       : limits.costBudgetReached
         ? "cost_budget_limit"
       : finishReason;
@@ -1130,6 +1303,27 @@ function createTraceWriter({
       maxStepLimitReached: limits.maxStepLimitReached,
       maxCostUsd: limits.maxCostUsd,
       costBudgetReached: limits.costBudgetReached,
+      profile,
+      mode,
+      tokenBudgetMultiplier,
+      cacheHitRate: limits.tokenAudit?.promptCache?.cacheHitRate,
+      loopGuardCount: limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
+      verificationSummary,
+      ...(limits.tokenAudit?.promotionReason ?? promotionReason
+        ? {
+            promotionReason:
+              limits.tokenAudit?.promotionReason ?? promotionReason,
+          }
+        : {}),
+      ...(limits.tokenAudit?.effectiveProfile ?? effectiveProfile
+        ? {
+            effectiveProfile:
+              limits.tokenAudit?.effectiveProfile ?? effectiveProfile,
+          }
+        : {}),
+      hadSuccessfulEdit: stateChangingEditSucceeded,
+      rawTotalTokens: tokenUsage?.rawTotalTokens ?? totalTokens,
+      effectiveTokens: tokenUsage?.effectiveTokens,
     });
     if (limits.maxStepLimitReached) {
       startEvent({
@@ -1150,22 +1344,44 @@ function createTraceWriter({
       const tokensUsed =
         (limits.priorTokensUsed ?? tokenBudgetContext.priorTokensUsed) +
         segmentTokens;
+      const effectiveTokensUsed =
+        tokenBudgetContext.priorEffectiveTokensUsed +
+        (tokenUsage?.effectiveTokens ?? segmentTokens);
       const currentMultiplier =
         limits.tokenBudgetMultiplier ?? tokenBudgetContext.tokenBudgetMultiplier;
       const baseMaxTotalTokens =
         limits.baseMaxTotalTokens ?? tokenBudgetContext.baseMaxTotalTokens;
+      const baseMaxEffectiveTokens =
+        limits.baseMaxEffectiveTokens ?? tokenBudgetContext.baseMaxEffectiveTokens;
       const currentMaxTotalTokens =
         limits.maxTotalTokens ??
         baseMaxTotalTokens * Math.max(1, currentMultiplier);
-      const options = availableTokenBudgetMultipliers(currentMultiplier);
+      const currentMaxEffectiveTokens =
+        limits.maxEffectiveTokens ??
+        baseMaxEffectiveTokens * Math.max(1, currentMultiplier);
+      const options = availableTokenBudgetMultipliers(
+        currentMultiplier,
+        limits.tokenAudit?.profile ?? profile,
+      );
       const gateData: AntonBudgetGateData = {
         runId,
         status: options.length > 0 ? "open" : "exhausted",
         tokensUsed,
+        effectiveTokensUsed,
+        ...(tokenUsage?.cachedInputTokens !== undefined
+          ? { cachedInputTokens: tokenUsage.cachedInputTokens }
+          : {}),
+        ...(tokenUsage?.uncachedInputTokens !== undefined
+          ? { uncachedInputTokens: tokenUsage.uncachedInputTokens }
+          : {}),
         baseMaxTotalTokens,
         currentMaxTotalTokens,
+        currentMaxEffectiveTokens,
         currentMultiplier,
         options,
+        ...(!stateChangingEditSucceeded && latestFailedToolReason
+          ? { lastFailedToolReason: latestFailedToolReason }
+          : {}),
       };
       writer.write({
         type: "data-budget-gate",
@@ -1185,6 +1401,50 @@ function createTraceWriter({
           stepCount,
           maxCostUsd: limits.maxCostUsd,
           costUsd,
+        },
+      });
+    }
+    if (limits.loopGuardIncomplete && !limits.unverifiedEdit && !limits.verificationFailed) {
+      startEvent({
+        id: `${runId}:loop-guard-incomplete:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Run stopped before edits",
+        summary:
+          "Loop guards stopped tool use before any file edit succeeded. Treat the final answer as incomplete until an edit and verify succeed.",
+        details: {
+          finishReason: storedFinishReason,
+          stepCount,
+          loopGuardCount: limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
+        },
+      });
+    }
+    if (limits.verificationFailed) {
+      startEvent({
+        id: `${runId}:verification-failed:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Verification failed after edit",
+        summary:
+          verificationSummary ??
+          "At least one file edit succeeded and verify ran, but verification failed before the run ended.",
+        details: {
+          finishReason: storedFinishReason,
+          stepCount,
+        },
+      });
+    }
+    if (limits.unverifiedEdit) {
+      startEvent({
+        id: `${runId}:unverified-edit:${sequence + 1}`,
+        kind: "error",
+        status: "error",
+        label: "Edit completed without verification",
+        summary:
+          "At least one file edit succeeded, but verify did not run before the run ended. Treat the final answer as incomplete until verify succeeds.",
+        details: {
+          finishReason: storedFinishReason,
+          stepCount,
         },
       });
     }
@@ -1215,6 +1475,64 @@ function createTraceWriter({
         details: { contextBudget: report },
       });
     },
+    noteModelSelection(summary: string) {
+      startEvent({
+        id: `${runId}:model-selection:${sequence + 1}`,
+        kind: "progress",
+        status: "completed",
+        label: "Model selection preserved",
+        summary,
+      });
+    },
+    noteProfilePromotion(event: ProfilePromotionEvent) {
+      promotionReason = event.reason;
+      effectiveProfile = event.toProfile;
+      startEvent({
+        id: `${runId}:profile-promotion:${sequence + 1}`,
+        kind: "progress",
+        status: "completed",
+        label: "Fast-edit promoted to Agent",
+        summary: event.reason,
+        details: {
+          promotion: {
+            fromProfile: event.fromProfile,
+            toProfile: event.toProfile,
+            reason: event.reason,
+          },
+        },
+      });
+    },
+    noteLoopGuard(event: {
+      reason: string;
+      blockedTools: string[];
+      affectedPath?: string;
+      phase?: string;
+      failureCode?: string;
+      recommendedNext?: string;
+      forceFinal: boolean;
+    }) {
+      loopGuardCount += 1;
+      startEvent({
+        id: `${runId}:loop-guard:${sequence + 1}`,
+        kind: "progress",
+        status: "completed",
+        label: "Loop guard activated",
+        summary: event.reason,
+        details: {
+          loopGuard: {
+            reason: event.reason,
+            blockedTools: event.blockedTools,
+            ...(event.affectedPath ? { affectedPath: event.affectedPath } : {}),
+            ...(event.phase ? { phase: event.phase } : {}),
+            ...(event.failureCode ? { failureCode: event.failureCode } : {}),
+            ...(event.recommendedNext
+              ? { recommendedNext: event.recommendedNext }
+              : {}),
+            forceFinal: event.forceFinal,
+          },
+        },
+      });
+    },
     startStep(stepNumber: number) {
       stepCount = Math.max(stepCount, stepNumber + 1);
       startEvent({
@@ -1227,6 +1545,16 @@ function createTraceWriter({
       finishEvent(`${runId}:step:${stepNumber}`, {
         status: "completed",
         label: `Step ${stepNumber + 1} completed`,
+      });
+    },
+    updateStepUsage(steps: NonNullable<TokenAudit["steps"]>) {
+      writeRun("running", {
+        costMetadata: {
+          tokenAudit: {
+            profile,
+            steps,
+          },
+        },
       });
     },
     startTool(event: {
@@ -1324,6 +1652,22 @@ function createTraceWriter({
       const current = events.get(`${runId}:tool:${event.toolCallId}`);
       const error = toolError(event.success, event.output, event.error);
       const status = error ? "error" : "completed";
+      if (
+        event.success &&
+        isStateChangingEditTool(event.toolName) &&
+        isRecord(event.output) &&
+        event.output.ok === true
+      ) {
+        stateChangingEditSucceeded = true;
+      }
+      if (!event.success || (isRecord(event.output) && event.output.ok === false)) {
+        const reason =
+          error ??
+          (isRecord(event.output)
+            ? failedToolOutputMessage(event.output)
+            : undefined);
+        if (reason) latestFailedToolReason = reason;
+      }
       finishEvent(`${runId}:tool:${event.toolCallId}`, {
         status,
         label: toolLabel(event.toolName, event.input),
@@ -1334,6 +1678,17 @@ function createTraceWriter({
           stepNumber: event.stepNumber,
           success: event.success,
           error,
+          ...(event.toolName === "read_file" &&
+          isRecord(event.output) &&
+          event.success
+            ? {
+                durableOutput: event.output,
+                modelVisibleOutput: compactReadFileForModel(
+                  event.output,
+                  profile,
+                ),
+              }
+            : {}),
         },
       });
       const currentApproval = structuredApprovalDetails(current?.details?.approval);
@@ -1347,6 +1702,10 @@ function createTraceWriter({
       };
       if (currentApproval) toolCallUpdate.approvalDecision = "approved";
       updateToolCall(`${runId}:tool:${event.toolCallId}`, toolCallUpdate);
+      if (event.toolName === "verify" && isRecord(event.output)) {
+        const summary = event.output.summary;
+        if (typeof summary === "string") verificationSummary = summary;
+      }
       if (currentApproval) {
         upsertToolApproval({
           id: `${runId}:tool:${event.toolCallId}:approval`,
@@ -1363,9 +1722,7 @@ function createTraceWriter({
           respondedAt: new Date(),
         });
       }
-      const todos =
-        todoItemsFromToolOutput(event.toolName, event.output) ??
-        todoItemsFromToolInput(event.toolName, event.input);
+      const todos = todoItemsFromToolOutput(event.toolName, event.output, event.success);
       if (todos) writeTodos(todos);
     },
     handleStreamPart(part: TextStreamPart<ToolSet>) {
@@ -1418,8 +1775,9 @@ function createTraceWriter({
 function todoItemsFromToolOutput(
   toolName: string,
   output: unknown,
+  success: boolean,
 ): AntonTodoItem[] | undefined {
-  if (toolName !== "update_todos") return undefined;
+  if (toolName !== "update_todos" || !success) return undefined;
   if (!isRecord(output) || output.ok !== true || !Array.isArray(output.items)) {
     return undefined;
   }
@@ -1428,37 +1786,6 @@ function todoItemsFromToolOutput(
     if (!isRecord(item)) return [];
     const id = typeof item.id === "string" ? item.id : "";
     const text = typeof item.text === "string" ? item.text : "";
-    const status = item.status;
-    if (
-      !id ||
-      !text ||
-      (status !== "pending" &&
-        status !== "in_progress" &&
-        status !== "completed")
-    ) {
-      return [];
-    }
-    return [{ id, text, status }];
-  });
-
-  return items.length > 0 ? items : undefined;
-}
-
-function todoItemsFromToolInput(
-  toolName: string,
-  input: unknown,
-): AntonTodoItem[] | undefined {
-  if (toolName !== "update_todos" || !isRecord(input) || !Array.isArray(input.items)) {
-    return undefined;
-  }
-
-  const items = input.items.flatMap((item): AntonTodoItem[] => {
-    if (!isRecord(item)) return [];
-    const id = typeof item.id === "string" ? item.id.trim() : "";
-    const text =
-      typeof item.text === "string"
-        ? item.text.replace(/\s+/g, " ").trim()
-        : "";
     const status = item.status;
     if (
       !id ||
@@ -1544,6 +1871,18 @@ function runCostMetadata(
     observedCostUsd: number | undefined;
     reached: boolean;
   },
+  execution: {
+    profile: AgentRunProfile;
+    mode: AgentRunMode;
+    model: string;
+    tokenBudgetMultiplier: number;
+    loopGuardCount: number;
+    verificationSummary?: string;
+    cacheHitRate?: number;
+    promotionReason?: string;
+    effectiveProfile?: AgentRunProfile;
+    hadSuccessfulEdit?: boolean;
+  },
 ): Record<string, unknown> | null {
   const providerCostMetadata = openRouterCostMetadata(
     providerMetadata,
@@ -1559,15 +1898,58 @@ function runCostMetadata(
         : "enforced_provider_cost",
   };
   if (!tokenAudit && !tokenUsage && !providerCostMetadata) {
-    return redactValue({ costBudget: costBudgetMetadata }) as Record<
-      string,
-      unknown
-    >;
+    return redactValue({
+      execution: {
+        profile: execution.profile,
+        mode: execution.mode,
+        model: execution.model,
+        tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
+        loopGuardCount: execution.loopGuardCount,
+        ...(execution.verificationSummary
+          ? { verificationSummary: execution.verificationSummary }
+          : {}),
+        ...(execution.cacheHitRate !== undefined
+          ? { cacheHitRate: execution.cacheHitRate }
+          : {}),
+        ...(execution.promotionReason
+          ? { promotionReason: execution.promotionReason }
+          : {}),
+        ...(execution.effectiveProfile
+          ? { effectiveProfile: execution.effectiveProfile }
+          : {}),
+        ...(execution.hadSuccessfulEdit !== undefined
+          ? { hadSuccessfulEdit: execution.hadSuccessfulEdit }
+          : {}),
+      },
+      costBudget: costBudgetMetadata,
+    }) as Record<string, unknown>;
   }
   return redactValue({
     ...(providerCostMetadata ?? {}),
     ...(tokenUsage ? { tokenUsage } : {}),
     ...(tokenAudit ? { tokenAudit } : {}),
+    execution: {
+      profile: execution.profile,
+      mode: execution.mode,
+      model: execution.model,
+      tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
+      loopGuardCount: execution.loopGuardCount,
+      ...(execution.verificationSummary
+        ? { verificationSummary: execution.verificationSummary }
+        : {}),
+      ...(execution.cacheHitRate !== undefined
+        ? { cacheHitRate: execution.cacheHitRate }
+        : {}),
+      ...(execution.promotionReason
+        ? { promotionReason: execution.promotionReason }
+        : {}),
+      ...(execution.effectiveProfile
+        ? { effectiveProfile: execution.effectiveProfile }
+        : {}),
+      ...(execution.hadSuccessfulEdit !== undefined
+        ? { hadSuccessfulEdit: execution.hadSuccessfulEdit }
+        : {}),
+    },
     costBudget: costBudgetMetadata,
   }) as Record<string, unknown>;
 }
@@ -1577,35 +1959,45 @@ function formatCostLimit(value: number | undefined): string {
   return value.toFixed(value >= 1 ? 2 : 4);
 }
 
-function runProfileForMessages(
-  mode: ChatMode,
-  messages: AntonUIMessage[],
-): AgentRunProfile {
-  if (isToolApprovalContinuation(messages)) return "approval-continuation";
-  if (mode === "chat") return "pure-chat";
-  if (mode === "ask") return "ask";
-  if (mode === "plan") return "plan";
-  const latestText = latestUserText(messages).trim().toLowerCase();
-  if (latestText === "implement plan") return "accepted-plan-simple";
-  if (
-    latestText === "implement the plan" ||
-    latestText === "apply plan" ||
-    latestText === "apply the plan"
-  ) {
-    return "accepted-plan-general";
-  }
-  if (isCommandRunRequest(latestText)) return "command-run";
-  return "general-chat";
+function runEligibleForBudgetContinuation(run: {
+  finishReason: string | null;
+  costMetadata: unknown;
+}): boolean {
+  if (run.finishReason === "token_budget_limit") return true;
+  if (!isRecord(run.costMetadata)) return false;
+  const tokenAudit = isRecord(run.costMetadata.tokenAudit)
+    ? run.costMetadata.tokenAudit
+    : undefined;
+  return tokenAudit?.tokenBudgetReached === true;
 }
 
-function isCommandRunRequest(latestText: string): boolean {
-  return (
-    /^(run|execute|rerun|use bash|use terminal)\b/.test(latestText) ||
-    /`(?:git|pnpm|npm|yarn|bun|cat|ls|rg|grep|find)\b[^`]*`/.test(latestText) ||
-    /\b(?:discard|revert|restore)\b.*\b(?:changes|repo|repository|working tree|workspace)\b/.test(latestText) ||
-    /\b(?:clean|stash)\b.*\b(?:repo|repository|working tree|workspace)\b/.test(latestText) ||
-    /\bkeep\b.*\b(?:repo|repository|working tree|workspace)\b.*\bclean\b/.test(latestText)
-  );
+function resolveRunProfile({
+  mode,
+  messages,
+  approvalContinuation,
+  budgetContinuationRun,
+}: {
+  mode: ChatMode;
+  messages: AntonUIMessage[];
+  approvalContinuation: boolean;
+  budgetContinuationRun: ReturnType<typeof getRunById> | undefined;
+}): AgentRunProfile {
+  if (approvalContinuation) {
+    const runId = runIdFromAssistantMessage(messages.at(-1));
+    const originatingRun = runId ? getRunById(runId) : undefined;
+    return (
+      executionProfileFromCostMetadata(originatingRun?.costMetadata) ??
+      executionProfileFromCostMetadata(budgetContinuationRun?.costMetadata) ??
+      classifyRunProfile(mode, latestUserText(messages))
+    );
+  }
+  if (budgetContinuationRun) {
+    return (
+      executionProfileFromCostMetadata(budgetContinuationRun.costMetadata) ??
+      classifyRunProfile(mode, latestUserText(messages))
+    );
+  }
+  return classifyRunProfile(mode, latestUserText(messages));
 }
 
 function isAcceptedPlanProfile(profile: AgentRunProfile): boolean {
@@ -1627,6 +2019,17 @@ function latestUserText(messages: AntonUIMessage[]): string {
 
 function byteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
+}
+
+function isStateChangingEditTool(toolName: string): boolean {
+  return (
+    toolName === "edit_file" ||
+    toolName === "edit_text" ||
+    toolName === "replace_text" ||
+    toolName === "replace_lines" ||
+    toolName === "multi_replace_text" ||
+    toolName === "write_file"
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/components/features/chat/budget-gate-card.tsx
+++ b/components/features/chat/budget-gate-card.tsx
@@ -44,8 +44,10 @@ export function BudgetGateCard({
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span className="text-[11px] text-foreground/85">
-              Token budget reached · {gate.tokensUsed.toLocaleString()} /{" "}
-              {gate.currentMaxTotalTokens.toLocaleString()} ({gate.currentMultiplier}x)
+              Effective budget reached ·{" "}
+              {(gate.effectiveTokensUsed ?? gate.tokensUsed).toLocaleString()} /{" "}
+              {(gate.currentMaxEffectiveTokens ?? gate.currentMaxTotalTokens).toLocaleString()}{" "}
+              ({gate.currentMultiplier}x)
             </span>
             {gate.options.map((multiplier) => (
               <Button
@@ -60,6 +62,11 @@ export function BudgetGateCard({
               </Button>
             ))}
           </div>
+          {gate.lastFailedToolReason ? (
+            <p className="mt-1 text-[11px] text-destructive/90">
+              Latest tool failure: {gate.lastFailedToolReason}
+            </p>
+          ) : null}
         </div>
       </div>
     );
@@ -71,13 +78,32 @@ export function BudgetGateCard({
         <Gauge className="mt-0.5 size-3.5 shrink-0 text-amber-400" />
         <div className="min-w-0 flex-1">
           <div className="text-xs font-medium text-foreground">
-            Token budget reached
+            Effective budget reached
           </div>
           <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-            Used {gate.tokensUsed.toLocaleString()} of{" "}
-            {gate.currentMaxTotalTokens.toLocaleString()} tokens at{" "}
-            {gate.currentMultiplier}x.
+            Effective{" "}
+            {(gate.effectiveTokensUsed ?? gate.tokensUsed).toLocaleString()} /{" "}
+            {(gate.currentMaxEffectiveTokens ?? gate.currentMaxTotalTokens).toLocaleString()}{" "}
+            at {gate.currentMultiplier}x.
+            {gate.cachedInputTokens !== undefined ? (
+              <>
+                {" "}
+                Cached read {gate.cachedInputTokens.toLocaleString()}
+                {gate.uncachedInputTokens !== undefined
+                  ? ` · uncached ${gate.uncachedInputTokens.toLocaleString()}`
+                  : ""}
+                .
+              </>
+            ) : null}
+            {" "}
+            Raw total {gate.tokensUsed.toLocaleString()} /{" "}
+            {gate.currentMaxTotalTokens.toLocaleString()}.
           </p>
+          {gate.lastFailedToolReason ? (
+            <p className="mt-1 text-[11px] leading-relaxed text-destructive/90">
+              Latest tool failure: {gate.lastFailedToolReason}
+            </p>
+          ) : null}
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {gate.options.map((multiplier) => (
               <Button

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -76,6 +76,12 @@ type ComposerControlState = {
 const composerControlStateBySession = new Map<string, ComposerControlState>();
 const COMPOSER_CONTROLS_STORAGE_PREFIX = "anton:composer-controls:";
 const PERMISSION_MODES = ["default", "auto-review", "full-access"] as const;
+const WORKLOG_OPEN_STORAGE_KEY = "anton-worklog-open";
+
+function readStoredWorklogOpen(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.sessionStorage.getItem(WORKLOG_OPEN_STORAGE_KEY) === "1";
+}
 
 function ChatSession({
   sessionId: sessionIdProp,
@@ -109,7 +115,7 @@ function ChatSession({
     () => composerControlStateBySession.get(sessionId),
     [sessionId],
   );
-  const [worklogOpen, setWorklogOpen] = useState(false);
+  const [worklogOpen, setWorklogOpen] = useState(readStoredWorklogOpen);
   const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
   const layoutRef = useRef<HTMLDivElement>(null);
   const {
@@ -120,6 +126,12 @@ function ChatSession({
     toggleExpanded: toggleWorklogExpanded,
     startResize: startWorklogResize,
   } = useWorklogWidth(layoutRef);
+  useEffect(() => {
+    window.sessionStorage.setItem(
+      WORKLOG_OPEN_STORAGE_KEY,
+      worklogOpen ? "1" : "0",
+    );
+  }, [worklogOpen]);
   const [restoreVersion, setRestoreVersion] = useState(0);
   const [messageDisplayOverride, setMessageDisplayOverride] = useState<
     AntonUIMessage[] | null
@@ -406,7 +418,7 @@ function ChatSession({
   );
 
   const extendTokenBudget = useCallback(
-    (runId: string, multiplier: 2 | 3 | 5) => {
+    (runId: string, multiplier: 2 | 3) => {
       if (lastNonEmptyMessagesRef.current.length > 0) {
         setMessageDisplayOverride(lastNonEmptyMessagesRef.current);
       }

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -22,7 +22,11 @@ import {
   getRunData,
   getToolTraceEntries,
   hasPendingToolApproval,
+  messageHadSuccessfulStateChangingEdit,
   messageHasBudgetLimit,
+  messageIsLoopGuardIncomplete,
+  messageIsUnverifiedEdit,
+  messageIsVerificationFailed,
   type AntonUIMessage,
   type TokenBudgetMultiplierOption,
 } from "@/src/lib/trace";
@@ -201,8 +205,15 @@ function MessageEvent({
     assistantFinal &&
     !streaming;
   const openBudgetGate = showBudgetGate ? getLatestOpenBudgetGate(message) : undefined;
+  const incompleteWithoutEdits =
+    !isUser && messageIsLoopGuardIncomplete(message) && !messageHadSuccessfulStateChangingEdit(message);
+  const unverifiedWithEdits =
+    !isUser && messageIsUnverifiedEdit(message) && messageHadSuccessfulStateChangingEdit(message);
+  const verificationFailedWithEdits =
+    !isUser && messageIsVerificationFailed(message) && messageHadSuccessfulStateChangingEdit(message);
   const suppressToolFailure =
-    openBudgetGate !== undefined || messageHasBudgetLimit(message);
+    (openBudgetGate !== undefined || messageHasBudgetLimit(message)) &&
+    messageHadSuccessfulStateChangingEdit(message);
   const showToolFailure =
     !isUser &&
     !suppressToolFailure &&
@@ -256,6 +267,28 @@ function MessageEvent({
         ) : showToolFailure ? (
           <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             Tool failed: {failedToolText}
+          </div>
+        ) : incompleteWithoutEdits && assistantFinal ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            No changes were written. {failedToolText || "Loop guards stopped the run before a successful edit."}
+          </div>
+        ) : unverifiedWithEdits && assistantFinal ? (
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+            Edit completed without verification. Run verify before treating this answer as done.
+            {responseText.length > 0 ? (
+              <div className="mt-2 opacity-90">
+                <Markdown className="text-xs">{responseText}</Markdown>
+              </div>
+            ) : null}
+          </div>
+        ) : verificationFailedWithEdits && assistantFinal ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            Verification failed after edits. Treat this answer as incomplete until the reported verification issue is fixed.
+            {responseText.length > 0 ? (
+              <div className="mt-2 opacity-90">
+                <Markdown className="text-xs">{responseText}</Markdown>
+              </div>
+            ) : null}
           </div>
         ) : responseKind === "plan" ? null
         : responseText.length > 0 ? (

--- a/components/features/run-trace/project-run-details.tsx
+++ b/components/features/run-trace/project-run-details.tsx
@@ -40,6 +40,16 @@ import {
   timelineEventMeta,
 } from "@/components/features/run-trace/trace-timeline-ui";
 import {
+  formatCompactCount,
+  parseHarnessStepNumber,
+  PromptCacheSection,
+  StepCacheIndicator,
+  stepUsageByNumber,
+  StepUsageTable,
+  UsageStatGrid,
+  UsageSectionShell,
+} from "@/components/features/run-trace/trace-usage-ui";
+import {
   contextCompositionSections,
   contextCompositionTotalTokens,
 } from "@/src/lib/context-composition";
@@ -47,6 +57,7 @@ import { cn } from "@/lib/utils";
 import type {
   ProjectRunDetailsApproval,
   ProjectRunDetailsEvent,
+  ProjectRunDetailsStepUsage,
   ProjectRunDetailsSummary,
   ProjectRunDetailsToolCall,
 } from "@/src/lib/api-types";
@@ -185,6 +196,7 @@ export function ProjectRunDetails({
               events={events}
               toolCalls={toolCalls}
               approvals={approvals}
+              stepUsage={run.stepUsage ?? []}
             />
           )}
         </TabsContent>
@@ -237,6 +249,17 @@ function RunMetaStrip({
           {segmentCount && segmentCount > 1 ? ` · ${segmentCount} segments` : ""}
         </MetaChip>
       ) : null}
+      {run.profile ? (
+        <MetaChip accent="muted">profile: {run.profile}</MetaChip>
+      ) : null}
+      {run.loopGuardCount !== null && run.loopGuardCount !== undefined && run.loopGuardCount > 0 ? (
+        <MetaChip accent="muted">guards: {run.loopGuardCount}</MetaChip>
+      ) : null}
+      {run.cacheHitRate !== null && run.cacheHitRate !== undefined ? (
+        <MetaChip accent="muted">
+          cache: {(run.cacheHitRate * 100).toFixed(0)}%
+        </MetaChip>
+      ) : null}
       <Button
         type="button"
         size="xs"
@@ -282,14 +305,17 @@ function TraceTimeline({
   events,
   toolCalls,
   approvals,
+  stepUsage,
 }: {
   run: ProjectRunDetailsSummary["run"];
   segmentCount?: number;
   events: ProjectRunDetailsEvent[];
   toolCalls: ProjectRunDetailsToolCall[];
   approvals: ProjectRunDetailsApproval[];
+  stepUsage: readonly ProjectRunDetailsStepUsage[];
 }) {
   const [expandedEventId, setExpandedEventId] = useState<string | null>(null);
+  const stepUsageMap = stepUsageByNumber(stepUsage);
   const displayEvents = events.filter(
     (event) =>
       event.kind !== "approval" && !isStaleTokenBudgetTraceEvent(event),
@@ -312,13 +338,32 @@ function TraceTimeline({
             status={run.status === "error" ? "error" : "completed"}
           />
           <TraceThreadChildren>
-            {group.steps.map((step) => (
+            {group.steps.map((step) => {
+              const harnessStepNumber = parseHarnessStepNumber(step.id);
+              const stepMetrics =
+                harnessStepNumber !== undefined
+                  ? stepUsageMap.get(harnessStepNumber)
+                  : undefined;
+              const displayStepNumber =
+                harnessStepNumber !== undefined
+                  ? harnessStepDisplayNumber(harnessStepNumber)
+                  : undefined;
+
+              return (
               <TraceThreadNode key={step.id}>
                 <TraceThreadHeaderRow
                   icon={Hash}
                   iconClass={stepMeta.iconClass}
                   dotClass={stepMeta.dotClass}
                   label={step.label}
+                  labelSuffix={
+                    displayStepNumber !== undefined ? (
+                      <StepCacheIndicator
+                        step={stepMetrics}
+                        displayStepNumber={displayStepNumber}
+                      />
+                    ) : undefined
+                  }
                   durationMs={step.durationMs}
                   subdued
                 />
@@ -382,7 +427,8 @@ function TraceTimeline({
                   </TraceThreadChildren>
                 ) : null}
               </TraceThreadNode>
-            ))}
+            );
+            })}
           </TraceThreadChildren>
         </TraceThreadNode>
       ))}
@@ -661,6 +707,8 @@ function TokenUsagePanel({
 }) {
   const usage = run.tokenUsage;
   const composition = run.contextComposition;
+  const promptCache = run.promptCache;
+  const stepUsage = run.stepUsage ?? [];
   const sections = composition
     ? contextCompositionSections(composition)
     : [];
@@ -669,33 +717,25 @@ function TokenUsagePanel({
     : 0;
   const providerInput = run.inputTokens ?? usage?.rawInputTokens;
 
-  const billingNotes = [
-    usage?.cachedInputTokens !== undefined && usage.cachedInputTokens > 0
-      ? `${formatCompactCount(usage.cachedInputTokens)} cached read`
-      : null,
-    usage?.reasoningTokens !== undefined && usage.reasoningTokens > 0
-      ? `${formatCompactCount(usage.reasoningTokens)} reasoning`
-      : null,
-    usage?.providerEffectiveTokens !== undefined
-      ? `${formatCompactCount(usage.providerEffectiveTokens)} provider billed`
-      : null,
-  ].filter((note): note is string => note !== null);
-
   return (
-    <div className="space-y-3">
-      {sections.length > 0 ? (
-        <section className="space-y-2">
-          <div className="flex items-baseline justify-between gap-2">
-            <h4 className="text-[11px] font-medium text-foreground/90">
-              Context
-            </h4>
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
-              ~{formatCompactCount(compositionTotal)} tokens
-            </span>
-          </div>
+    <div className="space-y-2">
+      <UsageStatGrid run={run} usage={usage} />
 
+      {promptCache ? <PromptCacheSection promptCache={promptCache} /> : null}
+
+      {stepUsage.length > 0 ? <StepUsageTable stepUsage={stepUsage} /> : null}
+
+      {sections.length > 0 ? (
+        <UsageSectionShell
+          title="Context"
+          trailing={
+            <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+              ~{formatCompactCount(compositionTotal)}
+            </span>
+          }
+        >
           {compositionTotal > 0 ? (
-            <div className="flex h-2 overflow-hidden rounded-full bg-muted/30">
+            <div className="mb-1.5 flex h-2 overflow-hidden rounded-full bg-muted/30">
               {sections.map((section) => (
                 <div
                   key={section.key}
@@ -709,11 +749,11 @@ function TokenUsagePanel({
             </div>
           ) : null}
 
-          <ul className="space-y-1">
+          <ul className="space-y-0.5">
             {sections.map((section) => (
               <li
                 key={section.key}
-                className="flex min-w-0 items-center gap-2 text-[11px]"
+                className="flex min-w-0 items-center gap-2 text-[10px]"
               >
                 <span
                   className={cn(
@@ -731,31 +771,18 @@ function TokenUsagePanel({
             ))}
           </ul>
 
-          <p className="text-[10px] leading-snug text-muted-foreground">
-            Estimated from prompt size at run start. Provider-reported input was{" "}
-            {formatCount(providerInput)} across all steps
-            {run.stepCount !== null ? ` (${run.stepCount} steps)` : ""}.
+          <p className="mt-1.5 text-[9px] leading-snug text-muted-foreground/80">
+            Estimated at run start · provider input{" "}
+            {formatCount(providerInput)}
+            {run.stepCount !== null ? ` · ${run.stepCount} steps` : ""}
           </p>
-        </section>
+        </UsageSectionShell>
       ) : (
         <EmptyHint>
           Context breakdown is available for new runs. Older runs only store
           provider totals.
         </EmptyHint>
       )}
-
-      {billingNotes.length > 0 ? (
-        <section className="space-y-1 border-t border-border/30 pt-2">
-          <h4 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Billing notes
-          </h4>
-          <ul className="space-y-0.5 text-[10px] text-muted-foreground">
-            {billingNotes.map((note) => (
-              <li key={note}>{note}</li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
     </div>
   );
 }
@@ -781,17 +808,6 @@ function contextSectionColor(key: string): string {
     default:
       return "bg-muted-foreground/50";
   }
-}
-
-function formatCompactCount(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "—";
-  if (value >= 1000) {
-    const compact = value / 1000;
-    return compact >= 10
-      ? `${Math.round(compact)}K`
-      : `${compact.toFixed(1).replace(/\.0$/, "")}K`;
-  }
-  return value.toLocaleString();
 }
 
 function ContextPanel({
@@ -1187,6 +1203,20 @@ function buildRunSummaryText(details: ProjectRunDetailsSummary): string {
       ? [`Duration: ${formatDuration(run.durationMs)}`]
       : []),
     ...(run.stepCount !== null ? [`Steps: ${run.stepCount}`] : []),
+    ...(run.profile ? [`Profile: ${run.profile}`] : []),
+    ...(run.rawTotalTokens !== null && run.rawTotalTokens !== undefined
+      ? [`Raw tokens: ${formatCount(run.rawTotalTokens)}`]
+      : []),
+    ...(run.effectiveTokens !== null && run.effectiveTokens !== undefined
+      ? [`Effective tokens: ${formatCount(run.effectiveTokens)}`]
+      : []),
+    ...(run.cacheHitRate !== null && run.cacheHitRate !== undefined
+      ? [`Cache hit rate: ${(run.cacheHitRate * 100).toFixed(1)}%`]
+      : []),
+    ...(run.loopGuardCount !== null && run.loopGuardCount !== undefined
+      ? [`Loop guards: ${run.loopGuardCount}`]
+      : []),
+    ...(run.verificationSummary ? [`Verification: ${run.verificationSummary}`] : []),
     `Tokens: ${formatCount(run.totalTokens)} (in ${formatCount(run.inputTokens)} / out ${formatCount(run.outputTokens)})`,
     ...(run.costUsd !== null ? [`Cost: $${run.costUsd.toFixed(4)}`] : []),
     "",

--- a/components/features/run-trace/trace-timeline-ui.tsx
+++ b/components/features/run-trace/trace-timeline-ui.tsx
@@ -75,6 +75,7 @@ export function TraceThreadHeaderRow({
   iconClass,
   dotClass,
   label,
+  labelSuffix,
   durationMs,
   status,
   subdued = false,
@@ -83,6 +84,7 @@ export function TraceThreadHeaderRow({
   iconClass: string;
   dotClass: string;
   label: string;
+  labelSuffix?: ReactNode;
   durationMs?: number | null;
   status?: AntonRunStatus;
   subdued?: boolean;
@@ -105,13 +107,14 @@ export function TraceThreadHeaderRow({
       <div className="flex min-w-0 items-center gap-1.5">
         <span
           className={cn(
-            "min-w-0 flex-1 truncate text-[11px]",
+            "inline-flex min-w-0 flex-1 items-center gap-1 truncate text-[11px]",
             subdued
               ? "font-medium text-foreground/85"
               : "font-semibold text-foreground/95",
           )}
         >
-          {label}
+          <span className="truncate">{label}</span>
+          {labelSuffix}
         </span>
         {status === "running" ? (
           <Loader2 className="size-3 shrink-0 animate-spin text-sky-400" />

--- a/components/features/run-trace/trace-usage-ui.tsx
+++ b/components/features/run-trace/trace-usage-ui.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Database } from "lucide-react";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
+import type {
+  ProjectRunDetailsPromptCache,
+  ProjectRunDetailsRun,
+  ProjectRunDetailsStepUsage,
+} from "@/src/lib/api-types";
+
+export function stepUsageByNumber(
+  stepUsage: readonly ProjectRunDetailsStepUsage[],
+): Map<number, ProjectRunDetailsStepUsage> {
+  return new Map(stepUsage.map((step) => [step.stepNumber, step]));
+}
+
+export function stepUsageFromCostMetadata(
+  costMetadata: unknown,
+): ProjectRunDetailsStepUsage[] {
+  if (!isRecord(costMetadata)) return [];
+  const tokenAudit = isRecord(costMetadata.tokenAudit)
+    ? costMetadata.tokenAudit
+    : null;
+  if (!tokenAudit || !Array.isArray(tokenAudit.steps)) return [];
+
+  return tokenAudit.steps.flatMap((step): ProjectRunDetailsStepUsage[] => {
+    if (!isRecord(step)) return [];
+    const stepNumber = finiteNumber(step.stepNumber);
+    if (stepNumber === undefined) return [];
+    return [
+      {
+        stepNumber,
+        ...(finiteNumber(step.inputTokens) !== undefined
+          ? { inputTokens: finiteNumber(step.inputTokens) }
+          : {}),
+        ...(finiteNumber(step.outputTokens) !== undefined
+          ? { outputTokens: finiteNumber(step.outputTokens) }
+          : {}),
+        ...(finiteNumber(step.reasoningTokens) !== undefined
+          ? { reasoningTokens: finiteNumber(step.reasoningTokens) }
+          : {}),
+        ...(finiteNumber(step.cachedInputTokens) !== undefined
+          ? { cachedInputTokens: finiteNumber(step.cachedInputTokens) }
+          : {}),
+        ...(finiteNumber(step.toolCallCount) !== undefined
+          ? { toolCallCount: finiteNumber(step.toolCallCount) }
+          : {}),
+        ...(typeof step.finishReason === "string"
+          ? { finishReason: step.finishReason }
+          : {}),
+      },
+    ];
+  });
+}
+
+export function parseHarnessStepNumber(stepId: string): number | undefined {
+  const match = stepId.match(/:step:(\d+)$/);
+  if (!match) return undefined;
+  const value = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+export function stepCacheStatus(
+  step: ProjectRunDetailsStepUsage | undefined,
+): "hit" | "miss" | undefined {
+  if (!step) return undefined;
+  if (step.cachedInputTokens !== undefined && step.cachedInputTokens > 0) {
+    return "hit";
+  }
+  if (step.inputTokens !== undefined && step.inputTokens > 0) return "miss";
+  return undefined;
+}
+
+export function StepCacheIndicator({
+  step,
+  displayStepNumber,
+}: {
+  step: ProjectRunDetailsStepUsage | undefined;
+  displayStepNumber: number;
+}) {
+  const status = stepCacheStatus(step);
+  if (!step || status === undefined) return null;
+
+  const inputTokens = step.inputTokens;
+  const cachedTokens = step.cachedInputTokens ?? 0;
+  const cachePercent =
+    inputTokens !== undefined && inputTokens > 0
+      ? Math.round((cachedTokens / inputTokens) * 100)
+      : undefined;
+
+  return (
+    <HoverCard openDelay={120} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex shrink-0 items-center rounded p-0.5 transition-colors",
+            "hover:bg-secondary/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            status === "hit"
+              ? "text-emerald-400/90"
+              : "text-muted-foreground/55",
+          )}
+          aria-label={
+            status === "hit"
+              ? `Step ${displayStepNumber} cache hit`
+              : `Step ${displayStepNumber} cache miss`
+          }
+        >
+          <Database className="size-3" strokeWidth={2.25} />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-52 space-y-1.5 p-2.5">
+        <p className="text-[10px] font-medium text-foreground/90">
+          Step {displayStepNumber} ·{" "}
+          <span
+            className={cn(
+              status === "hit" ? "text-emerald-400" : "text-muted-foreground",
+            )}
+          >
+            cache {status}
+          </span>
+        </p>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">
+          <dt>Input</dt>
+          <dd className="text-right text-foreground/85">
+            {formatCompactCount(inputTokens)}
+          </dd>
+          <dt>Cached</dt>
+          <dd className="text-right text-foreground/85">
+            {cachedTokens > 0 ? formatCompactCount(cachedTokens) : "—"}
+            {cachePercent !== undefined && cachedTokens > 0
+              ? ` (${cachePercent}%)`
+              : ""}
+          </dd>
+          {step.outputTokens !== undefined ? (
+            <>
+              <dt>Output</dt>
+              <dd className="text-right text-foreground/85">
+                {formatCompactCount(step.outputTokens)}
+              </dd>
+            </>
+          ) : null}
+          {step.toolCallCount !== undefined ? (
+            <>
+              <dt>Tools</dt>
+              <dd className="text-right text-foreground/85">
+                {step.toolCallCount}
+              </dd>
+            </>
+          ) : null}
+        </dl>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+export function UsageStatGrid({
+  run,
+  usage,
+}: {
+  run: ProjectRunDetailsRun;
+  usage: ProjectRunDetailsRun["tokenUsage"];
+}) {
+  const stats = [
+    {
+      label: "Raw total",
+      value: formatCompactCount(run.rawTotalTokens ?? run.totalTokens),
+    },
+    {
+      label: "Effective",
+      value: formatCompactCount(run.effectiveTokens ?? usage?.effectiveTokens),
+    },
+    {
+      label: "Cached read",
+      value: formatCompactCount(usage?.cachedInputTokens),
+      accent: (usage?.cachedInputTokens ?? 0) > 0,
+    },
+    {
+      label: "Cache write",
+      value: formatCompactCount(usage?.cacheWriteTokens),
+    },
+    {
+      label: "Reasoning",
+      value: formatCompactCount(usage?.reasoningTokens),
+    },
+    {
+      label: "Provider billed",
+      value: formatCompactCount(usage?.providerEffectiveTokens),
+    },
+  ].filter((stat) => stat.value !== "—");
+
+  if (stats.length === 0) return null;
+
+  return (
+    <section className="rounded-md border border-border/40 bg-background/20 p-2">
+      <h4 className="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Token totals
+      </h4>
+      <div className="flex gap-1.5">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="min-w-0 flex-1 rounded bg-secondary/30 px-1.5 py-1 text-center ring-1 ring-border/30"
+          >
+            <div
+              className={cn(
+                "font-mono text-[11px] font-medium tabular-nums",
+                stat.accent ? "text-emerald-400/90" : "text-foreground/90",
+              )}
+            >
+              {stat.value}
+            </div>
+            <div className="truncate text-[9px] text-muted-foreground">
+              {stat.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function PromptCacheSection({
+  promptCache,
+}: {
+  promptCache: ProjectRunDetailsPromptCache;
+}) {
+  const hashRows = [
+    ["System", promptCache.systemPromptHash],
+    ["Tools", promptCache.toolSchemaHash],
+    ["Prefix", promptCache.messagePrefixHash],
+    ["Workspace", promptCache.workspaceContextHash],
+  ] as const;
+
+  return (
+    <section className="rounded-md border border-border/40 bg-background/20 p-2">
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <h4 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          Prompt cache
+        </h4>
+        {promptCache.cacheHitRate !== undefined ? (
+          <span className="font-mono text-[10px] tabular-nums text-emerald-400/85">
+            {(promptCache.cacheHitRate * 100).toFixed(1)}% hit
+          </span>
+        ) : null}
+      </div>
+      <div className="mb-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-muted-foreground">
+        <span className="truncate">{promptCache.modelId}</span>
+        <span className="text-muted-foreground/60">·</span>
+        <span>{promptCache.providerId}</span>
+        {promptCache.cachedInputTokens !== undefined ? (
+          <>
+            <span className="text-muted-foreground/60">·</span>
+            <span>{formatCompactCount(promptCache.cachedInputTokens)} cached</span>
+          </>
+        ) : null}
+      </div>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-0.5 font-mono text-[9px] text-muted-foreground/80">
+        {hashRows.map(([label, hash]) => (
+          <div key={label} className="flex min-w-0 gap-1">
+            <span className="shrink-0 text-muted-foreground/60">{label}</span>
+            <span className="truncate">{hash}</span>
+          </div>
+        ))}
+      </div>
+          {promptCache.cacheBreakReasons.length > 0 ? (
+            <ul className="mt-1.5 space-y-0.5 border-t border-border/30 pt-1.5 text-[9px] leading-snug text-sky-200/75">
+              {promptCache.cacheBreakReasons.map((reason) => (
+                <li key={reason} className="line-clamp-2">
+                  {reason}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {promptCache.likelyCacheMissReasons.length > 0 ? (
+        <ul className="mt-1.5 space-y-0.5 border-t border-border/30 pt-1.5 text-[9px] leading-snug text-amber-200/75">
+          {promptCache.likelyCacheMissReasons.map((reason) => (
+            <li key={reason} className="line-clamp-2">
+              {reason}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+export function StepUsageTable({
+  stepUsage,
+}: {
+  stepUsage: readonly ProjectRunDetailsStepUsage[];
+}) {
+  if (stepUsage.length === 0) return null;
+
+  return (
+    <section className="rounded-md border border-border/40 bg-background/20 p-2">
+      <h4 className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Per-step usage
+      </h4>
+      <div className="overflow-x-auto">
+        <table className="w-full text-[10px]">
+          <thead>
+            <tr className="text-left text-[9px] uppercase tracking-wide text-muted-foreground/70">
+              <th className="pb-0.5 pr-2 font-medium">Step</th>
+              <th className="pb-0.5 pr-2 text-right font-medium">In</th>
+              <th className="pb-0.5 pr-2 text-right font-medium">Cached</th>
+              <th className="pb-0.5 pr-2 text-right font-medium">Out</th>
+              <th className="pb-0.5 text-right font-medium">Tools</th>
+            </tr>
+          </thead>
+          <tbody className="font-mono tabular-nums text-muted-foreground">
+            {stepUsage.map((step) => {
+              const status = stepCacheStatus(step);
+              return (
+                <tr
+                  key={step.stepNumber}
+                  className="border-t border-border/20 text-foreground/85"
+                >
+                  <td className="py-0.5 pr-2">
+                    <span className="inline-flex items-center gap-1">
+                      {step.stepNumber + 1}
+                      {status !== undefined ? (
+                        <Database
+                          className={cn(
+                            "size-2.5",
+                            status === "hit"
+                              ? "text-emerald-400/80"
+                              : "text-muted-foreground/40",
+                          )}
+                          strokeWidth={2.25}
+                        />
+                      ) : null}
+                    </span>
+                  </td>
+                  <td className="py-0.5 pr-2 text-right">
+                    {formatCompactCount(step.inputTokens)}
+                  </td>
+                  <td
+                    className={cn(
+                      "py-0.5 pr-2 text-right",
+                      (step.cachedInputTokens ?? 0) > 0 && "text-emerald-400/85",
+                    )}
+                  >
+                    {(step.cachedInputTokens ?? 0) > 0
+                      ? formatCompactCount(step.cachedInputTokens)
+                      : "—"}
+                  </td>
+                  <td className="py-0.5 pr-2 text-right">
+                    {formatCompactCount(step.outputTokens)}
+                  </td>
+                  <td className="py-0.5 text-right">
+                    {step.toolCallCount ?? "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export function UsageSectionShell({
+  title,
+  trailing,
+  children,
+  className,
+}: {
+  title: string;
+  trailing?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn(
+        "rounded-md border border-border/40 bg-background/20 p-2",
+        className,
+      )}
+    >
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <h4 className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h4>
+        {trailing}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function formatCompactCount(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  if (value >= 1000) {
+    const compact = value / 1000;
+    return compact >= 10
+      ? `${Math.round(compact)}K`
+      : `${compact.toFixed(1).replace(/\.0$/, "")}K`;
+  }
+  return value.toLocaleString();
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -53,6 +53,12 @@ import {
   TraceTimelineRow,
   timelineEventMeta,
 } from "@/components/features/run-trace/trace-timeline-ui";
+import {
+  parseHarnessStepNumber,
+  StepCacheIndicator,
+  stepUsageByNumber,
+  stepUsageFromCostMetadata,
+} from "@/components/features/run-trace/trace-usage-ui";
 
 export function WorklogTimeline({
   messages,
@@ -92,6 +98,9 @@ export function WorklogTimeline({
                 ? "error"
                 : "completed",
           );
+          const stepUsageMap = stepUsageByNumber(
+            stepUsageFromCostMetadata(group.run.costMetadata),
+          );
 
           return (
             <TraceThreadNode key={group.runId}>
@@ -106,6 +115,16 @@ export function WorklogTimeline({
               <TraceThreadChildren>
                 {group.steps.map((step) => {
                   const stepMeta = timelineEventMeta("step", "completed");
+                  const harnessStepNumber = parseHarnessStepNumber(step.id);
+                  const stepMetrics =
+                    harnessStepNumber !== undefined
+                      ? stepUsageMap.get(harnessStepNumber)
+                      : undefined;
+                  const displayStepNumber =
+                    harnessStepNumber !== undefined
+                      ? harnessStepDisplayNumber(harnessStepNumber)
+                      : undefined;
+
                   return (
                     <TraceThreadNode key={step.id}>
                       <TraceThreadHeaderRow
@@ -113,6 +132,14 @@ export function WorklogTimeline({
                         iconClass={stepMeta.iconClass}
                         dotClass={stepMeta.dotClass}
                         label={step.label}
+                        labelSuffix={
+                          displayStepNumber !== undefined ? (
+                            <StepCacheIndicator
+                              step={stepMetrics}
+                              displayStepNumber={displayStepNumber}
+                            />
+                          ) : undefined
+                        }
                         durationMs={step.durationMs}
                         subdued
                       />
@@ -413,12 +440,25 @@ function ToolEntryExpandPanel({
 
 function ToolIoBlocks({ entry }: { entry: ToolTraceEntry }) {
   const inputText = safeStringify(entry.input);
+  const durableOutput =
+    entry.name === "read_file" &&
+    entry.activity?.details &&
+    typeof entry.activity.details === "object" &&
+    "durableOutput" in entry.activity.details
+      ? safeStringify(entry.activity.details.durableOutput)
+      : undefined;
+  const modelVisibleOutput =
+    entry.name === "read_file" &&
+    entry.activity?.details &&
+    typeof entry.activity.details === "object" &&
+    "modelVisibleOutput" in entry.activity.details
+      ? safeStringify(entry.activity.details.modelVisibleOutput)
+      : undefined;
   const outputText =
     entry.state === "output-error" && entry.errorText
       ? undefined
-      : entry.output !== undefined
-        ? safeStringify(entry.output)
-        : undefined;
+      : durableOutput ??
+        (entry.output !== undefined ? safeStringify(entry.output) : undefined);
 
   return (
     <div className="space-y-1.5">
@@ -426,7 +466,14 @@ function ToolIoBlocks({ entry }: { entry: ToolTraceEntry }) {
         <TraceLogBlock title="Input">{inputText}</TraceLogBlock>
       ) : null}
       {outputText ? (
-        <TraceLogBlock title="Output">{outputText}</TraceLogBlock>
+        <TraceLogBlock title={durableOutput ? "Durable output" : "Output"}>
+          {outputText}
+        </TraceLogBlock>
+      ) : null}
+      {modelVisibleOutput && modelVisibleOutput !== outputText ? (
+        <TraceLogBlock title="Model-visible output">
+          {modelVisibleOutput}
+        </TraceLogBlock>
       ) : null}
       {entry.errorText ? (
         <TraceLogBlock title="Error" tone="error">

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,6 +1,5 @@
 import {
   streamText,
-  stepCountIs,
   type LanguageModelUsage,
   type ModelMessage,
   type ProviderMetadata,
@@ -27,10 +26,26 @@ import {
   budgetForProfile,
   capRunBudget,
   applyTokenBudgetMultiplier,
-  costBudgetStopCondition,
-  tokenBudgetStopCondition,
+  applyThinkingBudgetAdjustment,
+  mutableCostBudgetStopCondition,
+  mutableEffectiveTokenBudgetStopCondition,
+  mutableRawTokenSanityStopCondition,
+  mutableStepBudgetStopCondition,
   type RunBudget,
 } from "./run-budget";
+import {
+  type ProfilePromotionEvent,
+} from "./profile-promotion";
+import { localizedEditToolNames } from "./profile-classifier";
+import {
+  ToolPolicyEngine,
+  seedFromPriorToolRecords,
+  type PriorToolCallRecord,
+} from "./tool-policy";
+import {
+  buildPromptCacheAudit,
+  type PromptCacheAudit,
+} from "./prompt-cache-audit";
 import { listSkills } from "./skills";
 import {
   createAntonTools,
@@ -54,6 +69,7 @@ export type AgentRunProfile =
   | "accepted-plan-simple"
   | "accepted-plan-general"
   | "command-run"
+  | "localized-edit"
   | "general-chat"
   | "approval-continuation";
 
@@ -71,6 +87,11 @@ export type TokenAudit = {
   };
   budget: RunBudgetAudit;
   contextComposition: ContextCompositionAudit;
+  promptCache?: PromptCacheAudit;
+  loopGuardCount?: number;
+  promotionReason?: string;
+  effectiveProfile?: AgentRunProfile;
+  tokenBudgetReached?: boolean;
   usage?: UsageAudit;
   steps: StepUsageAudit[];
 };
@@ -95,6 +116,9 @@ type RunBudgetAudit = Pick<
   | "maxInputTokens"
   | "maxInputBytes"
   | "maxTotalTokens"
+  | "maxEffectiveTokens"
+  | "maxRawInputTokensPerStep"
+  | "rawTokenSanityCap"
   | "maxCostUsd"
   | "priorRunContextChars"
   | "workspaceContextChars"
@@ -166,6 +190,9 @@ const COMMAND_RUN_TOOLS = [
   "git_status",
 ] as const satisfies readonly NativeAntonToolName[];
 
+const LOCALIZED_EDIT_TOOLS =
+  localizedEditToolNames() as readonly NativeAntonToolName[];
+
 const PROFILE_NATIVE_TOOLS = {
   "pure-chat": CHAT_MODE_TOOLS,
   ask: ASK_MODE_TOOLS,
@@ -173,6 +200,7 @@ const PROFILE_NATIVE_TOOLS = {
   "accepted-plan-simple": ACCEPTED_PLAN_SIMPLE_TOOLS,
   "accepted-plan-general": ACCEPTED_PLAN_GENERAL_TOOLS,
   "command-run": COMMAND_RUN_TOOLS,
+  "localized-edit": LOCALIZED_EDIT_TOOLS,
   "general-chat": NATIVE_ANTON_TOOL_NAMES,
   "approval-continuation": NATIVE_ANTON_TOOL_NAMES,
 } as const satisfies Record<AgentRunProfile, readonly NativeAntonToolName[]>;
@@ -319,10 +347,23 @@ function runProfilePromptLines(
       "- Do not use `verify` in this profile; it is reserved for compact post-edit verification.",
     ];
   }
+  if (profile === "localized-edit") {
+    return [
+      ...header,
+      "- This is a fast-edit run. Start with one modest full-file read when possible, then edit in phases as needed.",
+      "- Multi-step work on the same file is fine: edit, read a range to confirm, edit again, then verify before answering.",
+      "- Prefer `edit_text` for surgical edits (reads disk, returns a diff; no expectedHash). Use several oldText/newText edits in one call when possible.",
+      "- Do not call `edit_file` until `edit_text` has failed on a path. Use `replace_lines` or `replace_text` only when text anchors fail.",
+      "- If the task needs multiple files, shell/git context, or repeated failed edits, the harness promotes to full Agent tools automatically.",
+      "- Run `verify` before the final answer. If verification fails, report it honestly.",
+    ];
+  }
   return [
     ...header,
     "- For multi-step coding tasks, call `update_todos` with a full checklist snapshot before the first edit and update it as work progresses.",
     "- Before the first coding action in a project, call `inspect_project`, then summarize the relevant stack, scripts, git state, and local instructions in your progress text.",
+    "- Prefer `edit_text` for surgical file changes; it reads the current file from disk and returns a compact diff so you rarely need to re-read the whole file.",
+    "- Do not use `edit_file` for small changes; reserve it for large structural rewrites only after `edit_text` fails on a path.",
     "- After editing files, run `verify` before the final answer when the project exposes typecheck, lint, or build scripts. If verification is skipped or fails, say exactly why.",
   ];
 }
@@ -398,12 +439,18 @@ export async function runAgent({
   contextBudget,
   tokenBudgetMultiplier = 1,
   priorTokensUsed = 0,
+  priorEffectiveTokens = 0,
   priorCostUsd = 0,
+  priorToolHistory = [],
+  previousPromptCacheAudit,
   onStepStart,
   onStepFinish,
+  onStepUsageUpdate,
   onToolCallStart,
   onToolCallFinish,
   onStreamPart,
+  onLoopGuard,
+  onProfilePromotion,
   onError,
   onAbort,
   onFinish,
@@ -421,9 +468,13 @@ export async function runAgent({
   contextBudget?: ContextBudgetAudit;
   tokenBudgetMultiplier?: number;
   priorTokensUsed?: number;
+  priorEffectiveTokens?: number;
   priorCostUsd?: number;
+  priorToolHistory?: readonly PriorToolCallRecord[];
+  previousPromptCacheAudit?: PromptCacheAudit | null;
   onStepStart?: (event: { stepNumber: number }) => void;
   onStepFinish?: (event: { stepNumber: number }) => void;
+  onStepUsageUpdate?: (steps: StepUsageAudit[]) => void;
   onToolCallStart?: (event: {
     stepNumber: number | undefined;
     toolCallId: string;
@@ -441,6 +492,16 @@ export async function runAgent({
     error?: unknown;
   }) => void;
   onStreamPart?: (part: TextStreamPart<ToolSet>) => void;
+  onLoopGuard?: (event: {
+    reason: string;
+    blockedTools: string[];
+    affectedPath?: string;
+    phase?: string;
+    failureCode?: string;
+    recommendedNext?: string;
+    forceFinal: boolean;
+  }) => void;
+  onProfilePromotion?: (event: ProfilePromotionEvent) => void;
   onError?: (error: unknown) => void;
   onAbort?: () => void;
   onFinish?: (result: {
@@ -451,20 +512,47 @@ export async function runAgent({
     stepCount: number;
     maxSteps: number;
     maxTotalTokens: number;
+    maxEffectiveTokens: number;
     baseMaxTotalTokens: number;
+    baseMaxEffectiveTokens: number;
     maxCostUsd: number;
     priorTokensUsed: number;
     priorCostUsd: number;
     maxStepLimitReached: boolean;
     tokenBudgetReached: boolean;
     costBudgetReached: boolean;
+    loopGuardIncomplete?: boolean;
+    unverifiedEdit?: boolean;
+    verificationFailed?: boolean;
     tokenAudit: TokenAudit;
   }) => void;
 }) {
-  const baseBudget = capRunBudget(budgetForProfile(profile), maxStepsCap);
-  const budget = applyTokenBudgetMultiplier(baseBudget, tokenBudgetMultiplier);
-  const nativeToolNames = PROFILE_NATIVE_TOOLS[profile];
-  const allowMcpTools = profileAllowsMcp(profile);
+  const isFastEditStart = profile === "localized-edit";
+  const baseBudget = capRunBudget(
+    budgetForProfile(isFastEditStart ? "localized-edit" : profile),
+    maxStepsCap,
+  );
+  const budget = applyThinkingBudgetAdjustment(
+    applyTokenBudgetMultiplier(baseBudget, tokenBudgetMultiplier),
+    thinkingEnabled,
+  );
+  const budgetState = {
+    maxSteps: budget.maxSteps,
+    maxEffectiveTokens: budget.maxEffectiveTokens,
+    maxCostUsd: budget.maxCostUsd,
+    rawTokenSanityCap: budget.rawTokenSanityCap,
+  };
+  let effectiveProfile: AgentRunProfile = profile;
+  let promotionReason: string | undefined;
+  const nativeToolNames = isFastEditStart
+    ? NATIVE_ANTON_TOOL_NAMES
+    : PROFILE_NATIVE_TOOLS[profile];
+  const initialActiveNativeToolNames = isFastEditStart
+    ? [...LOCALIZED_EDIT_TOOLS]
+    : [...PROFILE_NATIVE_TOOLS[profile]];
+  const allowMcpTools = isFastEditStart
+    ? permissionMode === "full-access"
+    : profileAllowsMcp(profile);
   const mcpTools = allowMcpTools
     ? await loadMcpTools({ workspaceRoot, enabledMcpServerIds })
     : emptyLoadedMcpTools();
@@ -485,6 +573,8 @@ export async function runAgent({
   const suppressedToolCallIds = new Set<string>();
   const finishedToolCallIds = new Set<string>();
   const finishedToolCallKeys = new Set<string>();
+  const toolPolicy = new ToolPolicyEngine(profile);
+  toolPolicy.seed(seedFromPriorToolRecords(priorToolHistory));
   const tools = createAntonTools({
     model: selectedModel,
     mcpTools: mcpTools.tools,
@@ -493,7 +583,14 @@ export async function runAgent({
     nativeToolNames,
     includeMcpTools: allowMcpTools,
     executionCache,
+    profile: isFastEditStart ? "localized-edit" : profile,
+    toolPolicy,
   });
+  const allActiveToolNames: string[] = Object.keys(tools);
+  const initialActiveToolNames = initialActiveNativeToolNames.filter((name) =>
+    Object.prototype.hasOwnProperty.call(tools, name),
+  );
+  let currentActiveToolNames: string[] = [...initialActiveToolNames];
   const systemParts =
     profile === "pure-chat"
       ? {
@@ -514,7 +611,6 @@ export async function runAgent({
           systemParts.skills,
           systemParts.profile,
         ].join("\n\n");
-  const activeTools = Object.keys(tools);
   const messageBytes = utf8Bytes(stableJson(messages));
   const contextComposition = buildContextCompositionAudit({
     systemParts,
@@ -532,15 +628,18 @@ export async function runAgent({
       nativeCount: nativeToolNames.length,
       mcpCount: Object.keys(mcpTools.tools).length,
       totalCount: Object.keys(tools).length,
-      activeCount: activeTools.length,
+      activeCount: currentActiveToolNames.length,
     },
     budget: {
       profile: budget.profile,
-      maxSteps: budget.maxSteps,
+      maxSteps: budgetState.maxSteps,
       maxOutputTokens: budget.maxOutputTokens,
       maxInputTokens: budget.maxInputTokens,
       maxInputBytes: budget.maxInputBytes,
       maxTotalTokens: budget.maxTotalTokens,
+      maxEffectiveTokens: budgetState.maxEffectiveTokens,
+      maxRawInputTokensPerStep: budget.maxRawInputTokensPerStep,
+      rawTokenSanityCap: budget.rawTokenSanityCap,
       maxCostUsd: budget.maxCostUsd,
       priorRunContextChars: budget.priorRunContextChars,
       workspaceContextChars: budget.workspaceContextChars,
@@ -555,31 +654,162 @@ export async function runAgent({
     messages,
     maxOutputTokens: budget.maxOutputTokens,
     tools,
-    activeTools,
+    activeTools: currentActiveToolNames,
     stopWhen: [
-      stepCountIs(budget.maxSteps),
-      tokenBudgetStopCondition(budget.maxTotalTokens, priorTokensUsed),
-      costBudgetStopCondition(budget.maxCostUsd, priorCostUsd),
+      mutableStepBudgetStopCondition(() => budgetState.maxSteps),
+      mutableEffectiveTokenBudgetStopCondition(
+        () => budgetState.maxEffectiveTokens,
+        priorEffectiveTokens,
+      ),
+      mutableRawTokenSanityStopCondition(
+        () => budgetState.rawTokenSanityCap,
+        priorTokensUsed,
+      ),
+      mutableCostBudgetStopCondition(() => budgetState.maxCostUsd, priorCostUsd),
     ],
     providerOptions: {
-      openrouter: openRouterProviderOptions(profile, thinkingEnabled),
+      openrouter: openRouterProviderOptions(
+        profile,
+        thinkingEnabled,
+        selectedModel,
+      ),
     },
     prepareStep: ({ messages: stepMessages, steps }) => {
-      const compacted = dedupeToolReplayMessages(stepMessages);
-      const forceFinalReason = forceFinalAnswerReason(steps);
-      if (!forceFinalReason && compacted === stepMessages) return undefined;
+      toolPolicy.observeSteps(steps);
+      const segmentEffective = steps.reduce((sum, step) => {
+        const metrics = buildTokenUsageMetrics({
+          usage: step.usage,
+          providerMetadata: step.providerMetadata,
+        });
+        if (metrics?.effectiveTokens !== undefined) {
+          return sum + metrics.effectiveTokens;
+        }
+        const total = finiteNumber(step.usage?.totalTokens);
+        if (total !== undefined) return sum + total;
+        return (
+          sum +
+          (finiteNumber(step.usage?.inputTokens) ?? 0) +
+          (finiteNumber(step.usage?.outputTokens) ?? 0)
+        );
+      }, 0);
+      const promotion = toolPolicy.checkPromotion(
+        priorEffectiveTokens + segmentEffective,
+        budgetState.maxEffectiveTokens,
+      );
+
+      let nextMessages = stepMessages;
+      if (promotion && isFastEditStart && !toolPolicy.wasPromoted) {
+        toolPolicy.markPromoted();
+        effectiveProfile = promotion.toProfile;
+        promotionReason = promotion.reason;
+        currentActiveToolNames = [...allActiveToolNames];
+        const promotedBudget = applyThinkingBudgetAdjustment(
+          applyTokenBudgetMultiplier(
+            capRunBudget(budgetForProfile("general-chat"), maxStepsCap),
+            tokenBudgetMultiplier,
+          ),
+          thinkingEnabled,
+        );
+        budgetState.maxSteps = Math.max(budgetState.maxSteps, promotedBudget.maxSteps);
+        budgetState.maxEffectiveTokens = promotedBudget.maxEffectiveTokens;
+        budgetState.maxCostUsd = promotedBudget.maxCostUsd;
+        budgetState.rawTokenSanityCap = promotedBudget.rawTokenSanityCap;
+        onProfilePromotion?.(promotion);
+        nextMessages = [
+          ...stepMessages,
+          {
+            role: "assistant" as const,
+            content: [
+              "Model-only profile promotion note:",
+              promotion.reason,
+              "Full Agent tools and budget are now available for the remainder of this run.",
+            ].join("\n"),
+          },
+        ];
+      }
+
+      const verifyReminder = toolPolicy.consumeVerifyReminder();
+      if (verifyReminder) {
+        nextMessages = [
+          ...nextMessages,
+          {
+            role: "assistant" as const,
+            content: verifyReminder,
+          },
+        ];
+      }
+
+      const verifyFixNote = toolPolicy.consumeVerifyFixNote();
+      if (verifyFixNote) {
+        nextMessages = [
+          ...nextMessages,
+          {
+            role: "assistant" as const,
+            content: verifyFixNote,
+          },
+        ];
+      }
+
+      const staleReadNote = toolPolicy.consumeStaleReadNote();
+      if (staleReadNote) {
+        nextMessages = [
+          ...nextMessages,
+          {
+            role: "assistant" as const,
+            content: staleReadNote,
+          },
+        ];
+      }
+
+      const duplicateReplay = messagesHaveDuplicateToolReplay(nextMessages);
+      const compacted = duplicateReplay
+        ? dedupeToolReplayMessages(nextMessages)
+        : nextMessages;
+      const forceFinalReason = toolPolicy.shouldForceFinal() ?? forceFinalAnswerReason(steps);
+      if (forceFinalReason && toolPolicy.shouldEmitLoopGuardEvent(forceFinalReason)) {
+        onLoopGuard?.({
+          reason: forceFinalReason,
+          blockedTools: currentActiveToolNames,
+          forceFinal: true,
+        });
+      }
+      const activeToolsDifferFromInitial =
+        currentActiveToolNames.length !== initialActiveToolNames.length ||
+        currentActiveToolNames.some(
+          (name, index) => name !== initialActiveToolNames[index],
+        );
+      if (
+        !forceFinalReason &&
+        !duplicateReplay &&
+        nextMessages === stepMessages &&
+        !promotion &&
+        !verifyReminder &&
+        !verifyFixNote &&
+        !staleReadNote &&
+        !activeToolsDifferFromInitial
+      ) {
+        return undefined;
+      }
       return {
-        ...(compacted === stepMessages ? {} : { messages: compacted }),
+        ...(duplicateReplay && compacted !== nextMessages
+          ? { messages: compacted }
+          : promotion || verifyReminder || verifyFixNote || staleReadNote
+            ? { messages: compacted }
+          : {}),
+        activeTools: currentActiveToolNames,
         ...(forceFinalReason
           ? {
-              activeTools: [],
-              system: [
-                system,
-                "",
-                "Loop guard:",
-                forceFinalReason,
-                "Write the final answer now without calling more tools.",
-              ].join("\n"),
+              messages: [
+                ...compacted,
+                {
+                  role: "assistant" as const,
+                  content: [
+                    "Loop guard:",
+                    forceFinalReason,
+                    "Write the final answer now without calling more tools.",
+                  ].join("\n"),
+                },
+              ],
             }
           : {}),
       };
@@ -612,6 +842,7 @@ export async function runAgent({
         ...usageAudit(usage, providerMetadata),
       });
       onStepFinish?.({ stepNumber });
+      onStepUsageUpdate?.([...stepUsage]);
     },
     experimental_onToolCallStart: ({ stepNumber, toolCall }) => {
       const key = toolCallSemanticKey(toolCall);
@@ -649,14 +880,65 @@ export async function runAgent({
         output: event.success ? event.output : undefined,
         error: event.success ? undefined : event.error,
       });
+      if (event.success) {
+        const output = event.output;
+        if (
+          isRecord(output) &&
+          output.code === "LOOP_GUARD_BLOCKED" &&
+          typeof output.message === "string" &&
+          toolPolicy.shouldEmitLoopGuardEvent(output.message)
+        ) {
+          onLoopGuard?.({
+            reason: output.message,
+            blockedTools: [event.toolCall.toolName],
+            forceFinal: false,
+            ...(typeof output.affectedPath === "string"
+              ? { affectedPath: output.affectedPath }
+              : {}),
+            ...(typeof output.phase === "string" ? { phase: output.phase } : {}),
+            ...(typeof output.failureCode === "string"
+              ? { failureCode: output.failureCode }
+              : {}),
+            ...(typeof output.recommendedNext === "string"
+              ? { recommendedNext: output.recommendedNext }
+              : {}),
+          });
+        }
+      }
     },
     onFinish: async ({ totalUsage, finishReason, providerMetadata }) => {
+      const tokenUsage = buildTokenUsageMetrics({
+        usage: totalUsage,
+        providerMetadata,
+        stepProviderMetadata,
+      });
+      const workspaceContextText = extractWorkspaceContextText(messages);
+      const promptCache = buildPromptCacheAudit({
+        modelId: selectedModel,
+        system,
+        tools,
+        nativeToolNames,
+        mcpToolNames: Object.keys(mcpTools.tools),
+        activeToolNames: currentActiveToolNames,
+        workspaceContextText,
+        messages,
+        tokenUsage,
+        previousAudit: previousPromptCacheAudit,
+      });
+      const segmentTokens = finiteNumber(totalUsage.totalTokens) ?? 0;
+      const segmentEffective = tokenUsage?.effectiveTokens ?? segmentTokens;
+      const tokenBudgetReached =
+        priorEffectiveTokens + segmentEffective >= budgetState.maxEffectiveTokens;
       const tokenAudit: TokenAudit = {
         ...tokenAuditBase,
+        profile: effectiveProfile,
+        ...(promotionReason ? { promotionReason, effectiveProfile } : {}),
+        tokenBudgetReached,
+        promptCache,
+        loopGuardCount: toolPolicy.loopGuardCount,
         usage: usageAudit(totalUsage, providerMetadata),
         steps: stepUsage,
       };
-      const segmentTokens = finiteNumber(totalUsage.totalTokens) ?? 0;
       const segmentCost =
         openRouterCostFromMetadata(undefined, stepProviderMetadata) ?? 0;
       onFinish?.({
@@ -665,19 +947,27 @@ export async function runAgent({
         providerMetadata,
         stepProviderMetadata,
         stepCount: observedStepCount,
-        maxSteps: budget.maxSteps,
+        maxSteps: budgetState.maxSteps,
         maxTotalTokens: budget.maxTotalTokens,
+        maxEffectiveTokens: budgetState.maxEffectiveTokens,
         baseMaxTotalTokens: baseBudget.maxTotalTokens,
-        maxCostUsd: budget.maxCostUsd,
+        baseMaxEffectiveTokens: baseBudget.maxEffectiveTokens,
+        maxCostUsd: budgetState.maxCostUsd,
         priorTokensUsed,
         priorCostUsd,
         maxStepLimitReached:
-          observedStepCount >= budget.maxSteps && finishReason === "tool-calls",
+          observedStepCount >= budgetState.maxSteps && finishReason === "tool-calls",
         tokenBudgetReached:
-          priorTokensUsed + segmentTokens >= budget.maxTotalTokens,
+          priorEffectiveTokens + segmentEffective >= budgetState.maxEffectiveTokens,
         costBudgetReached:
-          priorCostUsd + segmentCost >= budget.maxCostUsd &&
+          priorCostUsd + segmentCost >= budgetState.maxCostUsd &&
           segmentCost > 0,
+        loopGuardIncomplete:
+          toolPolicy.endedWithoutStateChange ||
+          toolPolicy.endedUnverified ||
+          toolPolicy.endedWithFailedVerification,
+        unverifiedEdit: toolPolicy.endedUnverified,
+        verificationFailed: toolPolicy.endedWithFailedVerification,
         tokenAudit,
       });
       await closeMcpTools();
@@ -703,7 +993,34 @@ export function profileForMode(mode: AgentRunMode): AgentRunProfile {
 }
 
 export function profileAllowsMcp(profile: AgentRunProfile): boolean {
-  return profile === "general-chat" || profile === "approval-continuation";
+  return profile === "general-chat";
+}
+
+function extractWorkspaceContextText(modelMessages: ModelMessage[]): string {
+  for (const message of modelMessages) {
+    if (message.role !== "assistant") continue;
+    const text =
+      typeof message.content === "string"
+        ? message.content
+        : Array.isArray(message.content)
+          ? message.content
+              .flatMap((part) =>
+                typeof part === "object" &&
+                part !== null &&
+                "type" in part &&
+                part.type === "text" &&
+                "text" in part &&
+                typeof part.text === "string"
+                  ? [part.text]
+                  : [],
+              )
+              .join("\n")
+          : "";
+    if (text.startsWith("Model-only context for this run:")) {
+      return text;
+    }
+  }
+  return "";
 }
 
 function emptyLoadedMcpTools(): LoadedMcpTools {
@@ -730,14 +1047,64 @@ function reasoningOptionsForProfile(profile: AgentRunProfile): {
 function openRouterProviderOptions(
   profile: AgentRunProfile,
   thinkingEnabled: boolean,
+  modelId: string,
 ): {
   reasoning?: ReturnType<typeof reasoningOptionsForProfile>;
   usage: { include: true };
+  provider?: {
+    order?: string[];
+    allow_fallbacks?: boolean;
+    require_parameters?: boolean;
+  };
 } {
+  const provider = openRouterProviderRouting(modelId);
   return {
     ...(thinkingEnabled ? { reasoning: reasoningOptionsForProfile(profile) } : {}),
     usage: { include: true },
+    ...(provider ? { provider } : {}),
   };
+}
+
+function openRouterProviderRouting(
+  modelId: string,
+): {
+  order?: string[];
+  allow_fallbacks?: boolean;
+  require_parameters?: boolean;
+} | undefined {
+  const envOrder = providerOrderFromEnv();
+  if (envOrder.length > 0) {
+    return {
+      order: envOrder,
+      allow_fallbacks: envBoolean("OPENROUTER_ALLOW_FALLBACKS") ?? true,
+      require_parameters: true,
+    };
+  }
+
+  if (modelId === "deepseek/deepseek-v4-pro") {
+    return {
+      order: ["alibaba"],
+      allow_fallbacks: true,
+      require_parameters: true,
+    };
+  }
+
+  return undefined;
+}
+
+function providerOrderFromEnv(): string[] {
+  return (process.env.OPENROUTER_PROVIDER_ORDER ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function envBoolean(name: string): boolean | undefined {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return undefined;
+  if (["1", "true", "yes", "on"].includes(value)) return true;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  return undefined;
 }
 
 function usageAudit(
@@ -763,6 +1130,30 @@ function usageAudit(
     result.cachedInputTokens = cachedInputTokens;
   }
   return result;
+}
+
+function messagesHaveDuplicateToolReplay(messages: ModelMessage[]): boolean {
+  const semanticToolCalls = new Map<string, string>();
+  const seenToolResults = new Set<string>();
+
+  for (const message of messages) {
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (!isToolCallPart(part)) continue;
+        const key = toolCallSemanticKey(part);
+        if (semanticToolCalls.has(key)) return true;
+        semanticToolCalls.set(key, part.toolCallId);
+      }
+    }
+    if (message.role === "tool" && Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (!isToolResultPart(part)) continue;
+        if (seenToolResults.has(part.toolCallId)) return true;
+        seenToolResults.add(part.toolCallId);
+      }
+    }
+  }
+  return false;
 }
 
 function dedupeToolReplayMessages(messages: ModelMessage[]): ModelMessage[] {

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -102,6 +102,26 @@ export const NATIVE_TOOL_PERMISSION_METADATA = {
     true,
     "Applies a patch to an existing workspace file.",
   ),
+  edit_text: toolMetadata(
+    ["write"],
+    true,
+    "Applies exact oldText/newText edits to an existing workspace file.",
+  ),
+  replace_text: toolMetadata(
+    ["write"],
+    true,
+    "Replaces one exact text span in an existing workspace file.",
+  ),
+  replace_lines: toolMetadata(
+    ["write"],
+    true,
+    "Replaces ordered line ranges in an existing workspace file.",
+  ),
+  multi_replace_text: toolMetadata(
+    ["write"],
+    true,
+    "Applies ordered exact-text replacements to one existing workspace file.",
+  ),
   read_dir: READ_ONLY,
   stat: READ_ONLY,
   mkdir: toolMetadata(
@@ -310,6 +330,14 @@ function buildNativeToolApprovalMetadata(
       return buildBashApproval(record, metadata, workspaceRoot);
     case "edit_file":
       return buildEditFileApproval(record, metadata, workspaceRoot);
+    case "edit_text":
+      return buildEditTextApproval(record, metadata, workspaceRoot);
+    case "replace_text":
+      return buildReplaceTextApproval(record, metadata, workspaceRoot);
+    case "replace_lines":
+      return buildReplaceLinesApproval(record, metadata, workspaceRoot);
+    case "multi_replace_text":
+      return buildMultiReplaceTextApproval(record, metadata, workspaceRoot);
     case "write_file":
       return buildWriteFileApproval(record, metadata, workspaceRoot);
     case "read_dir":
@@ -795,6 +823,142 @@ function buildEditFileApproval(
   };
 }
 
+function buildEditTextApproval(
+  input: Record<string, unknown>,
+  metadata: ToolPermissionMetadata,
+  workspaceRoot: string | undefined,
+): ToolApprovalMetadata {
+  const relPath = stringValue(input.path);
+  const edits = Array.isArray(input.edits) ? input.edits : [];
+  const first = isRecord(edits[0]) ? edits[0] : undefined;
+  const oldText = typeof first?.oldText === "string" ? first.oldText : "";
+  const newText = typeof first?.newText === "string" ? first.newText : "";
+  const diff = buildReplaceTextDiffPreview({
+    relPath,
+    find: oldText,
+    replace: newText,
+    expectedHash: undefined,
+    workspaceRoot,
+  });
+  const previewDetails = diff.message ? [diff.message] : [];
+
+  return {
+    title: "Edit workspace file (exact text)",
+    summary: metadata.summary,
+    riskCategories: metadata.categories,
+    target: relPath,
+    diffPreview: diff.preview,
+    details: [
+      pathDetail(relPath, workspaceRoot),
+      "Reads the current file from disk and applies ordered oldText/newText edits atomically.",
+      `Edit count: ${edits.length}.`,
+      "No expectedHash is required; the harness uses the live file snapshot.",
+      ...previewDetails,
+    ],
+  };
+}
+
+function buildReplaceTextApproval(
+  input: Record<string, unknown>,
+  metadata: ToolPermissionMetadata,
+  workspaceRoot: string | undefined,
+): ToolApprovalMetadata {
+  const relPath = stringValue(input.path);
+  const find = stringValue(input.find) ?? "";
+  const replace = stringValue(input.replace) ?? "";
+  const diff = buildReplaceTextDiffPreview({
+    relPath,
+    find,
+    replace,
+    expectedHash: stringValue(input.expectedHash),
+    workspaceRoot,
+  });
+  const previewDetails = diff.message ? [diff.message] : [];
+
+  return {
+    title: "Replace text in workspace file",
+    summary: metadata.summary,
+    riskCategories: metadata.categories,
+    target: relPath,
+    diffPreview: diff.preview,
+    details: [
+      pathDetail(relPath, workspaceRoot),
+      "Replaces one exact text span when expectedHash matches.",
+      `Find length: ${find.length} chars.`,
+      `Replace length: ${replace.length} chars.`,
+      `Replace all: ${booleanValue(input.replaceAll) ? "yes" : "no"}.`,
+      `Expected hash: ${stringValue(input.expectedHash) ?? "(missing)"}.`,
+      ...previewDetails,
+    ],
+  };
+}
+
+function buildMultiReplaceTextApproval(
+  input: Record<string, unknown>,
+  metadata: ToolPermissionMetadata,
+  workspaceRoot: string | undefined,
+): ToolApprovalMetadata {
+  const relPath = stringValue(input.path);
+  const replacements = Array.isArray(input.replacements) ? input.replacements : [];
+  const first = isRecord(replacements[0]) ? replacements[0] : undefined;
+  const find = typeof first?.find === "string" ? first.find : "";
+  const replace = typeof first?.replace === "string" ? first.replace : "";
+  const diff = buildReplaceTextDiffPreview({
+    relPath,
+    find,
+    replace,
+    expectedHash: stringValue(input.expectedHash),
+    workspaceRoot,
+  });
+  const previewDetails = diff.message ? [diff.message] : [];
+
+  return {
+    title: "Apply ordered replacements in workspace file",
+    summary: metadata.summary,
+    riskCategories: metadata.categories,
+    target: relPath,
+    diffPreview: diff.preview,
+    details: [
+      pathDetail(relPath, workspaceRoot),
+      "Applies ordered exact-text replacements atomically when expectedHash matches.",
+      `Replacement count: ${replacements.length}.`,
+      `Expected hash: ${stringValue(input.expectedHash) ?? "(missing)"}.`,
+      ...previewDetails,
+    ],
+  };
+}
+
+function buildReplaceLinesApproval(
+  input: Record<string, unknown>,
+  metadata: ToolPermissionMetadata,
+  workspaceRoot: string | undefined,
+): ToolApprovalMetadata {
+  const relPath = stringValue(input.path);
+  const edits = Array.isArray(input.edits) ? input.edits : [];
+  const diff = buildReplaceLinesDiffPreview({
+    relPath,
+    edits,
+    expectedHash: stringValue(input.expectedHash),
+    workspaceRoot,
+  });
+  const previewDetails = diff.message ? [diff.message] : [];
+
+  return {
+    title: "Replace line ranges in workspace file",
+    summary: metadata.summary,
+    riskCategories: metadata.categories,
+    target: relPath,
+    diffPreview: diff.preview,
+    details: [
+      pathDetail(relPath, workspaceRoot),
+      "Applies ordered, non-overlapping line-range replacements atomically when expectedHash matches.",
+      `Edit count: ${edits.length}.`,
+      `Expected hash: ${stringValue(input.expectedHash) ?? "(missing)"}.`,
+      ...previewDetails,
+    ],
+  };
+}
+
 function buildMcpToolApprovalMetadata(toolName: string): ToolApprovalMetadata {
   const [, serverName = "unknown", mcpToolName = toolName] = toolName.split("__");
   return {
@@ -972,6 +1136,121 @@ function buildEditFileDiffPreview(
       patch,
       relPath,
     });
+    if (Buffer.byteLength(next, "utf8") > DIFF_PREVIEW_BYTES) {
+      return {
+        message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,
+      };
+    }
+    return {
+      preview: {
+        path: relPath,
+        previous: current.content,
+        next,
+        truncated: false,
+      },
+    };
+  } catch (err) {
+    return { message: `Diff preview unavailable: ${errorMessage(err)}.` };
+  }
+}
+
+function buildReplaceTextDiffPreview({
+  relPath,
+  find,
+  replace,
+  expectedHash,
+  workspaceRoot,
+}: {
+  relPath: string | undefined;
+  find: string;
+  replace: string;
+  expectedHash: string | undefined;
+  workspaceRoot: string | undefined;
+}): {
+  preview?: ToolApprovalMetadata["diffPreview"];
+  message?: string;
+} {
+  if (!relPath) return { message: "Diff preview unavailable: path is missing." };
+  if (!find) return { message: "Diff preview unavailable: find text is missing." };
+  try {
+    const current = readPreviewTextSync(relPath, workspaceRoot);
+    if (!current.ok) return { message: current.message };
+    if (expectedHash && current.sha256 !== expectedHash) {
+      return {
+        message: `Diff preview unavailable because expectedHash does not match current file hash ${current.sha256}.`,
+      };
+    }
+    if (!current.content.includes(find)) {
+      return { message: "Diff preview unavailable: find text is not present in the file." };
+    }
+    const next = current.content.replace(find, replace);
+    if (Buffer.byteLength(next, "utf8") > DIFF_PREVIEW_BYTES) {
+      return {
+        message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,
+      };
+    }
+    return {
+      preview: {
+        path: relPath,
+        previous: current.content,
+        next,
+        truncated: false,
+      },
+    };
+  } catch (err) {
+    return { message: `Diff preview unavailable: ${errorMessage(err)}.` };
+  }
+}
+
+function buildReplaceLinesDiffPreview({
+  relPath,
+  edits,
+  expectedHash,
+  workspaceRoot,
+}: {
+  relPath: string | undefined;
+  edits: unknown[];
+  expectedHash: string | undefined;
+  workspaceRoot: string | undefined;
+}): {
+  preview?: ToolApprovalMetadata["diffPreview"];
+  message?: string;
+} {
+  if (!relPath) return { message: "Diff preview unavailable: path is missing." };
+  if (edits.length === 0) {
+    return { message: "Diff preview unavailable: no line edits provided." };
+  }
+  try {
+    const current = readPreviewTextSync(relPath, workspaceRoot);
+    if (!current.ok) return { message: current.message };
+    if (expectedHash && current.sha256 !== expectedHash) {
+      return {
+        message: `Diff preview unavailable because expectedHash does not match current file hash ${current.sha256}.`,
+      };
+    }
+    const normalized = edits.flatMap((edit, index) => {
+      if (!isRecord(edit)) return [];
+      const startLine = numberValue(edit.startLine);
+      const endLine = numberValue(edit.endLine);
+      const replacement = stringValue(edit.replacement);
+      if (startLine === undefined || endLine === undefined || replacement === undefined) {
+        return [];
+      }
+      return [{ startLine, endLine, replacement, index }];
+    });
+    if (normalized.length === 0) {
+      return { message: "Diff preview unavailable: line edits are invalid." };
+    }
+    const lines = current.content.split("\n");
+    const sorted = [...normalized].sort((left, right) => right.startLine - left.startLine);
+    for (const edit of sorted) {
+      lines.splice(
+        edit.startLine - 1,
+        edit.endLine - edit.startLine + 1,
+        ...edit.replacement.split("\n"),
+      );
+    }
+    const next = lines.join("\n");
     if (Buffer.byteLength(next, "utf8") > DIFF_PREVIEW_BYTES) {
       return {
         message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,

--- a/src/agent/profile-classifier.ts
+++ b/src/agent/profile-classifier.ts
@@ -1,0 +1,194 @@
+import type { AgentRunMode, AgentRunProfile } from "./loop";
+import type { AntonUIMessage } from "@/src/lib/trace";
+import { isRunDataPart } from "@/src/lib/trace";
+
+const BROAD_SCOPE_PATTERNS = [
+  /\bentire app\b/,
+  /\bwhole app\b/,
+  /\barchitecture\b/,
+  /\bmultiple modules\b/,
+  /\bacross modules\b/,
+  /\bmigration\b/,
+  /\bimplement roadmap\b/,
+  /\blarge refactor\b/,
+  /\bfull refactor\b/,
+  /\brefactor the entire\b/,
+  /\bimplement the plan\b/,
+  /\bapply plan\b/,
+  /\bapply the plan\b/,
+  /\bimplement plan\b/,
+] as const;
+
+const IMPLEMENTATION_PATTERNS = [
+  /\bimplement\b/,
+  /\bfix\b/,
+  /\badd\b/,
+  /\bwire\b/,
+  /\bhook up\b/,
+  /\bintegrate\b/,
+  /\bbuild\b/,
+  /\bcreate\b/,
+  /\benable\b/,
+  /\bsupport\b/,
+  /\bmake\b.+\bwork\b/,
+] as const;
+
+const LOCALIZED_SCOPE_PATTERNS = [
+  /\bminimal\b/,
+  /\bsmall\b/,
+  /\bsurgical\b/,
+  /\bone file\b/,
+  /\bsingle file\b/,
+  /\bcomponent\b/,
+  /\bpage\b/,
+  /\broute\b/,
+  /\bfunction\b/,
+  /\bmethod\b/,
+  /\bclass\b/,
+  /\bsearch bar\b/,
+  /\bsidebar\b/,
+  /\b[a-z0-9_-]+\.(?:ts|tsx|js|jsx|css|scss|md|json)\b/,
+] as const;
+
+const LOCALIZED_EDIT_TOOLS = [
+  "read_file",
+  "grep",
+  "glob",
+  "stat",
+  "edit_text",
+  "replace_text",
+  "replace_lines",
+  "multi_replace_text",
+  "edit_file",
+  "verify",
+  "git_status",
+] as const;
+
+export type LocalizedEditToolName = (typeof LOCALIZED_EDIT_TOOLS)[number];
+
+export function localizedEditToolNames(): readonly LocalizedEditToolName[] {
+  return LOCALIZED_EDIT_TOOLS;
+}
+
+export function isBroadScopeRequest(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return true;
+  return BROAD_SCOPE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isImplementationRequest(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return false;
+  return IMPLEMENTATION_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isLocalizedImplementationRequest(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized || !isImplementationRequest(normalized)) return false;
+  return LOCALIZED_SCOPE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isCommandRunRequest(latestText: string): boolean {
+  return (
+    /^(run|execute|rerun|use bash|use terminal)\b/.test(latestText) ||
+    /`(?:git|pnpm|npm|yarn|bun|cat|ls|rg|grep|find)\b[^`]*`/.test(latestText) ||
+    /\b(?:discard|revert|restore)\b.*\b(?:changes|repo|repository|working tree|workspace)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:clean|stash)\b.*\b(?:repo|repository|working tree|workspace)\b/.test(
+      latestText,
+    ) ||
+    /\bkeep\b.*\b(?:repo|repository|working tree|workspace)\b.*\bclean\b/.test(
+      latestText,
+    )
+  );
+}
+
+export function classifyAgentProfile(latestUserText: string): AgentRunProfile {
+  const normalized = latestUserText.trim().toLowerCase();
+  if (normalized === "implement plan") return "accepted-plan-simple";
+  if (
+    normalized === "implement the plan" ||
+    normalized === "apply plan" ||
+    normalized === "apply the plan"
+  ) {
+    return "accepted-plan-general";
+  }
+  if (isCommandRunRequest(normalized)) return "command-run";
+  if (isBroadScopeRequest(normalized)) return "general-chat";
+  if (isLocalizedImplementationRequest(normalized)) return "localized-edit";
+  if (isImplementationRequest(normalized)) return "general-chat";
+  return "localized-edit";
+}
+
+export function classifyRunProfile(
+  mode: AgentRunMode,
+  latestUserText: string,
+): AgentRunProfile {
+  if (mode === "chat") return "pure-chat";
+  if (mode === "ask") return "ask";
+  if (mode === "plan") return "plan";
+  return classifyAgentProfile(latestUserText);
+}
+
+export function executionProfileFromCostMetadata(
+  costMetadata: unknown,
+): AgentRunProfile | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const profile = execution?.profile;
+  return isAgentRunProfile(profile) ? profile : undefined;
+}
+
+export function effectiveProfileFromCostMetadata(
+  costMetadata: unknown,
+): AgentRunProfile | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const effectiveProfile = execution?.effectiveProfile;
+  return isAgentRunProfile(effectiveProfile) ? effectiveProfile : undefined;
+}
+
+export function executionModelFromCostMetadata(
+  costMetadata: unknown,
+): string | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const model = execution?.model;
+  return typeof model === "string" && model.length > 0 ? model : undefined;
+}
+
+export function runIdFromAssistantMessage(
+  message: AntonUIMessage | undefined,
+): string | undefined {
+  if (!message || message.role !== "assistant") return undefined;
+  if (typeof message.metadata?.runId === "string") {
+    return message.metadata.runId;
+  }
+  const runPart = message.parts.find(isRunDataPart);
+  return runPart?.data.runId;
+}
+
+function isAgentRunProfile(value: unknown): value is AgentRunProfile {
+  return (
+    value === "pure-chat" ||
+    value === "ask" ||
+    value === "plan" ||
+    value === "accepted-plan-simple" ||
+    value === "accepted-plan-general" ||
+    value === "command-run" ||
+    value === "general-chat" ||
+    value === "localized-edit" ||
+    value === "approval-continuation"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/profile-promotion.ts
+++ b/src/agent/profile-promotion.ts
@@ -1,0 +1,59 @@
+import type { AgentRunProfile } from "./loop";
+
+export type ProfilePromotionEvent = {
+  fromProfile: AgentRunProfile;
+  toProfile: AgentRunProfile;
+  reason: string;
+};
+
+export type PromotionTriggerInput = {
+  distinctPathsRead: number;
+  partialReadPaths: number;
+  failedEditPaths: number;
+  searchStepsBeforeEdit: number;
+  effectiveTokensUsed: number;
+  maxEffectiveTokens: number;
+  hadSuccessfulEdit: boolean;
+};
+
+export function evaluateFastEditPromotion(
+  profile: AgentRunProfile,
+  alreadyPromoted: boolean,
+  input: PromotionTriggerInput,
+): ProfilePromotionEvent | undefined {
+  if (profile !== "localized-edit" || alreadyPromoted) return undefined;
+  if (input.hadSuccessfulEdit) return undefined;
+
+  const reasons: string[] = [];
+
+  if (input.partialReadPaths > 1) {
+    reasons.push(
+      "Multiple target files required partial reads; continuing with full Agent tools avoids repeated range reads.",
+    );
+  }
+  if (input.distinctPathsRead > 3) {
+    reasons.push("Several files appear relevant to this task.");
+  }
+  if (input.failedEditPaths > 0) {
+    reasons.push("An edit attempt failed and needs broader recovery tools.");
+  }
+  if (input.searchStepsBeforeEdit >= 3) {
+    reasons.push("Multiple searches ran before a successful edit.");
+  }
+  if (
+    input.maxEffectiveTokens > 0 &&
+    input.effectiveTokensUsed >= Math.floor(input.maxEffectiveTokens * 0.75)
+  ) {
+    reasons.push(
+      "Half of the fast-edit effective budget was used without a successful edit.",
+    );
+  }
+
+  if (reasons.length === 0) return undefined;
+
+  return {
+    fromProfile: "localized-edit",
+    toProfile: "general-chat",
+    reason: reasons[0],
+  };
+}

--- a/src/agent/prompt-cache-audit.ts
+++ b/src/agent/prompt-cache-audit.ts
@@ -1,0 +1,260 @@
+import { createHash } from "node:crypto";
+import type { ModelMessage, ToolSet } from "ai";
+
+import type { TokenUsageMetrics } from "@/src/lib/token-usage";
+
+export type PromptCacheAudit = {
+  modelId: string;
+  providerId: string;
+  systemPromptHash: string;
+  toolSchemaHash: string;
+  nativeToolNamesHash: string;
+  mcpToolNamesHash: string;
+  workspaceContextHash: string;
+  messagePrefixHash: string;
+  cachedInputTokens?: number;
+  cacheWriteTokens?: number;
+  cacheHitRate?: number;
+  likelyCacheMissReasons: string[];
+  cacheBreakReasons: string[];
+};
+
+export function buildPromptCacheAudit({
+  modelId,
+  system,
+  tools,
+  nativeToolNames,
+  mcpToolNames,
+  activeToolNames,
+  workspaceContextText,
+  messages,
+  tokenUsage,
+  previousAudit,
+}: {
+  modelId: string;
+  system: string;
+  tools: ToolSet;
+  nativeToolNames: readonly string[];
+  mcpToolNames: readonly string[];
+  activeToolNames?: readonly string[];
+  workspaceContextText: string;
+  messages: ModelMessage[];
+  tokenUsage?: TokenUsageMetrics;
+  previousAudit?: PromptCacheAudit | null;
+}): PromptCacheAudit {
+  const cachedInputTokens = tokenUsage?.cachedInputTokens;
+  const cacheWriteTokens = tokenUsage?.cacheWriteTokens;
+  const rawInputTokens = tokenUsage?.rawInputTokens;
+  const cacheHitRate =
+    rawInputTokens !== undefined &&
+    rawInputTokens > 0 &&
+    cachedInputTokens !== undefined
+      ? cachedInputTokens / rawInputTokens
+      : undefined;
+
+  const likelyCacheMissReasons = likelyCacheMissReasonsFor({
+    cacheHitRate,
+    cacheWriteTokens,
+    workspaceContextText,
+    messageCount: messages.length,
+  });
+
+  const auditBase = {
+    modelId,
+    providerId: "openrouter",
+    systemPromptHash: hashText(system),
+    toolSchemaHash: hashText(stableJson(toolSchemas(tools, activeToolNames))),
+    nativeToolNamesHash: hashText((activeToolNames ?? nativeToolNames).join("\n")),
+    mcpToolNamesHash: hashText(mcpToolNames.join("\n")),
+    workspaceContextHash: hashText(workspaceContextText),
+    messagePrefixHash: hashText(stableJson(messagePrefix(messages))),
+  };
+
+  const cacheBreakReasons = comparePromptCacheAudit(previousAudit ?? undefined, auditBase);
+
+  return {
+    ...auditBase,
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
+    ...(cacheHitRate !== undefined ? { cacheHitRate } : {}),
+    likelyCacheMissReasons,
+    cacheBreakReasons,
+  };
+}
+
+export function comparePromptCacheAudit(
+  previous: Pick<
+    PromptCacheAudit,
+    | "modelId"
+    | "providerId"
+    | "systemPromptHash"
+    | "toolSchemaHash"
+    | "nativeToolNamesHash"
+    | "mcpToolNamesHash"
+    | "workspaceContextHash"
+    | "messagePrefixHash"
+  > | undefined,
+  current: Pick<
+    PromptCacheAudit,
+    | "modelId"
+    | "providerId"
+    | "systemPromptHash"
+    | "toolSchemaHash"
+    | "nativeToolNamesHash"
+    | "mcpToolNamesHash"
+    | "workspaceContextHash"
+    | "messagePrefixHash"
+  >,
+): string[] {
+  if (!previous) return [];
+  const reasons: string[] = [];
+  if (previous.modelId !== current.modelId) {
+    reasons.push("model id changed from the previous run in this session");
+  }
+  if (previous.providerId !== current.providerId) {
+    reasons.push("provider id changed from the previous run in this session");
+  }
+  if (previous.systemPromptHash !== current.systemPromptHash) {
+    reasons.push("system prompt hash changed");
+  }
+  if (previous.toolSchemaHash !== current.toolSchemaHash) {
+    reasons.push("tool schema hash changed");
+  }
+  if (previous.nativeToolNamesHash !== current.nativeToolNamesHash) {
+    reasons.push("native tool set hash changed");
+  }
+  if (previous.mcpToolNamesHash !== current.mcpToolNamesHash) {
+    reasons.push("MCP tool set hash changed");
+  }
+  if (previous.workspaceContextHash !== current.workspaceContextHash) {
+    reasons.push("workspace/session context hash changed");
+  }
+  if (previous.messagePrefixHash !== current.messagePrefixHash) {
+    reasons.push("message prefix hash changed");
+  }
+  return reasons;
+}
+
+export function promptCacheAuditFromCostMetadata(
+  costMetadata: unknown,
+): PromptCacheAudit | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const tokenAudit = isRecord(costMetadata.tokenAudit)
+    ? costMetadata.tokenAudit
+    : undefined;
+  const promptCache = tokenAudit && isRecord(tokenAudit.promptCache)
+    ? tokenAudit.promptCache
+    : undefined;
+  if (!promptCache) return undefined;
+  const modelId = stringValue(promptCache.modelId);
+  const providerId = stringValue(promptCache.providerId);
+  if (!modelId || !providerId) return undefined;
+  return {
+    modelId,
+    providerId,
+    systemPromptHash: stringValue(promptCache.systemPromptHash) ?? "—",
+    toolSchemaHash: stringValue(promptCache.toolSchemaHash) ?? "—",
+    nativeToolNamesHash: stringValue(promptCache.nativeToolNamesHash) ?? "—",
+    mcpToolNamesHash: stringValue(promptCache.mcpToolNamesHash) ?? "—",
+    workspaceContextHash: stringValue(promptCache.workspaceContextHash) ?? "—",
+    messagePrefixHash: stringValue(promptCache.messagePrefixHash) ?? "—",
+    likelyCacheMissReasons: stringArray(promptCache.likelyCacheMissReasons),
+    cacheBreakReasons: stringArray(promptCache.cacheBreakReasons),
+    ...(finiteNumber(promptCache.cachedInputTokens) !== undefined
+      ? { cachedInputTokens: finiteNumber(promptCache.cachedInputTokens) }
+      : {}),
+    ...(finiteNumber(promptCache.cacheWriteTokens) !== undefined
+      ? { cacheWriteTokens: finiteNumber(promptCache.cacheWriteTokens) }
+      : {}),
+    ...(finiteNumber(promptCache.cacheHitRate) !== undefined
+      ? { cacheHitRate: finiteNumber(promptCache.cacheHitRate) }
+      : {}),
+  };
+}
+
+function likelyCacheMissReasonsFor(input: {
+  cacheHitRate: number | undefined;
+  cacheWriteTokens: number | undefined;
+  workspaceContextText: string;
+  messageCount: number;
+}): string[] {
+  const reasons: string[] = [];
+  if (input.cacheWriteTokens !== undefined && input.cacheWriteTokens > 0) {
+    reasons.push("provider reported cache write tokens on this run");
+  }
+  if (input.workspaceContextText.trim().length > 0) {
+    reasons.push("dynamic workspace/session context precedes the latest user turn");
+  }
+  if (input.messageCount > 4) {
+    reasons.push("conversation prefix grew beyond the initial stable prompt block");
+  }
+  if (input.cacheHitRate !== undefined && input.cacheHitRate < 0.2) {
+    reasons.push("low cache hit rate for provider-reported input tokens");
+  }
+  return reasons;
+}
+
+function toolSchemas(
+  tools: ToolSet,
+  activeToolNames: readonly string[] | undefined,
+): unknown {
+  const activeSet = activeToolNames ? new Set(activeToolNames) : undefined;
+  return Object.fromEntries(
+    Object.keys(tools)
+      .filter((name) => !activeSet || activeSet.has(name))
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => {
+        const toolValue = tools[name];
+        return [
+          name,
+          {
+            description:
+              typeof toolValue === "object" &&
+              toolValue !== null &&
+              "description" in toolValue
+                ? toolValue.description
+                : undefined,
+            inputSchema:
+              typeof toolValue === "object" &&
+              toolValue !== null &&
+              "inputSchema" in toolValue
+                ? toolValue.inputSchema
+                : undefined,
+          },
+        ];
+      }),
+  );
+}
+
+function messagePrefix(messages: ModelMessage[]): unknown {
+  const latestUserIndex = messages.findLastIndex(
+    (message) => message.role === "user",
+  );
+  if (latestUserIndex <= 0) return messages.slice(0, 1);
+  return messages.slice(0, latestUserIndex);
+}
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => (typeof item === "string" ? [item] : []));
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/run-budget.ts
+++ b/src/agent/run-budget.ts
@@ -1,11 +1,15 @@
 import {
   stepCountIs,
+  type LanguageModelUsage,
   type ProviderMetadata,
   type StopCondition,
   type ToolSet,
 } from "ai";
 
-import { openRouterCostFromMetadata } from "@/src/lib/token-usage";
+import {
+  buildTokenUsageMetrics,
+  openRouterCostFromMetadata,
+} from "@/src/lib/token-usage";
 import type { AgentRunProfile } from "./loop";
 
 export type RunBudget = {
@@ -15,6 +19,9 @@ export type RunBudget = {
   maxInputTokens: number;
   maxInputBytes: number;
   maxTotalTokens: number;
+  maxEffectiveTokens: number;
+  maxRawInputTokensPerStep: number;
+  rawTokenSanityCap: number;
   maxCostUsd: number;
   priorRunContextChars: number;
   workspaceContextChars: number;
@@ -87,6 +94,15 @@ const RUN_BUDGETS = {
     priorRunContextChars: 6_000,
     workspaceContextChars: 6_000,
   },
+  "localized-edit": {
+    maxSteps: 8,
+    maxOutputTokens: 2_048,
+    maxInputTokens: 24_000,
+    maxTotalTokens: 40_000,
+    maxCostUsd: 0.05,
+    priorRunContextChars: 1_500,
+    workspaceContextChars: 1_500,
+  },
   "approval-continuation": {
     maxSteps: 32,
     maxOutputTokens: 8_192,
@@ -98,8 +114,39 @@ const RUN_BUDGETS = {
   },
 } as const satisfies Record<
   AgentRunProfile,
-  Omit<RunBudget, "profile" | "maxInputBytes" | "latestUserMaxBytes">
+  Omit<
+    RunBudget,
+    | "profile"
+    | "maxInputBytes"
+    | "latestUserMaxBytes"
+    | "maxEffectiveTokens"
+    | "maxRawInputTokensPerStep"
+    | "rawTokenSanityCap"
+  >
 >;
+
+const DEFAULT_EFFECTIVE_RATIO = 0.55;
+const DEFAULT_RAW_INPUT_PER_STEP_RATIO = 1;
+const DEFAULT_RAW_SANITY_MULTIPLIER = 4;
+
+export const THINKING_BUDGET_MULTIPLIER = 1.75;
+
+export function applyThinkingBudgetAdjustment(
+  budget: RunBudget,
+  thinkingEnabled: boolean,
+): RunBudget {
+  if (!thinkingEnabled) return budget;
+  return {
+    ...budget,
+    maxEffectiveTokens: Math.round(
+      budget.maxEffectiveTokens * THINKING_BUDGET_MULTIPLIER,
+    ),
+    rawTokenSanityCap: Math.round(
+      budget.rawTokenSanityCap * THINKING_BUDGET_MULTIPLIER,
+    ),
+    maxCostUsd: budget.maxCostUsd * THINKING_BUDGET_MULTIPLIER,
+  };
+}
 
 export function budgetForProfile(profile: AgentRunProfile): RunBudget {
   const budget = RUN_BUDGETS[profile];
@@ -107,6 +154,13 @@ export function budgetForProfile(profile: AgentRunProfile): RunBudget {
   return {
     profile,
     ...budget,
+    maxEffectiveTokens: Math.round(
+      budget.maxTotalTokens * DEFAULT_EFFECTIVE_RATIO,
+    ),
+    maxRawInputTokensPerStep: Math.round(
+      budget.maxInputTokens * DEFAULT_RAW_INPUT_PER_STEP_RATIO,
+    ),
+    rawTokenSanityCap: budget.maxTotalTokens * DEFAULT_RAW_SANITY_MULTIPLIER,
     maxInputBytes,
     latestUserMaxBytes: Math.floor(maxInputBytes * 0.8),
   };
@@ -131,30 +185,55 @@ export function applyTokenBudgetMultiplier(
   return {
     ...budget,
     maxTotalTokens: budget.maxTotalTokens * scale,
+    maxEffectiveTokens: budget.maxEffectiveTokens * scale,
+    rawTokenSanityCap: budget.rawTokenSanityCap * scale,
     maxCostUsd: budget.maxCostUsd * scale,
   };
 }
 
-export const TOKEN_BUDGET_MULTIPLIER_OPTIONS = [2, 3, 5] as const;
+export const TOKEN_BUDGET_MULTIPLIER_OPTIONS = [2, 3] as const;
 
 export type TokenBudgetMultiplierOption =
   (typeof TOKEN_BUDGET_MULTIPLIER_OPTIONS)[number];
 
 export function availableTokenBudgetMultipliers(
   currentMultiplier: number,
+  profile?: AgentRunProfile,
 ): TokenBudgetMultiplierOption[] {
-  return TOKEN_BUDGET_MULTIPLIER_OPTIONS.filter(
-    (option) => option > currentMultiplier,
-  );
+  const allowed =
+    profile === "localized-edit"
+      ? ([2] as const)
+      : profile === "general-chat" || profile === "approval-continuation"
+        ? ([2, 3] as const)
+        : TOKEN_BUDGET_MULTIPLIER_OPTIONS;
+  return allowed.filter((option) => option > currentMultiplier);
 }
 
+export function effectiveTokenBudgetStopCondition(
+  maxEffectiveTokens: number,
+  priorEffectiveTokens = 0,
+): StopCondition<ToolSet> {
+  return ({ steps }) => {
+    const segmentEffective = totalStepEffectiveTokens(steps);
+    return priorEffectiveTokens + segmentEffective >= maxEffectiveTokens;
+  };
+}
+
+export function rawTokenSanityStopCondition(
+  rawTokenSanityCap: number,
+  priorRawTokens = 0,
+): StopCondition<ToolSet> {
+  return ({ steps }) => {
+    return priorRawTokens + totalStepTokens(steps) >= rawTokenSanityCap;
+  };
+}
+
+/** @deprecated Prefer effectiveTokenBudgetStopCondition for hard stops. */
 export function tokenBudgetStopCondition(
   maxTotalTokens: number,
   priorTokensUsed = 0,
 ): StopCondition<ToolSet> {
-  return ({ steps }) => {
-    return priorTokensUsed + totalStepTokens(steps) >= maxTotalTokens;
-  };
+  return effectiveTokenBudgetStopCondition(maxTotalTokens, priorTokensUsed);
 }
 
 export function costBudgetStopCondition(
@@ -177,6 +256,40 @@ export function remainingStepsStopCondition(
   return stepCountIs(remaining);
 }
 
+export function mutableEffectiveTokenBudgetStopCondition(
+  readMaxEffectiveTokens: () => number,
+  priorEffectiveTokens = 0,
+): StopCondition<ToolSet> {
+  return ({ steps }) =>
+    priorEffectiveTokens + totalStepEffectiveTokens(steps) >= readMaxEffectiveTokens();
+}
+
+export function mutableStepBudgetStopCondition(
+  readMaxSteps: () => number,
+): StopCondition<ToolSet> {
+  return ({ steps }) => steps.length >= readMaxSteps();
+}
+
+export function mutableRawTokenSanityStopCondition(
+  readRawTokenSanityCap: () => number,
+  priorRawTokens = 0,
+): StopCondition<ToolSet> {
+  return ({ steps }) =>
+    priorRawTokens + totalStepTokens(steps) >= readRawTokenSanityCap();
+}
+
+export function mutableCostBudgetStopCondition(
+  readMaxCostUsd: () => number,
+  priorCostUsd = 0,
+): StopCondition<ToolSet> {
+  return ({ steps }) => {
+    const segmentCost = totalStepCostUsd(steps);
+    return (
+      segmentCost !== undefined && priorCostUsd + segmentCost >= readMaxCostUsd()
+    );
+  };
+}
+
 function totalStepCostUsd(
   steps: readonly { providerMetadata?: ProviderMetadata }[],
 ): number | undefined {
@@ -187,9 +300,36 @@ function totalStepCostUsd(
 }
 
 function totalStepTokens(
-  steps: readonly { usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number } }[],
+  steps: readonly {
+    usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number };
+    providerMetadata?: ProviderMetadata;
+  }[],
 ): number {
   return steps.reduce((sum, step) => {
+    const total = finiteNumber(step.usage?.totalTokens);
+    if (total !== undefined) return sum + total;
+    return (
+      sum +
+      (finiteNumber(step.usage?.inputTokens) ?? 0) +
+      (finiteNumber(step.usage?.outputTokens) ?? 0)
+    );
+  }, 0);
+}
+
+function totalStepEffectiveTokens(
+  steps: readonly {
+    usage?: LanguageModelUsage;
+    providerMetadata?: ProviderMetadata;
+  }[],
+): number {
+  return steps.reduce((sum, step) => {
+    const metrics = buildTokenUsageMetrics({
+      usage: step.usage,
+      providerMetadata: step.providerMetadata,
+    });
+    if (metrics?.effectiveTokens !== undefined) {
+      return sum + metrics.effectiveTokens;
+    }
     const total = finiteNumber(step.usage?.totalTokens);
     if (total !== undefined) return sum + total;
     return (

--- a/src/agent/tool-policy.ts
+++ b/src/agent/tool-policy.ts
@@ -1,0 +1,1079 @@
+import type { AgentRunProfile } from "./loop";
+import {
+  evaluateFastEditPromotion,
+  type ProfilePromotionEvent,
+  type PromotionTriggerInput,
+} from "./profile-promotion";
+import { localizedEditToolNames } from "./profile-classifier";
+import { readFileOutputIsFullCoverage, extractVerifyFailureSummary } from "./tools/model-output";
+
+export type ToolPolicyPhase =
+  | "explore"
+  | "recoverEdit"
+  | "postEdit"
+  | "verify"
+  | "final";
+
+export type LoopGuardBlockedOutput = {
+  ok: false;
+  code: "LOOP_GUARD_BLOCKED";
+  message: string;
+  phase?: ToolPolicyPhase;
+  failureCode?: string;
+  affectedPath?: string;
+  recommendedNext?:
+    | "verify"
+    | "edit_text"
+    | "replace_text"
+    | "replace_lines"
+    | "read_file"
+    | "final";
+};
+
+export type PriorToolCallRecord = {
+  toolName: string;
+  input: unknown;
+  output: unknown;
+  success: boolean;
+};
+
+export type ToolPolicySeed = {
+  phase?: ToolPolicyPhase;
+  readCountsByPath?: Record<string, number>;
+  readCountsByPathRange?: Record<string, number>;
+  lastHashByPath?: Record<string, string>;
+  lastSuccessfulEdit?: { path: string; nextHash: string };
+  failedEditsByPath?: Record<string, number>;
+  multiReplaceBlockedKeys?: string[];
+  recoveryReadUsedByPath?: string[];
+  verifyCompleted?: boolean;
+  verifyFixPending?: boolean;
+  lastVerifyFailureSummary?: string;
+  editedPaths?: string[];
+  promoted?: boolean;
+};
+
+const STATE_CHANGING_TOOLS = new Set([
+  "edit_file",
+  "edit_text",
+  "replace_text",
+  "replace_lines",
+  "multi_replace_text",
+  "write_file",
+]);
+
+const MAP_CAP = 128;
+
+const EXPLORATION_ONLY_TOOLS = new Set(["grep", "glob"]);
+
+const LOCALIZED_EDIT_TOOL_SET = new Set<string>(localizedEditToolNames());
+
+const EXPLORATION_BEFORE_VERIFY = new Set([
+  "grep",
+  "glob",
+  "inspect_project",
+  "delegate_task",
+  "remember_memory",
+  "forget_memory",
+  "list_memory",
+  "read_dir",
+]);
+
+const PROFILES_REQUIRING_VERIFY: ReadonlySet<AgentRunProfile> = new Set([
+  "localized-edit",
+  "general-chat",
+  "accepted-plan-simple",
+  "accepted-plan-general",
+  "approval-continuation",
+]);
+
+const PROFILES_PREFER_EDIT_TEXT: ReadonlySet<AgentRunProfile> = new Set([
+  "localized-edit",
+  "general-chat",
+  "accepted-plan-simple",
+  "accepted-plan-general",
+  "approval-continuation",
+]);
+
+export class ToolPolicyEngine {
+  private phase: ToolPolicyPhase = "explore";
+  private readCountsByPath = new Map<string, number>();
+  private readCountsByPathRange = new Map<string, number>();
+  private searchCounts = new Map<string, number>();
+  private failedEditsByPath = new Map<string, number>();
+  private semanticToolCounts = new Map<string, number>();
+  private pendingSemanticKeys = new Set<string>();
+  private lastHashByPath = new Map<string, string>();
+  private lastReadHashByRange = new Map<string, string>();
+  private lastSuccessfulEdit: { path: string; nextHash: string } | undefined;
+  private multiReplaceBlockedKeys = new Set<string>();
+  private recoveryReadAllowedByPath = new Set<string>();
+  private recoveryReadUsedByPath = new Set<string>();
+  private lastFailedEditCodeByPath = new Map<string, string>();
+  private fullCoveragePaths = new Set<string>();
+  private partialReadPaths = new Set<string>();
+  private distinctPathsRead = new Set<string>();
+  private editFileBlockedPaths = new Set<string>();
+  private searchStepsBeforeEdit = 0;
+  private promoted = false;
+  private promotionEvent: ProfilePromotionEvent | undefined;
+  private blockedAttemptCount = 0;
+  private guardCount = 0;
+  private stepsWithoutStateChange = 0;
+  private stateChangingToolCount = 0;
+  private forceFinalReason: string | undefined;
+  private processedStepCount = 0;
+  private hadStateChangingSuccess = false;
+  private emittedGuardReasons = new Set<string>();
+  private verifyCompleted = false;
+  private verifyNudgeCount = 0;
+  private verifyFixPending = false;
+  private verifyFixNoteCount = 0;
+  private lastVerifyFailureSummary: string | undefined;
+  private editedPaths = new Set<string>();
+  private pendingStaleReadNote: string | undefined;
+  private editTextFailedPaths = new Set<string>();
+  private readonly requireVerifyAfterEdit: boolean;
+
+  constructor(private readonly profile: AgentRunProfile) {
+    this.requireVerifyAfterEdit = PROFILES_REQUIRING_VERIFY.has(profile);
+  }
+
+  get loopGuardCount(): number {
+    return this.guardCount;
+  }
+
+  get currentPhase(): ToolPolicyPhase {
+    return this.phase;
+  }
+
+  get promotionReason(): string | undefined {
+    return this.promotionEvent?.reason;
+  }
+
+  get wasPromoted(): boolean {
+    return this.promoted;
+  }
+
+  get endedWithoutStateChange(): boolean {
+    return (
+      this.hadStateChangingSuccess === false &&
+      (this.forceFinalReason !== undefined || this.blockedAttemptCount >= 3)
+    );
+  }
+
+  get endedUnverified(): boolean {
+    return (
+      this.requireVerifyAfterEdit &&
+      this.hadStateChangingSuccess &&
+      !this.verifyCompleted &&
+      !this.verifyFixPending
+    );
+  }
+
+  get endedWithFailedVerification(): boolean {
+    return (
+      this.requireVerifyAfterEdit &&
+      this.hadStateChangingSuccess &&
+      this.verifyFixPending
+    );
+  }
+
+  get needsVerify(): boolean {
+    return (
+      this.requireVerifyAfterEdit &&
+      this.hadStateChangingSuccess &&
+      !this.verifyCompleted
+    );
+  }
+
+  consumeVerifyReminder(): string | undefined {
+    if (!this.needsVerify || this.verifyNudgeCount >= 3) return undefined;
+    if (this.verifyFixPending && this.lastVerifyFailureSummary) return undefined;
+    this.verifyNudgeCount += 1;
+    return [
+      "Verification required:",
+      "At least one file edit succeeded in this run.",
+      "Run the verify tool once before writing the final answer.",
+      "Use edit_text for fixups; avoid re-reading whole files unless a targeted range is needed.",
+    ].join(" ");
+  }
+
+  consumeStaleReadNote(): string | undefined {
+    const note = this.pendingStaleReadNote;
+    this.pendingStaleReadNote = undefined;
+    return note;
+  }
+
+  consumeVerifyFixNote(): string | undefined {
+    if (!this.verifyFixPending || !this.lastVerifyFailureSummary) return undefined;
+    if (this.verifyFixNoteCount >= 3) return undefined;
+    this.verifyFixNoteCount += 1;
+    const paths = [...this.editedPaths];
+    const pathHint =
+      paths.length > 0
+        ? ` Fix the edited file(s): ${paths.map((p) => `\`${p}\``).join(", ")}.`
+        : "";
+    return [
+      "Verification failed:",
+      this.lastVerifyFailureSummary,
+      pathHint,
+      "Use edit_text with a small fix at the reported line, then run verify again.",
+      "Do not use bash, grep, or glob until the syntax/lint error is fixed.",
+    ].join(" ");
+  }
+
+  needsVerifyFix(): boolean {
+    return (
+      this.requireVerifyAfterEdit &&
+      this.hadStateChangingSuccess &&
+      this.verifyFixPending
+    );
+  }
+
+  seed(input: ToolPolicySeed | undefined): void {
+    if (!input) return;
+    if (input.phase) this.phase = input.phase;
+    if (input.verifyCompleted === true) {
+      this.verifyCompleted = true;
+      if (this.phase === "postEdit") this.phase = "final";
+    }
+    if (input.promoted === true) {
+      this.promoted = true;
+    }
+    if (input.lastSuccessfulEdit) {
+      this.lastSuccessfulEdit = input.lastSuccessfulEdit;
+      this.phase = "postEdit";
+    }
+    for (const [path, count] of Object.entries(input.readCountsByPath ?? {})) {
+      this.readCountsByPath.set(path, count);
+    }
+    for (const [key, count] of Object.entries(input.readCountsByPathRange ?? {})) {
+      this.readCountsByPathRange.set(key, count);
+    }
+    for (const [path, hash] of Object.entries(input.lastHashByPath ?? {})) {
+      this.lastHashByPath.set(path, hash);
+    }
+    for (const [path, count] of Object.entries(input.failedEditsByPath ?? {})) {
+      this.failedEditsByPath.set(path, count);
+      if (count >= 2) {
+        this.phase = "recoverEdit";
+        this.recoveryReadAllowedByPath.add(path);
+      }
+    }
+    for (const key of input.multiReplaceBlockedKeys ?? []) {
+      this.multiReplaceBlockedKeys.add(key);
+    }
+    for (const path of input.recoveryReadUsedByPath ?? []) {
+      this.recoveryReadUsedByPath.add(path);
+    }
+    if (input.verifyFixPending === true) {
+      this.verifyFixPending = true;
+      if (input.lastVerifyFailureSummary) {
+        this.lastVerifyFailureSummary = input.lastVerifyFailureSummary;
+      }
+    }
+    for (const path of input.editedPaths ?? []) {
+      this.editedPaths.add(path);
+    }
+  }
+
+  seedFromPriorToolHistory(records: readonly PriorToolCallRecord[]): void {
+    for (const record of records) {
+      this.observeToolCall(record.toolName, record.input);
+      this.observeToolResult(record.toolName, record.input, record.output, record.success);
+    }
+  }
+
+  observeSteps(
+    steps: readonly {
+      toolCalls?: readonly { toolName: string; input: unknown }[];
+      toolResults?: readonly { toolName: string; output: unknown }[];
+    }[],
+  ): void {
+    for (let index = this.processedStepCount; index < steps.length; index += 1) {
+      this.observeStep(steps[index]);
+    }
+    this.processedStepCount = steps.length;
+  }
+
+  checkPromotion(
+    effectiveTokensUsed: number,
+    maxEffectiveTokens: number,
+  ): ProfilePromotionEvent | undefined {
+    if (this.promoted || this.promotionEvent) return this.promotionEvent;
+    const event = evaluateFastEditPromotion(this.profile, this.promoted, {
+      distinctPathsRead: this.distinctPathsRead.size,
+      partialReadPaths: this.partialReadPaths.size,
+      failedEditPaths: this.failedEditsByPath.size,
+      searchStepsBeforeEdit: this.searchStepsBeforeEdit,
+      effectiveTokensUsed,
+      maxEffectiveTokens,
+      hadSuccessfulEdit: this.hadStateChangingSuccess,
+    });
+    if (event) this.promotionEvent = event;
+    return event;
+  }
+
+  markPromoted(): ProfilePromotionEvent | undefined {
+    this.promoted = true;
+    return this.promotionEvent;
+  }
+
+  promotionTriggerInput(
+    effectiveTokensUsed: number,
+    maxEffectiveTokens: number,
+  ): PromotionTriggerInput {
+    return {
+      distinctPathsRead: this.distinctPathsRead.size,
+      partialReadPaths: this.partialReadPaths.size,
+      failedEditPaths: this.failedEditsByPath.size,
+      searchStepsBeforeEdit: this.searchStepsBeforeEdit,
+      effectiveTokensUsed,
+      maxEffectiveTokens,
+      hadSuccessfulEdit: this.hadStateChangingSuccess,
+    };
+  }
+
+  checkBeforeExecute(
+    toolName: string,
+    input: unknown,
+  ): LoopGuardBlockedOutput | undefined {
+    if (this.forceFinalReason) {
+      return blockedOutput(this.forceFinalReason, "final", {
+        phase: this.phase,
+      });
+    }
+
+    const semanticKey = `${toolName}:${stableJson(input)}`;
+    if (
+      this.pendingSemanticKeys.has(semanticKey) ||
+      (this.semanticToolCounts.get(semanticKey) ?? 0) >= 1
+    ) {
+      this.recordBlockedAttempt();
+      return blockedOutput(
+        `The same \`${toolName}\` call repeated with identical input. Use the latest result instead of calling it again.`,
+        recommendedForTool(toolName),
+        { phase: this.phase, affectedPath: pathFromInput(input) },
+      );
+    }
+
+    if (
+      this.profile === "localized-edit" &&
+      !this.promoted &&
+      !LOCALIZED_EDIT_TOOL_SET.has(toolName)
+    ) {
+      this.recordBlockedAttempt();
+      return blockedOutput(
+        `Tool \`${toolName}\` is unavailable in fast-edit mode. Continue with edit, read, verify, or search tools until the harness promotes to full Agent.`,
+        "edit_text",
+        { phase: this.phase },
+      );
+    }
+
+    if (this.needsVerify && EXPLORATION_BEFORE_VERIFY.has(toolName)) {
+      this.recordBlockedAttempt();
+      const message = this.verifyFixPending
+        ? "Broad exploration is blocked while verification is failing. Fix the reported error with edit_text, then run verify again."
+        : "Broad exploration is blocked until verify runs after the latest edits. Run verify or make a targeted fixup edit first.";
+      return blockedOutput(message, this.verifyFixPending ? "edit_text" : "verify", {
+        phase: this.phase,
+      });
+    }
+
+    if (this.needsVerifyFix()) {
+      if (
+        toolName === "bash" ||
+        toolName === "grep" ||
+        toolName === "glob" ||
+        toolName === "inspect_project" ||
+        toolName === "delegate_task"
+      ) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          "Verification failed on the last edit. Fix the reported syntax/lint error with edit_text, then run verify again.",
+          "edit_text",
+          { phase: this.phase },
+        );
+      }
+    }
+
+    if (toolName === "read_file") {
+      const path = pathFromInput(input);
+      const readKey = path ? readFileRangeKey(input, path) : undefined;
+      const currentHash = path ? this.lastHashByPath.get(path) : undefined;
+
+      if (
+        path &&
+        readKey &&
+        currentHash &&
+        this.lastReadHashByRange.get(readKey) === currentHash &&
+        !this.recoveryReadAllowedByPath.has(path)
+      ) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `read_file for \`${path}\` at this range already returned content for hash ${currentHash.slice(0, 8)}…. Edit, verify, or read a different range instead of repeating the same read.`,
+          "edit_text",
+          {
+            phase: this.phase,
+            affectedPath: path,
+          },
+        );
+      }
+
+      if (
+        path &&
+        this.phase === "explore" &&
+        !this.hadStateChangingSuccess &&
+        this.fullCoveragePaths.has(path) &&
+        isFullFileReadInput(input) &&
+        !this.recoveryReadAllowedByPath.has(path)
+      ) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `Full file content for \`${path}\` is already available from a prior read. Edit or verify instead of re-reading the whole file.`,
+          "edit_text",
+          {
+            phase: this.phase,
+            affectedPath: path,
+          },
+        );
+      }
+
+      if (path && readKey) {
+        const rangeReads = (this.readCountsByPathRange.get(readKey) ?? 0) + 1;
+        if (
+          this.profile === "localized-edit" &&
+          !this.promoted &&
+          this.phase === "explore" &&
+          !this.hadStateChangingSuccess &&
+          rangeReads > 2 &&
+          !this.recoveryReadAllowedByPath.has(path)
+        ) {
+          this.recordBlockedAttempt();
+          return blockedOutput(
+            `Repeated reads of \`${path}\` at the same range are blocked before the first edit. Use the latest read_file result or switch to an edit tool.`,
+            "edit_text",
+            {
+              phase: this.phase,
+              affectedPath: path,
+            },
+          );
+        }
+      }
+    }
+
+    if (
+      (toolName === "grep" || toolName === "glob") &&
+      this.phase === "final"
+    ) {
+      this.recordBlockedAttempt();
+      return blockedOutput(
+        "Broad search is blocked after verification succeeded. Finish the answer.",
+        "final",
+        { phase: this.phase },
+      );
+    }
+
+    if (toolName === "edit_file") {
+      const path = pathFromInput(input);
+      if (
+        path &&
+        PROFILES_PREFER_EDIT_TEXT.has(this.profile) &&
+        !this.editTextFailedPaths.has(path) &&
+        !this.editFileBlockedPaths.has(path)
+      ) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `Use edit_text for surgical changes on \`${path}\`. edit_file is reserved for large structural unified-diff rewrites after edit_text fails.`,
+          "edit_text",
+          {
+            phase: this.phase,
+            affectedPath: path,
+          },
+        );
+      }
+      if (path && this.editFileBlockedPaths.has(path)) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `edit_file already failed on \`${path}\`. Switch to edit_text, replace_lines, or replace_text.`,
+          "edit_text",
+          {
+            phase: this.phase,
+            affectedPath: path,
+          },
+        );
+      }
+    }
+
+    if (toolName === "multi_replace_text") {
+      const path = pathFromInput(input);
+      const hash = hashFromInput(input);
+      const blockKey = path && hash ? `${path}:${hash}` : undefined;
+      if (blockKey && this.multiReplaceBlockedKeys.has(blockKey)) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `multi_replace_text already failed on \`${path}\` with the current hash. Re-read a targeted range or switch to replace_text/replace_lines.`,
+          "replace_lines",
+          {
+            phase: this.phase,
+            affectedPath: path,
+            failureCode: "FIND_NOT_FOUND",
+          },
+        );
+      }
+    }
+
+    if (
+      this.profile === "localized-edit" &&
+      !this.promoted &&
+      this.phase === "explore" &&
+      this.stepsWithoutStateChange >= 8 &&
+      this.stateChangingToolCount === 0 &&
+      !STATE_CHANGING_TOOLS.has(toolName)
+    ) {
+      this.forceFinalReason =
+        "Fast-edit exploration exceeded its step budget without a successful edit. Explain what is blocking progress or wait for profile promotion.";
+      this.recordGuard();
+      return blockedOutput(this.forceFinalReason, "replace_lines", {
+        phase: this.phase,
+      });
+    }
+
+    return undefined;
+  }
+
+  shouldForceFinal(): string | undefined {
+    if (this.forceFinalReason) return this.forceFinalReason;
+    if (this.blockedAttemptCount >= 3) {
+      return "Repeated loop-guard blocks exhausted recovery attempts. Write the final answer with the latest tool results.";
+    }
+    return undefined;
+  }
+
+  recordPendingToolCall(toolName: string, input: unknown): void {
+    const semanticKey = `${toolName}:${stableJson(input)}`;
+    this.pendingSemanticKeys.add(semanticKey);
+  }
+
+  shouldEmitLoopGuardEvent(reason: string): boolean {
+    if (this.emittedGuardReasons.has(reason)) return false;
+    this.emittedGuardReasons.add(reason);
+    return true;
+  }
+
+  loopGuardEventDetails(
+    toolName: string,
+    input: unknown,
+    blocked: LoopGuardBlockedOutput,
+  ): Record<string, unknown> {
+    return {
+      reason: blocked.message,
+      blockedTools: [toolName],
+      phase: blocked.phase ?? this.phase,
+      ...(blocked.affectedPath ? { affectedPath: blocked.affectedPath } : {}),
+      ...(blocked.failureCode ? { failureCode: blocked.failureCode } : {}),
+      ...(blocked.recommendedNext
+        ? { recommendedNext: blocked.recommendedNext }
+        : {}),
+      input,
+    };
+  }
+
+  private observeStep(step: {
+    toolCalls?: readonly { toolName: string; input: unknown }[];
+    toolResults?: readonly { toolName: string; output: unknown }[];
+  } | undefined): void {
+    if (!step) return;
+    this.pendingSemanticKeys.clear();
+    const calls = step.toolCalls ?? [];
+    const hadStateChange = calls.some(
+      (call) =>
+        STATE_CHANGING_TOOLS.has(call.toolName) &&
+        !isLoopGuardBlockedOutput(
+          step.toolResults?.find((result) => result.toolName === call.toolName)
+            ?.output,
+        ),
+    );
+    const hadExplorationOnly =
+      calls.length > 0 &&
+      calls.every((call) => EXPLORATION_ONLY_TOOLS.has(call.toolName));
+    if (hadStateChange) {
+      this.stepsWithoutStateChange = 0;
+    } else if (hadExplorationOnly || calls.some((call) => call.toolName === "read_file")) {
+      this.stepsWithoutStateChange += 1;
+    }
+    if (
+      !this.hadStateChangingSuccess &&
+      calls.some((call) => call.toolName === "grep" || call.toolName === "glob")
+    ) {
+      this.searchStepsBeforeEdit += 1;
+    }
+    for (const call of calls) {
+      this.observeToolCall(call.toolName, call.input);
+    }
+    for (const result of step.toolResults ?? []) {
+      const input =
+        calls.find((call) => call.toolName === result.toolName)?.input ?? {};
+      if (isLoopGuardBlockedOutput(result.output)) continue;
+      this.observeToolResult(
+        result.toolName,
+        input,
+        result.output,
+        !isFailedOutput(result.output),
+      );
+    }
+  }
+
+  private observeToolCall(toolName: string, input: unknown): void {
+    const semanticKey = `${toolName}:${stableJson(input)}`;
+    incrementBounded(this.semanticToolCounts, semanticKey);
+
+    if (toolName === "read_file") {
+      const path = pathFromInput(input);
+      if (path) {
+        incrementBounded(this.readCountsByPath, path);
+        this.distinctPathsRead.add(path);
+        if (this.recoveryReadAllowedByPath.has(path)) {
+          this.recoveryReadUsedByPath.add(path);
+          this.recoveryReadAllowedByPath.delete(path);
+        }
+      }
+    }
+    if (toolName === "grep" || toolName === "glob") {
+      const searchKey = searchKeyForCall(toolName, input);
+      if (searchKey) incrementBounded(this.searchCounts, searchKey);
+    }
+  }
+
+  private observeToolResult(
+    toolName: string,
+    input: unknown,
+    output: unknown,
+    success: boolean,
+  ): void {
+    if (success && toolName === "read_file" && isRecord(output)) {
+      const path = typeof output.path === "string" ? output.path : pathFromInput(input);
+      const hash = typeof output.sha256 === "string" ? output.sha256 : undefined;
+      if (path && hash) this.lastHashByPath.set(path, hash);
+      if (path) {
+        this.distinctPathsRead.add(path);
+        const readKey = readFileRangeKeyFromOutput(output, path);
+        if (readKey) {
+          incrementBounded(this.readCountsByPathRange, readKey);
+          if (hash) this.lastReadHashByRange.set(readKey, hash);
+        }
+        if (readFileOutputIsFullCoverage(output)) {
+          this.fullCoveragePaths.add(path);
+          this.partialReadPaths.delete(path);
+        } else {
+          this.partialReadPaths.add(path);
+        }
+      }
+    }
+
+    if (
+      success &&
+      (toolName === "edit_text" ||
+        toolName === "replace_text" ||
+        toolName === "replace_lines" ||
+        toolName === "multi_replace_text" ||
+        toolName === "edit_file") &&
+      isRecord(output) &&
+      output.ok === true
+    ) {
+      const path = typeof output.path === "string" ? output.path : pathFromInput(input);
+      const nextHash =
+        typeof output.nextHash === "string" ? output.nextHash : undefined;
+      if (path && nextHash) {
+        this.lastSuccessfulEdit = { path, nextHash };
+        this.lastHashByPath.set(path, nextHash);
+        this.editedPaths.add(path);
+        this.fullCoveragePaths.delete(path);
+        for (const key of [...this.lastReadHashByRange.keys()]) {
+          if (key.startsWith(`read_file:${path}:`)) {
+            this.lastReadHashByRange.delete(key);
+          }
+        }
+        this.phase = "postEdit";
+        this.hadStateChangingSuccess = true;
+        this.failedEditsByPath.delete(path);
+        this.recoveryReadAllowedByPath.delete(path);
+        this.recoveryReadUsedByPath.delete(path);
+        this.lastFailedEditCodeByPath.delete(path);
+        this.pendingStaleReadNote = [
+          "File changed on disk:",
+          `\`${path}\` hash is now ${nextHash.slice(0, 12)}….`,
+          "Prior read_file content for this path is stale.",
+          toolName === "edit_text"
+            ? "Use the edit_text diff in the latest tool result for the next edit."
+            : "Use edit_text for the next change, or read_file a targeted range if you must confirm JSX/imports.",
+        ].join(" ");
+      }
+    }
+
+    if (
+      (toolName === "edit_file" ||
+        toolName === "edit_text" ||
+        toolName === "replace_text" ||
+        toolName === "replace_lines" ||
+        toolName === "multi_replace_text") &&
+      isFailedOutput(output)
+    ) {
+      const path = pathFromInput(input);
+      const failureCode =
+        isRecord(output) && typeof output.code === "string"
+          ? output.code
+          : undefined;
+      if (path) {
+        incrementBounded(this.failedEditsByPath, path);
+        if (failureCode) this.lastFailedEditCodeByPath.set(path, failureCode);
+        if (toolName === "edit_text") {
+          this.editTextFailedPaths.add(path);
+        }
+        const failures = this.failedEditsByPath.get(path) ?? 0;
+        if (
+          toolName === "multi_replace_text" &&
+          failureCode === "FIND_NOT_FOUND"
+        ) {
+          const hash = hashFromInput(input);
+          if (hash) this.multiReplaceBlockedKeys.add(`${path}:${hash}`);
+        }
+        if (
+          toolName === "edit_file" &&
+          (failureCode === "PATCH_PARSE_FAILED" ||
+            failureCode === "PATCH_CONTEXT_FAILED")
+        ) {
+          this.editFileBlockedPaths.add(path);
+        }
+        if (failures >= 2 && failures < 3) {
+          this.phase = "recoverEdit";
+          this.recoveryReadAllowedByPath.add(path);
+        }
+        if (failures >= 3) {
+          this.forceFinalReason = `Editing \`${path}\` failed ${failures} times. Stop and explain the blocker with the latest structured error.`;
+          this.recordGuard();
+        } else if (
+          failures >= 2 &&
+          this.recoveryReadUsedByPath.has(path)
+        ) {
+          this.forceFinalReason = `Editing \`${path}\` failed after a recovery re-read. Stop and explain the blocker with the latest structured error.`;
+          this.recordGuard();
+        }
+      }
+    }
+
+    if (toolName === "verify" && success && isRecord(output)) {
+      if (output.ok === true) {
+        this.verifyCompleted = true;
+        this.verifyFixPending = false;
+        this.verifyFixNoteCount = 0;
+        this.lastVerifyFailureSummary = undefined;
+        this.phase = "final";
+      } else {
+        this.verifyCompleted = false;
+        this.verifyFixPending = true;
+        this.phase = "recoverEdit";
+        this.lastVerifyFailureSummary = extractVerifyFailureSummary(output);
+        this.recoveryReadAllowedByPath.clear();
+        for (const editedPath of this.editedPaths) {
+          this.recoveryReadAllowedByPath.add(editedPath);
+        }
+      }
+    }
+
+    if (STATE_CHANGING_TOOLS.has(toolName) && success) {
+      this.stateChangingToolCount += 1;
+      this.hadStateChangingSuccess = true;
+    }
+  }
+
+  private recordBlockedAttempt(): void {
+    this.blockedAttemptCount += 1;
+    this.recordGuard();
+    if (this.blockedAttemptCount >= 3 && !this.forceFinalReason) {
+      this.forceFinalReason =
+        "Repeated loop-guard blocks exhausted recovery attempts. Write the final answer with the latest tool results.";
+    }
+  }
+
+  private recordGuard(): void {
+    this.guardCount += 1;
+  }
+}
+
+function isLoopGuardBlockedOutput(output: unknown): boolean {
+  return isRecord(output) && output.code === "LOOP_GUARD_BLOCKED";
+}
+
+export function priorToolRecordsFromAssistantMessage(
+  message: { parts: readonly { type: string; [key: string]: unknown }[] } | undefined,
+): PriorToolCallRecord[] {
+  if (!message) return [];
+  const records: PriorToolCallRecord[] = [];
+  for (const part of message.parts) {
+    if (!part.type.startsWith("tool-")) continue;
+    if (!("state" in part) || typeof part.state !== "string") continue;
+    if (
+      part.state !== "output-available" &&
+      part.state !== "output-error" &&
+      part.state !== "output-denied"
+    ) {
+      continue;
+    }
+    const toolName = part.type.slice("tool-".length);
+    const input = "input" in part ? part.input : undefined;
+    const output = "output" in part ? part.output : undefined;
+    const success = part.state === "output-available" && !isFailedOutput(output);
+    records.push({ toolName, input, output, success });
+  }
+  return records;
+}
+
+export function seedFromPriorToolRecords(
+  records: readonly PriorToolCallRecord[],
+): ToolPolicySeed {
+  const readCountsByPath: Record<string, number> = {};
+  const readCountsByPathRange: Record<string, number> = {};
+  const lastHashByPath: Record<string, string> = {};
+  const failedEditsByPath: Record<string, number> = {};
+  const multiReplaceBlockedKeys: string[] = [];
+  const recoveryReadUsedByPath: string[] = [];
+  let lastSuccessfulEdit: { path: string; nextHash: string } | undefined;
+  let phase: ToolPolicyPhase = "explore";
+  let verifyFixPending = false;
+  let lastVerifyFailureSummary: string | undefined;
+  const editedPaths = new Set<string>();
+
+  for (const record of records) {
+    if (record.toolName === "read_file" && record.success && isRecord(record.output)) {
+      const path =
+        typeof record.output.path === "string"
+          ? record.output.path
+          : pathFromInput(record.input);
+      if (path) readCountsByPath[path] = (readCountsByPath[path] ?? 0) + 1;
+      const readKey = path
+        ? readFileRangeKeyFromOutput(record.output, path)
+        : undefined;
+      if (readKey) {
+        readCountsByPathRange[readKey] = (readCountsByPathRange[readKey] ?? 0) + 1;
+      }
+      const hash =
+        typeof record.output.sha256 === "string" ? record.output.sha256 : undefined;
+      if (path && hash) lastHashByPath[path] = hash;
+    }
+    if (
+      record.success &&
+      (record.toolName === "edit_text" ||
+        record.toolName === "replace_text" ||
+        record.toolName === "replace_lines" ||
+        record.toolName === "multi_replace_text" ||
+        record.toolName === "edit_file") &&
+      isRecord(record.output) &&
+      record.output.ok === true
+    ) {
+      const path =
+        typeof record.output.path === "string"
+          ? record.output.path
+          : pathFromInput(record.input);
+      const nextHash =
+        typeof record.output.nextHash === "string"
+          ? record.output.nextHash
+          : undefined;
+      if (path && nextHash) {
+        lastSuccessfulEdit = { path, nextHash };
+        lastHashByPath[path] = nextHash;
+        editedPaths.add(path);
+        phase = "postEdit";
+      }
+    }
+    if (
+      record.toolName === "edit_text" &&
+      isFailedOutput(record.output)
+    ) {
+      const path = pathFromInput(record.input);
+      if (path) {
+        failedEditsByPath[path] = (failedEditsByPath[path] ?? 0) + 1;
+      }
+    }
+    if (
+      (record.toolName === "edit_file" ||
+        record.toolName === "replace_text" ||
+        record.toolName === "replace_lines" ||
+        record.toolName === "multi_replace_text") &&
+      isFailedOutput(record.output)
+    ) {
+      const path = pathFromInput(record.input);
+      if (path) {
+        failedEditsByPath[path] = (failedEditsByPath[path] ?? 0) + 1;
+        if ((failedEditsByPath[path] ?? 0) >= 2) phase = "recoverEdit";
+      }
+      if (
+        record.toolName === "multi_replace_text" &&
+        isRecord(record.output) &&
+        record.output.code === "FIND_NOT_FOUND"
+      ) {
+        const hash = hashFromInput(record.input);
+        if (path && hash) multiReplaceBlockedKeys.push(`${path}:${hash}`);
+      }
+    }
+    if (record.toolName === "verify" && record.success && isRecord(record.output)) {
+      if (record.output.ok === true) {
+        phase = "final";
+      } else {
+        phase = "postEdit";
+        verifyFixPending = true;
+        lastVerifyFailureSummary = extractVerifyFailureSummary(record.output);
+      }
+    }
+  }
+
+  const verifyCompleted = records.some(
+    (record) =>
+      record.toolName === "verify" &&
+      record.success &&
+      isRecord(record.output) &&
+      record.output.ok === true,
+  );
+
+  return {
+    phase,
+    readCountsByPath,
+    readCountsByPathRange,
+    lastHashByPath,
+    failedEditsByPath,
+    multiReplaceBlockedKeys,
+    recoveryReadUsedByPath,
+    ...(verifyCompleted ? { verifyCompleted: true } : {}),
+    ...(verifyFixPending
+      ? {
+          verifyFixPending: true,
+          ...(lastVerifyFailureSummary
+            ? { lastVerifyFailureSummary }
+            : {}),
+          editedPaths: [...editedPaths],
+        }
+      : {}),
+    ...(lastSuccessfulEdit ? { lastSuccessfulEdit } : {}),
+  };
+}
+
+function blockedOutput(
+  message: string,
+  recommendedNext?: LoopGuardBlockedOutput["recommendedNext"],
+  extra: Pick<
+    LoopGuardBlockedOutput,
+    "phase" | "failureCode" | "affectedPath"
+  > = {},
+): LoopGuardBlockedOutput {
+  return {
+    ok: false,
+    code: "LOOP_GUARD_BLOCKED",
+    message,
+    ...(recommendedNext ? { recommendedNext } : {}),
+    ...extra,
+  };
+}
+
+function recommendedForTool(
+  toolName: string,
+): LoopGuardBlockedOutput["recommendedNext"] {
+  if (toolName === "verify") return "final";
+  if (toolName === "read_file") return "edit_text";
+  if (toolName === "grep" || toolName === "glob") return "read_file";
+  if (
+    toolName === "edit_file" ||
+    toolName === "edit_text" ||
+    toolName === "replace_text" ||
+    toolName === "replace_lines" ||
+    toolName === "multi_replace_text"
+  ) {
+    return "edit_text";
+  }
+  return "verify";
+}
+
+function incrementBounded(map: Map<string, number>, key: string): void {
+  const next = (map.get(key) ?? 0) + 1;
+  if (map.size >= MAP_CAP && !map.has(key)) {
+    const first = map.keys().next().value;
+    if (first !== undefined) map.delete(first);
+  }
+  map.set(key, next);
+}
+
+function pathFromInput(input: unknown): string | undefined {
+  if (!isRecord(input)) return undefined;
+  return typeof input.path === "string" && input.path.length > 0
+    ? input.path
+    : undefined;
+}
+
+function hashFromInput(input: unknown): string | undefined {
+  if (!isRecord(input)) return undefined;
+  return typeof input.expectedHash === "string" && input.expectedHash.length > 0
+    ? input.expectedHash
+    : undefined;
+}
+
+function readFileRangeKeyFromOutput(
+  output: Record<string, unknown>,
+  path: string,
+): string | undefined {
+  const start = finiteNumber(output.startLine) ?? 1;
+  const end = finiteNumber(output.endLine);
+  if (end === undefined) return undefined;
+  return `read_file:${path}:${start}-${end}`;
+}
+
+function readFileRangeKey(input: unknown, path: string): string | undefined {
+  if (!isRecord(input)) return undefined;
+  const start = finiteNumber(input.startLine) ?? 1;
+  const end = finiteNumber(input.endLine) ?? start + 199;
+  return `read_file:${path}:${start}-${end}`;
+}
+
+function isFullFileReadInput(input: unknown): boolean {
+  if (!isRecord(input)) return true;
+  return input.startLine === undefined && input.endLine === undefined;
+}
+
+function searchKeyForCall(toolName: string, input: unknown): string | undefined {
+  if (!isRecord(input)) return undefined;
+  if (toolName === "grep") {
+    const pattern = typeof input.pattern === "string" ? input.pattern : "";
+    const path = typeof input.path === "string" ? input.path : ".";
+    const glob = typeof input.glob === "string" ? input.glob : "";
+    return `grep:${hashKey(`${pattern}|${path}|${glob}`)}`;
+  }
+  if (toolName === "glob") {
+    const pattern = typeof input.pattern === "string" ? input.pattern : "";
+    const path = typeof input.path === "string" ? input.path : ".";
+    return `glob:${hashKey(`${pattern}|${path}`)}`;
+  }
+  return undefined;
+}
+
+function hashKey(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isFailedOutput(output: unknown): boolean {
+  return isRecord(output) && output.ok === false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/tools/edit-diagnostics.ts
+++ b/src/agent/tools/edit-diagnostics.ts
@@ -1,0 +1,90 @@
+export type NearMatch = {
+  line: number;
+  text: string;
+};
+
+export function findPreview(find: string, maxChars = 120): string {
+  const normalized = find.replace(/\r\n/g, "\n");
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars)}…`;
+}
+
+export function nearMatchesForFind(
+  content: string,
+  find: string,
+  limit = 5,
+): NearMatch[] {
+  const needle = primaryFindNeedle(find);
+  const normalizedFind = normalizeForScore(find);
+  if (!needle && !normalizedFind) return [];
+  const lines = content.split("\n");
+  const matches: (NearMatch & { score: number })[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.replace(/\r$/, "") ?? "";
+    const score = scoreNearLine(line, needle, normalizedFind);
+    if (score <= 0) continue;
+    matches.push({
+      line: index + 1,
+      text: truncateLine(line, 160),
+      score,
+    });
+  }
+  return matches
+    .sort((a, b) => b.score - a.score || a.line - b.line)
+    .slice(0, limit)
+    .map(({ line, text }) => ({ line, text }));
+}
+
+function primaryFindNeedle(find: string): string | undefined {
+  const normalized = find.replace(/\r\n/g, "\n");
+  const firstLine = normalized.split("\n").find((line) => line.trim().length > 0);
+  if (!firstLine) return undefined;
+  const trimmed = firstLine.trim();
+  if (trimmed.length >= 8) return trimmed;
+  if (normalized.length >= 8) return normalized.slice(0, 80);
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function scoreNearLine(
+  line: string,
+  needle: string | undefined,
+  normalizedFind: string,
+): number {
+  const trimmed = line.trim();
+  if (!trimmed) return 0;
+  if (needle && line.includes(needle)) return 100;
+
+  const normalizedLine = normalizeForScore(trimmed);
+  if (!normalizedLine || !normalizedFind) return 0;
+  if (normalizedFind.includes(normalizedLine) || normalizedLine.includes(normalizedFind)) {
+    return 90;
+  }
+
+  const findTokens = tokenSet(normalizedFind);
+  const lineTokens = tokenSet(normalizedLine);
+  if (findTokens.size === 0 || lineTokens.size === 0) return 0;
+  let overlap = 0;
+  for (const token of lineTokens) {
+    if (findTokens.has(token)) overlap += 1;
+  }
+  const score = Math.round((overlap / Math.max(findTokens.size, lineTokens.size)) * 80);
+  return score >= 35 ? score : 0;
+}
+
+function normalizeForScore(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .replace(/[{}()[\];,'"`]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function tokenSet(value: string): Set<string> {
+  return new Set(value.split(" ").filter((token) => token.length >= 2));
+}
+
+function truncateLine(line: string, maxChars: number): string {
+  if (line.length <= maxChars) return line;
+  return `${line.slice(0, maxChars)}…`;
+}

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -11,10 +11,17 @@ import {
 } from "./edit-utils";
 import { assertGuardAllowed } from "./file-guardrails";
 
+export type EditFileErrorCode =
+  | "HASH_MISMATCH"
+  | "PATCH_PARSE_FAILED"
+  | "PATCH_CONTEXT_FAILED"
+  | "GUARD_REJECTED"
+  | "WRITE_FAILED";
+
 export function createEditFileTool(workspaceRoot?: string) {
   return tool({
   description:
-    "Apply a single-file unified diff patch to an existing UTF-8 text file when expectedHash matches. Prefer this for edits to existing files. Requires user approval.",
+    "Apply a single-file unified diff patch to an existing UTF-8 text file when expectedHash matches. Prefer this for multi-line structural edits. Requires user approval.",
   inputSchema: z.object({
     path: z.string().describe("File path relative to the workspace root."),
     patch: z.string().describe("Single-file unified diff to apply."),
@@ -42,22 +49,38 @@ export function createEditFileTool(workspaceRoot?: string) {
         if (exactHunkPatchAlreadyApplied({ source: previous.content, patch })) {
           return alreadyAppliedResult(relPath, previous);
         }
-        return {
-          ok: false as const,
-          error: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${previous.sha256}`,
-        };
+        return structuredEditError({
+          code: "HASH_MISMATCH",
+          path: relPath,
+          expectedHash,
+          currentHash: previous.sha256,
+          message: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${previous.sha256}`,
+        });
       }
 
-      const nextContent = applySingleFilePatch({
-        source: previous.content,
-        patch,
-        relPath,
-      });
+      let nextContent: string;
+      try {
+        nextContent = applySingleFilePatch({
+          source: previous.content,
+          patch,
+          relPath,
+        });
+      } catch (err) {
+        return structuredEditError({
+          code: classifyPatchError(err),
+          path: relPath,
+          expectedHash,
+          currentHash: previous.sha256,
+          message: errorMessage(err),
+        });
+      }
       if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
-        return {
-          ok: false as const,
-          error: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
-        };
+        return structuredEditError({
+          code: "WRITE_FAILED",
+          path: relPath,
+          expectedHash,
+          message: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
+        });
       }
 
       const current = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
@@ -65,10 +88,13 @@ export function createEditFileTool(workspaceRoot?: string) {
         if (exactHunkPatchAlreadyApplied({ source: current.content, patch })) {
           return alreadyAppliedResult(relPath, current);
         }
-        return {
-          ok: false as const,
-          error: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${current.sha256}`,
-        };
+        return structuredEditError({
+          code: "HASH_MISMATCH",
+          path: relPath,
+          expectedHash,
+          currentHash: current.sha256,
+          message: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${current.sha256}`,
+        });
       }
 
       await atomicWriteTextFile(abs, nextContent);
@@ -83,7 +109,20 @@ export function createEditFileTool(workspaceRoot?: string) {
         bytesWritten: Buffer.byteLength(nextContent, "utf8"),
       };
     } catch (err) {
-      return { ok: false as const, error: errorMessage(err) };
+      if (err instanceof SandboxError && err.message.includes("guard")) {
+        return structuredEditError({
+          code: "GUARD_REJECTED",
+          path: relPath,
+          expectedHash,
+          message: err.message,
+        });
+      }
+      return structuredEditError({
+        code: "WRITE_FAILED",
+        path: relPath,
+        expectedHash,
+        message: errorMessage(err),
+      });
     }
   },
   });
@@ -107,6 +146,32 @@ function alreadyAppliedResult(
   };
 }
 
+function structuredEditError(input: {
+  code: EditFileErrorCode;
+  path: string;
+  expectedHash: string;
+  currentHash?: string;
+  message: string;
+}) {
+  return {
+    ok: false as const,
+    code: input.code,
+    path: input.path,
+    expectedHash: input.expectedHash,
+    ...(input.currentHash ? { currentHash: input.currentHash } : {}),
+    message: input.message,
+    error: input.message,
+  };
+}
+
+function classifyPatchError(err: unknown): EditFileErrorCode {
+  const message = errorMessage(err).toLowerCase();
+  if (message.includes("could not be parsed") || message.includes("must be")) {
+    return "PATCH_PARSE_FAILED";
+  }
+  return "PATCH_CONTEXT_FAILED";
+}
+
 function compactEditFileModelOutput(output: unknown): JSONValue {
   if (!isRecord(output)) {
     return { ok: false, error: "unexpected edit_file output" };
@@ -114,7 +179,11 @@ function compactEditFileModelOutput(output: unknown): JSONValue {
   if (output.ok !== true) {
     return {
       ok: false,
-      error: typeof output.error === "string" ? output.error : "edit_file failed",
+      code: stringValue(output.code),
+      path: stringValue(output.path),
+      expectedHash: stringValue(output.expectedHash),
+      currentHash: stringValue(output.currentHash),
+      message: stringValue(output.message) || stringValue(output.error),
     };
   }
   return {

--- a/src/agent/tools/edit-text.ts
+++ b/src/agent/tools/edit-text.ts
@@ -1,0 +1,231 @@
+import { createPatch } from "diff";
+import { z } from "zod";
+import { tool, type JSONValue } from "ai";
+import { resolveInWorkspace, SandboxError } from "../sandbox";
+import {
+  TEXT_FILE_MAX_BYTES,
+  atomicWriteTextFile,
+  readTextFileSnapshot,
+  sha256,
+} from "./edit-utils";
+import { assertGuardAllowed } from "./file-guardrails";
+import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
+import { applyTextEditsToContent, buildDisplayDiff } from "./text-edits";
+import { lintEditedFile } from "./post-edit-lint";
+
+const editSchema = z.object({
+  oldText: z.string().describe("Text to find in the current file on disk (LF or CRLF both work)."),
+  newText: z.string().describe("Replacement text."),
+  replaceAll: z
+    .boolean()
+    .optional()
+    .describe(
+      "Replace every occurrence of oldText. Defaults to false and requires a unique match.",
+    ),
+});
+
+export function createEditTextTool(workspaceRoot?: string) {
+  return tool({
+    description:
+      "Apply one or more oldText/newText edits to an existing UTF-8 file. Reads the current file from disk (no read_file hash required). Line-ending differences (CRLF vs LF) are normalized before matching. Returns a compact diff so you can continue editing without re-reading the whole file. Requires user approval.",
+    inputSchema: z.object({
+      path: z.string().describe("File path relative to the workspace root."),
+      edits: z
+        .array(editSchema)
+        .min(1)
+        .max(20)
+        .describe("Ordered edits applied atomically against one disk snapshot."),
+      allowGuarded: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true only when intentionally editing a guarded target such as a lockfile, migration, generated file, binary file, or large file.",
+        ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: "json",
+      value: compactEditTextModelOutput(output),
+    }),
+    execute: async ({ path: relPath, edits, allowGuarded = false }) => {
+      try {
+        const abs = resolveInWorkspace(relPath, workspaceRoot);
+        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
+
+        const result = applyTextEditsToContent(previous.content, edits);
+        if (!result.ok) {
+          const failed = edits[result.index];
+          return structuredError({
+            code: result.code,
+            path: relPath,
+            message: `${relPath}: edit ${result.index + 1} failed — ${result.message}`,
+            failedEditIndex: result.index,
+            find: failed?.oldText,
+            content: previous.content,
+            currentHash: previous.sha256,
+          });
+        }
+
+        if (Buffer.byteLength(result.content, "utf8") > TEXT_FILE_MAX_BYTES) {
+          return structuredError({
+            code: "WRITE_FAILED",
+            path: relPath,
+            message: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
+            currentHash: previous.sha256,
+          });
+        }
+
+        await atomicWriteTextFile(abs, result.content);
+        const lint = await lintEditedFile(relPath, workspaceRoot);
+        if (!lint.ok && !lint.skipped) {
+          await atomicWriteTextFile(abs, previous.content);
+          return structuredError({
+            code: "SYNTAX_OR_LINT_FAILED",
+            path: relPath,
+            message: `${relPath}: edit rolled back — ${lint.summary}`,
+            currentHash: previous.sha256,
+            lintIssues: lint.issues,
+            lintSummary: lint.summary,
+          });
+        }
+
+        const diff = buildDisplayDiff(previous.content, result.content);
+        const patch = createPatch(relPath, previous.content, result.content);
+        return {
+          ok: true as const,
+          path: relPath,
+          editCount: edits.length,
+          appliedReplacementCount: result.appliedCount,
+          previousHash: previous.sha256,
+          nextHash: sha256(result.content),
+          bytesWritten: Buffer.byteLength(result.content, "utf8"),
+          diff,
+          patchPreview: patch.length > 8_000 ? `${patch.slice(0, 8_000)}\n…` : patch,
+          priorReadStale: true as const,
+          ...(lint.skipped
+            ? { postEditLint: "skipped" as const, postEditLintReason: lint.reason }
+            : { postEditLint: "passed" as const }),
+        };
+      } catch (err) {
+        if (err instanceof SandboxError && err.message.includes("guard")) {
+          return structuredError({
+            code: "GUARD_REJECTED",
+            path: relPath,
+            message: errorMessage(err),
+          });
+        }
+        return structuredError({
+          code: "WRITE_FAILED",
+          path: relPath,
+          message: errorMessage(err),
+        });
+      }
+    },
+  });
+}
+
+export const editTextTool = createEditTextTool();
+
+function structuredError(input: {
+  code:
+    | "FIND_NOT_FOUND"
+    | "FIND_NOT_UNIQUE"
+    | "GUARD_REJECTED"
+    | "WRITE_FAILED"
+    | "SYNTAX_OR_LINT_FAILED";
+  path: string;
+  message: string;
+  failedEditIndex?: number;
+  find?: string;
+  content?: string;
+  currentHash?: string;
+  lintIssues?: readonly {
+    line: number;
+    column: number;
+    message: string;
+    ruleId?: string;
+  }[];
+  lintSummary?: string;
+}) {
+  const diagnostics =
+    input.code === "FIND_NOT_FOUND" && input.find && input.content
+      ? {
+          findPreview: findPreview(input.find),
+          nearMatches: nearMatchesForFind(input.content, input.find),
+        }
+      : {};
+  return {
+    ok: false as const,
+    code: input.code,
+    path: input.path,
+    message: input.message,
+    error: input.message,
+    noChangesApplied: true as const,
+    ...(input.failedEditIndex !== undefined
+      ? { failedEditIndex: input.failedEditIndex }
+      : {}),
+    ...(input.currentHash ? { currentHash: input.currentHash } : {}),
+    ...(input.lintSummary ? { lintSummary: input.lintSummary } : {}),
+    ...(input.lintIssues?.length
+      ? { lintIssues: input.lintIssues.slice(0, 5) }
+      : {}),
+    ...diagnostics,
+  };
+}
+
+function compactEditTextModelOutput(output: unknown): JSONValue {
+  if (!isRecord(output)) {
+    return { ok: false, error: "unexpected edit_text output" };
+  }
+  if (output.ok !== true) {
+    return {
+      ok: false,
+      code: stringValue(output.code),
+      path: stringValue(output.path),
+      message: stringValue(output.message) || stringValue(output.error),
+      noChangesApplied: true,
+      ...(typeof output.failedEditIndex === "number"
+        ? { failedEditIndex: output.failedEditIndex }
+        : {}),
+      ...(stringValue(output.findPreview)
+        ? { findPreview: stringValue(output.findPreview) }
+        : {}),
+      ...(Array.isArray(output.nearMatches)
+        ? { nearMatches: output.nearMatches.slice(0, 5) }
+        : {}),
+      ...(stringValue(output.lintSummary)
+        ? { lintSummary: stringValue(output.lintSummary) }
+        : {}),
+      ...(Array.isArray(output.lintIssues)
+        ? { lintIssues: output.lintIssues.slice(0, 5) }
+        : {}),
+    };
+  }
+  return {
+    ok: true,
+    path: stringValue(output.path),
+    editCount: numberValue(output.editCount),
+    previousHash: stringValue(output.previousHash),
+    nextHash: stringValue(output.nextHash),
+    diff: stringValue(output.diff),
+    priorReadStale: true,
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof SandboxError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/src/agent/tools/glob.ts
+++ b/src/agent/tools/glob.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { tool } from "ai";
+import { tool, type JSONValue } from "ai";
+import { compactGlobForModel } from "./model-output";
 import {
   resolveInWorkspace,
   SandboxError,
@@ -40,6 +41,10 @@ export function createGlobTool(workspaceRoot?: string) {
       .describe(
         "Optional subdirectory (relative to workspace root) to search in. Defaults to the workspace root.",
       ),
+  }),
+  toModelOutput: ({ output }) => ({
+    type: "json",
+    value: compactGlobForModel(output) as JSONValue,
   }),
   execute: async ({ pattern, path: relPath }) => {
     try {

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { execa } from "execa";
-import { tool } from "ai";
+import { tool, type JSONValue } from "ai";
+import { compactGrepForModel } from "./model-output";
 import {
   resolveInWorkspace,
   SandboxError,
@@ -35,6 +36,10 @@ export function createGrepTool(workspaceRoot?: string) {
       .boolean()
       .optional()
       .describe("Match case-insensitively. Defaults to false."),
+  }),
+  toModelOutput: ({ output }) => ({
+    type: "json",
+    value: compactGrepForModel(output) as JSONValue,
   }),
   execute: async ({ pattern, path: relPath, glob, caseInsensitive }) => {
     try {

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -6,6 +6,13 @@ import {
 } from "../permissions";
 import { createReadFileTool, readFileTool } from "./read-file";
 import { createEditFileTool, editFileTool } from "./edit-file";
+import { createReplaceTextTool, replaceTextTool } from "./replace-text";
+import {
+  createMultiReplaceTextTool,
+  multiReplaceTextTool,
+} from "./multi-replace-text";
+import { createReplaceLinesTool, replaceLinesTool } from "./replace-lines";
+import { createEditTextTool, editTextTool } from "./edit-text";
 import { createWriteFileTool, writeFileTool } from "./write-file";
 import { bashTool, createBashTool } from "./bash";
 import {
@@ -60,10 +67,16 @@ import {
 import { createDelegateTaskTool } from "./delegate";
 import { createUpdateTodosTool, updateTodosTool } from "./todos";
 import { createVerifyTool, verifyTool } from "./verify";
+import type { AgentRunProfile } from "../loop";
+import type { ToolPolicyEngine } from "../tool-policy";
 
 export const nativeAntonTools = applyNativeToolPermissionPolicy({
   read_file: readFileTool,
   edit_file: editFileTool,
+  replace_text: replaceTextTool,
+  replace_lines: replaceLinesTool,
+  edit_text: editTextTool,
+  multi_replace_text: multiReplaceTextTool,
   write_file: writeFileTool,
   read_dir: readDirTool,
   stat: statTool,
@@ -111,6 +124,8 @@ export function createAntonTools({
   nativeToolNames,
   includeMcpTools = true,
   executionCache,
+  profile = "general-chat",
+  toolPolicy,
 }: {
   model?: string;
   mcpTools?: ToolSet;
@@ -119,14 +134,20 @@ export function createAntonTools({
   nativeToolNames?: readonly NativeAntonToolName[];
   includeMcpTools?: boolean;
   executionCache?: ToolExecutionCache;
+  profile?: AgentRunProfile;
+  toolPolicy?: ToolPolicyEngine;
 }) {
   const selectedNativeToolNames = new Set(
     nativeToolNames ?? NATIVE_ANTON_TOOL_NAMES,
   );
   const allNativeTools = {
     ...nativeAntonTools,
-    read_file: createReadFileTool(workspaceRoot),
+    read_file: createReadFileTool(workspaceRoot, profile),
     edit_file: createEditFileTool(workspaceRoot),
+    replace_text: createReplaceTextTool(workspaceRoot),
+    replace_lines: createReplaceLinesTool(workspaceRoot),
+    edit_text: createEditTextTool(workspaceRoot),
+    multi_replace_text: createMultiReplaceTextTool(workspaceRoot),
     write_file: createWriteFileTool(workspaceRoot),
     read_dir: createReadDirTool(workspaceRoot),
     stat: createStatTool(workspaceRoot),
@@ -144,7 +165,7 @@ export function createAntonTools({
     revert_changes: createRevertChangesTool(workspaceRoot),
     bash: createBashTool(workspaceRoot),
     inspect_project: createInspectProjectTool(workspaceRoot),
-    verify: createVerifyTool(workspaceRoot),
+    verify: createVerifyTool(workspaceRoot, profile),
     grep: createGrepTool(workspaceRoot),
     glob: createGlobTool(workspaceRoot),
     list_skills: createListSkillsTool(workspaceRoot),
@@ -162,17 +183,57 @@ export function createAntonTools({
     permissionMode,
   );
 
-  return withExecutionCache({
-    ...nativeTools,
-    ...(includeMcpTools && permissionMode === "full-access" && mcpTools
-      ? stripApprovalFlags(mcpTools)
-      : includeMcpTools
-        ? (mcpTools ?? {})
-        : {}),
-  }, executionCache);
+  return withToolPolicy(
+    withExecutionCache(
+      {
+        ...nativeTools,
+        ...(includeMcpTools && permissionMode === "full-access" && mcpTools
+          ? stripApprovalFlags(mcpTools)
+          : includeMcpTools
+            ? (mcpTools ?? {})
+            : {}),
+      },
+      executionCache,
+    ),
+    toolPolicy,
+  );
 }
 
 export type AntonTools = ReturnType<typeof createAntonTools>;
+
+function withToolPolicy(
+  tools: ToolSet,
+  toolPolicy: ToolPolicyEngine | undefined,
+): ToolSet {
+  if (!toolPolicy) return tools;
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, toolValue]) => {
+      const candidate = toolValue as ToolSet[string] & {
+        execute?: (
+          input: unknown,
+          options: { toolCallId: string; [key: string]: unknown },
+        ) => unknown;
+      };
+      if (typeof candidate.execute !== "function") return [name, toolValue];
+      const execute = candidate.execute;
+      return [
+        name,
+        {
+          ...toolValue,
+          execute: (
+            input: unknown,
+            options: { toolCallId: string; [key: string]: unknown },
+          ) => {
+            const blocked = toolPolicy.checkBeforeExecute(name, input);
+            if (blocked) return blocked;
+            toolPolicy.recordPendingToolCall(name, input);
+            return execute(input, options);
+          },
+        },
+      ];
+    }),
+  ) as ToolSet;
+}
 
 function withExecutionCache(
   tools: ToolSet,

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -1,0 +1,332 @@
+import type { AgentRunProfile } from "../loop";
+
+export const READ_FILE_MODEL_MAX_LINES = 400;
+export const READ_FILE_MODEL_MAX_CHARS = 24_000;
+export const READ_FILE_LOCALIZED_FULL_MAX_LINES = 600;
+export const READ_FILE_LOCALIZED_FULL_MAX_CHARS = 40_000;
+export const READ_FILE_LOCALIZED_RANGE_MAX_LINES = 200;
+export const READ_FILE_LOCALIZED_RANGE_MAX_CHARS = 12_000;
+export const GREP_MODEL_MAX_MATCHES = 30;
+export const GREP_MODEL_MAX_MATCH_CHARS = 220;
+export const GLOB_MODEL_MAX_PATHS = 80;
+export const VERIFY_MODEL_OUTPUT_TAIL_CHARS = 1_200;
+
+export function readFileOutputIsFullCoverage(output: Record<string, unknown>): boolean {
+  if (output.truncated === true) return false;
+  const startLine = finiteNumber(output.startLine) ?? 1;
+  const endLine = finiteNumber(output.endLine);
+  const totalLines = finiteNumber(output.totalLines);
+  if (endLine === undefined || totalLines === undefined) return false;
+  return startLine <= 1 && endLine >= totalLines;
+}
+
+export function readFileOutputIsModestFullFile(
+  output: Record<string, unknown>,
+): boolean {
+  if (!readFileOutputIsFullCoverage(output)) return false;
+  const totalLines = finiteNumber(output.totalLines) ?? 0;
+  const sizeBytes =
+    finiteNumber(output.sizeBytes) ??
+    (typeof output.content === "string"
+      ? Buffer.byteLength(output.content, "utf8")
+      : 0);
+  return (
+    totalLines <= READ_FILE_LOCALIZED_FULL_MAX_LINES &&
+    sizeBytes <= READ_FILE_LOCALIZED_FULL_MAX_CHARS
+  );
+}
+
+export function compactReadFileForModel(
+  output: unknown,
+  profile: AgentRunProfile = "general-chat",
+): unknown {
+  if (!isRecord(output) || output.ok !== true) return output;
+  const content = typeof output.content === "string" ? output.content : "";
+
+  if (readFileOutputIsModestFullFile(output)) {
+    return {
+      ok: true,
+      path: output.path,
+      startLine: output.startLine,
+      endLine: output.endLine,
+      totalLines: output.totalLines,
+      sizeBytes: output.sizeBytes,
+      sha256: output.sha256,
+      content,
+    };
+  }
+
+  const lines = content.split("\n");
+  const maxLines =
+    profile === "localized-edit"
+      ? READ_FILE_LOCALIZED_RANGE_MAX_LINES
+      : READ_FILE_MODEL_MAX_LINES;
+  const maxChars =
+    profile === "localized-edit"
+      ? READ_FILE_LOCALIZED_RANGE_MAX_CHARS
+      : READ_FILE_MODEL_MAX_CHARS;
+  const trimmedLines =
+    lines.length > maxLines ? lines.slice(0, maxLines) : lines;
+  let compactContent = trimmedLines.join("\n");
+  let truncated = lines.length > maxLines || output.truncated === true;
+  if (compactContent.length > maxChars) {
+    compactContent = compactContent.slice(0, maxChars);
+    truncated = true;
+  }
+  const hasMoreBefore =
+    output.hasMoreBefore === true || (finiteNumber(output.startLine) ?? 1) > 1;
+  const hasMoreAfter =
+    output.hasMoreAfter === true ||
+    (finiteNumber(output.endLine) !== undefined &&
+      finiteNumber(output.totalLines) !== undefined &&
+      (finiteNumber(output.endLine) as number) <
+        (finiteNumber(output.totalLines) as number));
+  return {
+    ok: true,
+    path: output.path,
+    startLine: output.startLine,
+    endLine: output.endLine,
+    totalLines: output.totalLines,
+    sizeBytes: output.sizeBytes,
+    sha256: output.sha256,
+    ...(truncated
+      ? {
+          truncated: true as const,
+          modelVisibleLines: trimmedLines.length,
+          ...(hasMoreBefore ? { hasMoreBefore: true as const } : {}),
+          ...(hasMoreAfter ? { hasMoreAfter: true as const } : {}),
+          ...(finiteNumber(output.nextStartLine) !== undefined
+            ? { nextStartLine: output.nextStartLine }
+            : {}),
+          ...(finiteNumber(output.nextEndLine) !== undefined
+            ? { nextEndLine: output.nextEndLine }
+            : {}),
+        }
+      : {}),
+    content: compactContent,
+  };
+}
+
+export function compactGrepForModel(output: unknown): unknown {
+  if (!isRecord(output) || output.ok !== true || !Array.isArray(output.matches)) {
+    return output;
+  }
+  const matches = output.matches.slice(0, GREP_MODEL_MAX_MATCHES).map((match) => {
+    if (!isRecord(match)) return match;
+    const text = typeof match.text === "string" ? match.text : "";
+    return {
+      ...match,
+      text:
+        text.length > GREP_MODEL_MAX_MATCH_CHARS
+          ? `${text.slice(0, GREP_MODEL_MAX_MATCH_CHARS)}…`
+          : text,
+    };
+  });
+  return {
+    ...output,
+    matches,
+    matchCount: matches.length,
+    truncated:
+      output.truncated === true ||
+      (Array.isArray(output.matches) &&
+        output.matches.length > GREP_MODEL_MAX_MATCHES),
+  };
+}
+
+export function compactGlobForModel(output: unknown): unknown {
+  if (!isRecord(output) || output.ok !== true || !Array.isArray(output.matches)) {
+    return output;
+  }
+  const matches = output.matches.slice(0, GLOB_MODEL_MAX_PATHS);
+  return {
+    ...output,
+    matches,
+    matchCount: matches.length,
+    truncated:
+      output.truncated === true ||
+      output.matches.length > GLOB_MODEL_MAX_PATHS,
+  };
+}
+
+export function compactVerifyForModel(output: unknown): unknown {
+  if (!isRecord(output)) return output;
+  const results = Array.isArray(output.results)
+    ? output.results.map(compactVerifyResultForModel)
+    : output.results;
+  const failed = Array.isArray(results)
+    ? results.find((result) => isRecord(result) && result.ok === false)
+    : undefined;
+  const failureSummary = extractVerifyFailureSummary(output);
+  const parseIssues =
+    failed && isRecord(failed)
+      ? extractParseIssuesFromText(
+          [failed.stderr, failed.stdout, failed.error]
+            .filter((value): value is string => typeof value === "string")
+            .join("\n"),
+        )
+      : [];
+
+  if (output.ok === false) {
+    return {
+      ok: false,
+      summary: output.summary,
+      packageManager: output.packageManager,
+      ranCount: output.ranCount,
+      skippedCount: output.skippedCount,
+      ...(failureSummary ? { failureSummary } : {}),
+      ...(parseIssues.length > 0 ? { parseIssues: parseIssues.slice(0, 5) } : {}),
+      ...(failed && isRecord(failed)
+        ? {
+            failedTarget: failed.target,
+            failedCommand: failed.command,
+            exitCode: failed.exitCode,
+          }
+        : {}),
+    };
+  }
+
+  return {
+    ok: output.ok,
+    summary: output.summary,
+    packageManager: output.packageManager,
+    ranCount: output.ranCount,
+    skippedCount: output.skippedCount,
+    results,
+  };
+}
+
+export function extractVerifyFailureSummary(output: unknown): string | undefined {
+  if (!isRecord(output)) return undefined;
+  if (typeof output.summary === "string" && output.summary.trim().length > 0) {
+    const base = output.summary.trim();
+    if (!Array.isArray(output.results)) return base;
+    const failed = output.results.find(
+      (result) => isRecord(result) && result.ok === false && result.skipped !== true,
+    );
+    if (!isRecord(failed)) return base;
+    const text = [failed.stderr, failed.stdout, failed.error, failed.message]
+      .filter((value): value is string => typeof value === "string")
+      .join("\n");
+    const issues = extractParseIssuesFromText(text);
+    if (issues.length > 0) {
+      const primary = issues[0];
+      const loc =
+        primary.line !== undefined
+          ? ` at line ${primary.line}${primary.column !== undefined ? `:${primary.column}` : ""}`
+          : "";
+      return `${base} — ${primary.message}${loc}`;
+    }
+    if (typeof failed.error === "string" && failed.error.trim().length > 0) {
+      return `${base} — ${failed.error.trim().slice(0, 200)}`;
+    }
+    return base;
+  }
+  return undefined;
+}
+
+export function extractParseIssuesFromText(
+  text: string,
+): { line?: number; column?: number; message: string }[] {
+  const issues: { line?: number; column?: number; message: string }[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const unix = trimmed.match(
+      /^(?:.*[\\/])?([^:]+):(\d+):(\d+):\s*(.+?)(?:\s+\[(.+)\])?$/,
+    );
+    if (unix) {
+      const [, , lineText, columnText, message] = unix;
+      issues.push({
+        line: Number.parseInt(lineText, 10),
+        column: Number.parseInt(columnText, 10),
+        message: message.trim(),
+      });
+      continue;
+    }
+    const parsing = trimmed.match(/Parsing error:\s*(.+)$/i);
+    if (parsing) {
+      const lineMatch = trimmed.match(/:(\d+):(\d+)/);
+      issues.push({
+        ...(lineMatch
+          ? {
+              line: Number.parseInt(lineMatch[1], 10),
+              column: Number.parseInt(lineMatch[2], 10),
+            }
+          : {}),
+        message: `Parsing error: ${parsing[1].trim()}`,
+      });
+    }
+  }
+  return issues;
+}
+
+function compactVerifyResultForModel(result: unknown): unknown {
+  if (!isRecord(result)) return result;
+  return {
+    target: result.target,
+    skipped: result.skipped,
+    ok: result.ok,
+    ...(result.skipped
+      ? { reason: result.reason }
+      : {
+          command: result.command,
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          stdout: tailText(result.stdout),
+          stderr: tailText(result.stderr),
+          ...(result.ok === false ? { error: result.error } : {}),
+        }),
+  };
+}
+
+function tailText(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  if (value.length <= VERIFY_MODEL_OUTPUT_TAIL_CHARS) return value;
+  return value.slice(-VERIFY_MODEL_OUTPUT_TAIL_CHARS);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export type VerifyToolDefaults = {
+  targets?: readonly ("typecheck" | "lint" | "build")[];
+  timeoutMs: number;
+};
+
+export function readFileDefaultMaxLines(profile: AgentRunProfile): number {
+  return profile === "localized-edit"
+    ? READ_FILE_LOCALIZED_FULL_MAX_LINES
+    : READ_FILE_MODEL_MAX_LINES;
+}
+
+export function readFileReturnsFullByDefault(
+  profile: AgentRunProfile,
+  totalLines: number,
+  sizeBytes: number,
+): boolean {
+  return (
+    profile === "localized-edit" &&
+    totalLines <= READ_FILE_LOCALIZED_FULL_MAX_LINES &&
+    sizeBytes <= READ_FILE_LOCALIZED_FULL_MAX_CHARS
+  );
+}
+
+export function verifyDefaultsForProfile(
+  profile: AgentRunProfile,
+): VerifyToolDefaults {
+  if (profile === "localized-edit") {
+    return {
+      targets: ["typecheck", "lint"],
+      timeoutMs: 60_000,
+    };
+  }
+  return {
+    targets: ["typecheck", "lint"],
+    timeoutMs: 120_000,
+  };
+}

--- a/src/agent/tools/multi-replace-text.ts
+++ b/src/agent/tools/multi-replace-text.ts
@@ -1,0 +1,235 @@
+import { z } from "zod";
+import { tool, type JSONValue } from "ai";
+import { resolveInWorkspace, SandboxError } from "../sandbox";
+import {
+  TEXT_FILE_MAX_BYTES,
+  atomicWriteTextFile,
+  readTextFileSnapshot,
+  sha256,
+} from "./edit-utils";
+import { assertGuardAllowed } from "./file-guardrails";
+import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
+
+const replacementSchema = z.object({
+  find: z.string().min(1).describe("Exact text to find in the file."),
+  replace: z.string().describe("Replacement text."),
+});
+
+export function createMultiReplaceTextTool(workspaceRoot?: string) {
+  return tool({
+    description:
+      "Apply ordered exact-text replacements to one existing UTF-8 file when expectedHash matches. All replacements run atomically. Requires user approval.",
+    inputSchema: z.object({
+      path: z.string().describe("File path relative to the workspace root."),
+      expectedHash: z
+        .string()
+        .min(1)
+        .describe("SHA-256 from the most recent read_file result."),
+      replacements: z
+        .array(replacementSchema)
+        .min(1)
+        .max(20)
+        .describe("Ordered find/replace pairs applied sequentially."),
+      allowGuarded: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true only when intentionally editing a guarded target such as a lockfile, migration, generated file, binary file, or large file.",
+        ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: "json",
+      value: compactMultiReplaceModelOutput(output),
+    }),
+    execute: async ({ path: relPath, expectedHash, replacements, allowGuarded = false }) => {
+      try {
+        const abs = resolveInWorkspace(relPath, workspaceRoot);
+        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
+        if (previous.sha256 !== expectedHash) {
+          return structuredError({
+            code: "HASH_MISMATCH",
+            path: relPath,
+            expectedHash,
+            currentHash: previous.sha256,
+            message: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${previous.sha256}`,
+          });
+        }
+
+        let nextContent = previous.content;
+        let replacementCount = 0;
+        for (const [index, replacement] of replacements.entries()) {
+          const occurrences = countOccurrences(nextContent, replacement.find);
+          if (occurrences === 0) {
+            return structuredError({
+              code: "FIND_NOT_FOUND",
+              path: relPath,
+              expectedHash,
+              message: `${relPath} exists and hash matched, but replacement ${index + 1} find snippet was not found`,
+              failedReplacementIndex: index,
+              matchedReplacementCount: replacementCount,
+              find: replacement.find,
+              content: previous.content,
+            });
+          }
+          if (occurrences > 1) {
+            return structuredError({
+              code: "FIND_NOT_UNIQUE",
+              path: relPath,
+              expectedHash,
+              message: `replacement ${index + 1}: find text occurs ${occurrences} times in ${relPath}; narrow find`,
+            });
+          }
+          nextContent = nextContent.replace(replacement.find, replacement.replace);
+          replacementCount += 1;
+        }
+
+        if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
+          return structuredError({
+            code: "WRITE_FAILED",
+            path: relPath,
+            expectedHash,
+            message: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
+          });
+        }
+
+        await atomicWriteTextFile(abs, nextContent);
+        return {
+          ok: true as const,
+          path: relPath,
+          replacementCount,
+          previousHash: previous.sha256,
+          nextHash: sha256(nextContent),
+          bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+        };
+      } catch (err) {
+        if (err instanceof SandboxError && err.message.includes("guard")) {
+          return structuredError({
+            code: "GUARD_REJECTED",
+            path: relPath,
+            expectedHash,
+            message: err.message,
+          });
+        }
+        return structuredError({
+          code: "WRITE_FAILED",
+          path: relPath,
+          expectedHash,
+          message: errorMessage(err),
+        });
+      }
+    },
+  });
+}
+
+export const multiReplaceTextTool = createMultiReplaceTextTool();
+
+function countOccurrences(source: string, find: string): number {
+  if (find.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while (index <= source.length - find.length) {
+    const next = source.indexOf(find, index);
+    if (next === -1) break;
+    count += 1;
+    index = next + find.length;
+  }
+  return count;
+}
+
+function structuredError(input: {
+  code:
+    | "HASH_MISMATCH"
+    | "FIND_NOT_FOUND"
+    | "FIND_NOT_UNIQUE"
+    | "GUARD_REJECTED"
+    | "WRITE_FAILED";
+  path: string;
+  expectedHash: string;
+  currentHash?: string;
+  message: string;
+  failedReplacementIndex?: number;
+  matchedReplacementCount?: number;
+  find?: string;
+  content?: string;
+}) {
+  const diagnostics =
+    input.code === "FIND_NOT_FOUND" && input.find && input.content
+      ? {
+          findPreview: findPreview(input.find),
+          nearMatches: nearMatchesForFind(input.content, input.find),
+        }
+      : {};
+  return {
+    ok: false as const,
+    code: input.code,
+    path: input.path,
+    expectedHash: input.expectedHash,
+    ...(input.currentHash ? { currentHash: input.currentHash } : {}),
+    message: input.message,
+    error: input.message,
+    noChangesApplied: true as const,
+    ...(input.failedReplacementIndex !== undefined
+      ? { failedReplacementIndex: input.failedReplacementIndex }
+      : {}),
+    ...(input.matchedReplacementCount !== undefined
+      ? { matchedReplacementCount: input.matchedReplacementCount }
+      : {}),
+    ...diagnostics,
+  };
+}
+
+function compactMultiReplaceModelOutput(output: unknown): JSONValue {
+  if (!isRecord(output)) {
+    return { ok: false, error: "unexpected multi_replace_text output" };
+  }
+  if (output.ok !== true) {
+    return {
+      ok: false,
+      code: stringValue(output.code),
+      path: stringValue(output.path),
+      expectedHash: stringValue(output.expectedHash),
+      currentHash: stringValue(output.currentHash),
+      message: stringValue(output.message) || stringValue(output.error),
+      noChangesApplied: true,
+      ...(typeof output.failedReplacementIndex === "number"
+        ? { failedReplacementIndex: output.failedReplacementIndex }
+        : {}),
+      ...(typeof output.matchedReplacementCount === "number"
+        ? { matchedReplacementCount: output.matchedReplacementCount }
+        : {}),
+      ...(stringValue(output.findPreview)
+        ? { findPreview: stringValue(output.findPreview) }
+        : {}),
+      ...(Array.isArray(output.nearMatches)
+        ? { nearMatches: output.nearMatches.slice(0, 5) }
+        : {}),
+    };
+  }
+  return {
+    ok: true,
+    path: stringValue(output.path),
+    replacementCount: numberValue(output.replacementCount),
+    previousHash: stringValue(output.previousHash),
+    nextHash: stringValue(output.nextHash),
+    bytesWritten: numberValue(output.bytesWritten),
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof SandboxError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/src/agent/tools/post-edit-lint.ts
+++ b/src/agent/tools/post-edit-lint.ts
@@ -1,0 +1,207 @@
+import path from "node:path";
+
+import { ensureWorkspaceRoot, ensureWorkspaceRootAt } from "../sandbox";
+import {
+  detectPackageManager,
+  execCommand,
+  hasDependency,
+  readPackageJson,
+  runScriptCommand,
+  scriptNames,
+} from "./package-manager";
+import { runWorkspaceProcess } from "./process";
+
+export type PostEditLintIssue = {
+  line: number;
+  column: number;
+  message: string;
+  ruleId?: string;
+};
+
+export type PostEditLintResult =
+  | { ok: true; skipped: true; reason: string }
+  | { ok: true; skipped: false }
+  | {
+      ok: false;
+      skipped: false;
+      issues: PostEditLintIssue[];
+      summary: string;
+      rawOutput?: string;
+    };
+
+const LINT_TIMEOUT_MS = 30_000;
+
+export async function lintEditedFile(
+  relPath: string,
+  workspaceRoot?: string,
+): Promise<PostEditLintResult> {
+  const root = workspaceRoot
+    ? ensureWorkspaceRootAt(workspaceRoot)
+    : ensureWorkspaceRoot();
+  const packageJson = readPackageJson(root);
+  if (!packageJson.ok) {
+    return { ok: true, skipped: true, reason: packageJson.error };
+  }
+
+  const ext = path.extname(relPath).toLowerCase();
+  if (![".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: `No post-edit lint for ${ext || "extensionless"} files.`,
+    };
+  }
+
+  const packageManager = detectPackageManager(root, packageJson.value);
+  const hasDirectEslint = hasDependency(packageJson.value, "eslint");
+  const hasLintScript = scriptNames(packageJson.value).includes("lint");
+  if (!hasDirectEslint && !hasLintScript) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "No eslint dependency or lint script found in this workspace.",
+    };
+  }
+
+  const normalizedPath = relPath.replace(/\\/g, "/");
+  const command = hasDirectEslint
+    ? execCommand(packageManager, [
+        "eslint",
+        normalizedPath,
+        "--max-warnings",
+        "0",
+        "--format",
+        "json",
+      ])
+    : runScriptCommand(packageManager, "lint");
+
+  const [file, ...args] = command;
+  if (!file) {
+    return { ok: true, skipped: true, reason: "lint command could not be built." };
+  }
+
+  const result = await runWorkspaceProcess(file, args, root, {
+    timeoutMs: LINT_TIMEOUT_MS,
+  });
+  if (result.exitCode === 0) {
+    return { ok: true, skipped: false };
+  }
+
+  const combined = [result.stdout, result.stderr].filter(Boolean).join("\n");
+  const issues = parseLintOutput(combined, normalizedPath);
+  if (issues.length === 0) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: hasDirectEslint
+        ? "eslint failed without diagnostics for the edited file."
+        : "lint script failed, but no diagnostics matched the edited file.",
+    };
+  }
+
+  const summary = issues
+    .slice(0, 5)
+    .map(
+      (issue) =>
+        `${normalizedPath}:${issue.line}:${issue.column} ${issue.message}${
+          issue.ruleId ? ` (${issue.ruleId})` : ""
+        }`,
+    )
+    .join("; ");
+
+  return {
+    ok: false,
+    skipped: false,
+    issues,
+    summary,
+    ...(combined.trim().length > 0 ? { rawOutput: combined.slice(0, 4_000) } : {}),
+  };
+}
+
+function parseLintOutput(output: string, relPath: string): PostEditLintIssue[] {
+  const jsonIssues = parseJsonLintOutput(output, relPath);
+  if (jsonIssues.length > 0) return jsonIssues;
+  return parseTextLintOutput(output, relPath);
+}
+
+function parseJsonLintOutput(output: string, relPath: string): PostEditLintIssue[] {
+  const trimmed = output.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) return [];
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const files = Array.isArray(parsed) ? parsed : [parsed];
+    return files.flatMap((file) => {
+      if (!isRecord(file)) return [];
+      const filePath = typeof file.filePath === "string" ? file.filePath.replace(/\\/g, "/") : "";
+      if (!filePath.endsWith(relPath)) return [];
+      const messages = Array.isArray(file.messages) ? file.messages : [];
+      return messages.flatMap((message): PostEditLintIssue[] => {
+        if (!isRecord(message)) return [];
+        const line = typeof message.line === "number" ? message.line : 1;
+        const column = typeof message.column === "number" ? message.column : 1;
+        const text =
+          typeof message.message === "string"
+            ? message.message
+            : "eslint reported an issue on the edited file.";
+        const ruleId =
+          typeof message.ruleId === "string" ? message.ruleId : undefined;
+        return [{ line, column, message: text, ...(ruleId ? { ruleId } : {}) }];
+      });
+    });
+  } catch {
+    return [];
+  }
+}
+
+function parseTextLintOutput(output: string, relPath: string): PostEditLintIssue[] {
+  const basename = relPath.split("/").pop() ?? relPath;
+  const issues: PostEditLintIssue[] = [];
+  let currentFileMatches = false;
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.includes("/") || trimmed.includes("\\")) {
+      const normalized = trimmed.replace(/\\/g, "/");
+      if (normalized.endsWith(relPath) || normalized.endsWith(`/${basename}`)) {
+        currentFileMatches = true;
+        continue;
+      }
+      if (/\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(normalized)) {
+        currentFileMatches = false;
+        continue;
+      }
+    }
+    const unixMatch = trimmed.match(
+      /^(?:.*[\\/])?([^:]+):(\d+):(\d+):\s*(.+?)(?:\s+\[(.+)\])?$/,
+    );
+    const stylishMatch = trimmed.match(
+      /^\s*(\d+):(\d+)\s+(?:error|warning)\s+(.+?)(?:\s{2,}([@\w/-]+))?$/,
+    );
+    const match = unixMatch ?? stylishMatch;
+    if (!match) continue;
+    const [, filePartOrLine, lineTextOrColumn, columnTextOrMessage, messageOrRule, ruleIdOrUndefined] =
+      match;
+    const isUnix = unixMatch !== null;
+    const filePart = isUnix ? filePartOrLine : basename;
+    const lineText = isUnix ? lineTextOrColumn : filePartOrLine;
+    const columnText = isUnix ? columnTextOrMessage : lineTextOrColumn;
+    const message = isUnix ? messageOrRule : columnTextOrMessage;
+    const ruleId = isUnix ? ruleIdOrUndefined : messageOrRule;
+    if (isUnix) {
+      if (!filePart?.includes(basename) && !trimmed.includes(relPath)) continue;
+    } else if (!currentFileMatches) {
+      continue;
+    }
+    issues.push({
+      line: Number.parseInt(lineText, 10),
+      column: Number.parseInt(columnText, 10),
+      message: message.trim(),
+      ...(ruleId ? { ruleId: ruleId.trim() } : {}),
+    });
+  }
+  return issues;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/agent/tools/read-file.ts
+++ b/src/agent/tools/read-file.ts
@@ -1,14 +1,23 @@
 import { z } from "zod";
-import { tool } from "ai";
+import { tool, type JSONValue } from "ai";
 import { resolveInWorkspace, SandboxError } from "../sandbox";
 import {
   READ_FILE_MAX_BYTES,
   readTextFileSnapshot,
 } from "./edit-utils";
+import type { AgentRunProfile } from "../loop";
+import {
+  compactReadFileForModel,
+  readFileDefaultMaxLines,
+  readFileReturnsFullByDefault,
+  READ_FILE_LOCALIZED_RANGE_MAX_LINES,
+} from "./model-output";
 
-const MAX_LINES_DEFAULT = 2000;
-
-export function createReadFileTool(workspaceRoot?: string) {
+export function createReadFileTool(
+  workspaceRoot?: string,
+  profile: AgentRunProfile = "general-chat",
+) {
+  const maxLinesDefault = readFileDefaultMaxLines(profile);
   return tool({
   description:
     "Read a UTF-8 text file from the workspace. Supports optional line ranges. Paths are relative to WORKSPACE_ROOT and must stay inside it.",
@@ -26,8 +35,12 @@ export function createReadFileTool(workspaceRoot?: string) {
       .min(1)
       .optional()
       .describe(
-        "1-indexed last line to return (inclusive). Defaults to startLine + 2000.",
+        `1-indexed last line to return (inclusive). Defaults to startLine + ${maxLinesDefault - 1} for modest files, or a bounded range for large files.`,
       ),
+  }),
+  toModelOutput: ({ output }) => ({
+    type: "json",
+    value: compactReadFileForModel(output, profile) as JSONValue,
   }),
   execute: async ({ path: relPath, startLine, endLine }) => {
     try {
@@ -35,18 +48,48 @@ export function createReadFileTool(workspaceRoot?: string) {
       const snapshot = await readTextFileSnapshot(abs, READ_FILE_MAX_BYTES);
       const raw = snapshot.content;
       const lines = raw.split("\n");
+      const totalLines = lines.length;
+      const fullByDefault = readFileReturnsFullByDefault(
+        profile,
+        totalLines,
+        snapshot.sizeBytes,
+      );
       const from = startLine ?? 1;
-      const to = endLine ?? Math.min(lines.length, from + MAX_LINES_DEFAULT - 1);
+      const defaultEnd = fullByDefault
+        ? totalLines
+        : Math.min(
+            totalLines,
+            from + (profile === "localized-edit"
+              ? READ_FILE_LOCALIZED_RANGE_MAX_LINES
+              : maxLinesDefault) - 1,
+          );
+      const to = endLine ?? defaultEnd;
       const slice = lines.slice(from - 1, to);
+      const truncated = from > 1 || to < totalLines;
       return {
         ok: true as const,
         path: relPath,
         startLine: from,
-        endLine: Math.min(to, lines.length),
-        totalLines: lines.length,
+        endLine: Math.min(to, totalLines),
+        totalLines,
         sizeBytes: snapshot.sizeBytes,
         sha256: snapshot.sha256,
         content: slice.join("\n"),
+        ...(truncated
+          ? {
+              truncated: true as const,
+              hasMoreBefore: from > 1,
+              hasMoreAfter: to < totalLines,
+              nextStartLine: to < totalLines ? to + 1 : undefined,
+              nextEndLine:
+                to < totalLines
+                  ? Math.min(
+                      totalLines,
+                      to + READ_FILE_LOCALIZED_RANGE_MAX_LINES,
+                    )
+                  : undefined,
+            }
+          : {}),
       };
     } catch (err) {
       return { ok: false as const, error: errorMessage(err) };

--- a/src/agent/tools/replace-lines.ts
+++ b/src/agent/tools/replace-lines.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+import { tool, type JSONValue } from "ai";
+import { resolveInWorkspace, SandboxError } from "../sandbox";
+import {
+  TEXT_FILE_MAX_BYTES,
+  atomicWriteTextFile,
+  readTextFileSnapshot,
+  sha256,
+} from "./edit-utils";
+import { assertGuardAllowed } from "./file-guardrails";
+
+const editSchema = z.object({
+  startLine: z.number().int().min(1).describe("1-indexed first line to replace (inclusive)."),
+  endLine: z
+    .number()
+    .int()
+    .min(1)
+    .describe("1-indexed last line to replace (inclusive)."),
+  replacement: z.string().describe("Replacement text for the line range."),
+});
+
+export function createReplaceLinesTool(workspaceRoot?: string) {
+  return tool({
+    description:
+      "Replace ordered, non-overlapping line ranges in an existing UTF-8 file when expectedHash matches. Prefer this when exact find strings are brittle. Requires user approval.",
+    inputSchema: z.object({
+      path: z.string().describe("File path relative to the workspace root."),
+      expectedHash: z
+        .string()
+        .min(1)
+        .describe("SHA-256 from the most recent read_file result."),
+      edits: z
+        .array(editSchema)
+        .min(1)
+        .max(20)
+        .describe("Ordered, non-overlapping line-range replacements."),
+      allowGuarded: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true only when intentionally editing a guarded target such as a lockfile, migration, generated file, binary file, or large file.",
+        ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: "json",
+      value: compactReplaceLinesModelOutput(output),
+    }),
+    execute: async ({
+      path: relPath,
+      expectedHash,
+      edits,
+      allowGuarded = false,
+    }) => {
+      try {
+        const abs = resolveInWorkspace(relPath, workspaceRoot);
+        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
+        if (previous.sha256 !== expectedHash) {
+          return structuredError({
+            code: "HASH_MISMATCH",
+            path: relPath,
+            expectedHash,
+            currentHash: previous.sha256,
+            message: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${previous.sha256}`,
+          });
+        }
+
+        const validation = validateEdits(edits, previous.content);
+        if (!validation.ok) {
+          return structuredError({
+            code: validation.code,
+            path: relPath,
+            expectedHash,
+            message: validation.message,
+          });
+        }
+
+        const nextContent = applyLineEdits(previous.content, validation.normalizedEdits);
+        if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
+          return structuredError({
+            code: "WRITE_FAILED",
+            path: relPath,
+            expectedHash,
+            message: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
+          });
+        }
+
+        await atomicWriteTextFile(abs, nextContent);
+        return {
+          ok: true as const,
+          path: relPath,
+          editCount: validation.normalizedEdits.length,
+          previousHash: previous.sha256,
+          nextHash: sha256(nextContent),
+          bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+          changedRanges: validation.normalizedEdits.map((edit) => ({
+            startLine: edit.startLine,
+            endLine: edit.endLine,
+            previousLineCount: edit.endLine - edit.startLine + 1,
+            newLineCount: edit.replacement.split("\n").length,
+          })),
+        };
+      } catch (err) {
+        if (err instanceof SandboxError && err.message.includes("guard")) {
+          return structuredError({
+            code: "GUARD_REJECTED",
+            path: relPath,
+            expectedHash,
+            message: errorMessage(err),
+          });
+        }
+        return structuredError({
+          code: "WRITE_FAILED",
+          path: relPath,
+          expectedHash,
+          message: errorMessage(err),
+        });
+      }
+    },
+  });
+}
+
+export const replaceLinesTool = createReplaceLinesTool();
+
+type NormalizedEdit = {
+  startLine: number;
+  endLine: number;
+  replacement: string;
+};
+
+function validateEdits(
+  edits: readonly { startLine: number; endLine: number; replacement: string }[],
+  content: string,
+):
+  | { ok: true; normalizedEdits: NormalizedEdit[] }
+  | {
+      ok: false;
+      code: "INVALID_RANGE" | "OVERLAPPING_EDITS";
+      message: string;
+    } {
+  const totalLines = content.split("\n").length;
+  const normalized = [...edits].sort((left, right) => left.startLine - right.startLine);
+  for (const [index, edit] of normalized.entries()) {
+    if (edit.endLine < edit.startLine) {
+      return {
+        ok: false,
+        code: "INVALID_RANGE",
+        message: `edit ${index + 1}: endLine ${edit.endLine} is before startLine ${edit.startLine}`,
+      };
+    }
+    if (edit.startLine > totalLines || edit.endLine > totalLines) {
+      return {
+        ok: false,
+        code: "INVALID_RANGE",
+        message: `edit ${index + 1}: line range ${edit.startLine}-${edit.endLine} exceeds file length ${totalLines}`,
+      };
+    }
+    const previous = normalized[index - 1];
+    if (previous && edit.startLine <= previous.endLine) {
+      return {
+        ok: false,
+        code: "OVERLAPPING_EDITS",
+        message: `edit ${index + 1}: line range overlaps the previous edit ending at line ${previous.endLine}`,
+      };
+    }
+  }
+  return { ok: true, normalizedEdits: normalized };
+}
+
+function applyLineEdits(content: string, edits: readonly NormalizedEdit[]): string {
+  const lines = content.split("\n");
+  const sorted = [...edits].sort((left, right) => right.startLine - left.startLine);
+  for (const edit of sorted) {
+    const replacementLines = edit.replacement.split("\n");
+    lines.splice(edit.startLine - 1, edit.endLine - edit.startLine + 1, ...replacementLines);
+  }
+  return lines.join("\n");
+}
+
+function structuredError(input: {
+  code:
+    | "HASH_MISMATCH"
+    | "INVALID_RANGE"
+    | "OVERLAPPING_EDITS"
+    | "GUARD_REJECTED"
+    | "WRITE_FAILED";
+  path: string;
+  expectedHash: string;
+  currentHash?: string;
+  message: string;
+}) {
+  return {
+    ok: false as const,
+    code: input.code,
+    path: input.path,
+    expectedHash: input.expectedHash,
+    ...(input.currentHash ? { currentHash: input.currentHash } : {}),
+    message: input.message,
+    error: input.message,
+    noChangesApplied: true as const,
+  };
+}
+
+function compactReplaceLinesModelOutput(output: unknown): JSONValue {
+  if (!isRecord(output)) {
+    return { ok: false, error: "unexpected replace_lines output" };
+  }
+  if (output.ok !== true) {
+    return {
+      ok: false,
+      code: stringValue(output.code),
+      path: stringValue(output.path),
+      expectedHash: stringValue(output.expectedHash),
+      currentHash: stringValue(output.currentHash),
+      message: stringValue(output.message) || stringValue(output.error),
+      noChangesApplied: true,
+    };
+  }
+  return {
+    ok: true,
+    path: stringValue(output.path),
+    editCount: numberValue(output.editCount),
+    previousHash: stringValue(output.previousHash),
+    nextHash: stringValue(output.nextHash),
+    bytesWritten: numberValue(output.bytesWritten),
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof SandboxError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/src/agent/tools/replace-text.ts
+++ b/src/agent/tools/replace-text.ts
@@ -1,0 +1,221 @@
+import { z } from "zod";
+import { tool, type JSONValue } from "ai";
+import { resolveInWorkspace, SandboxError } from "../sandbox";
+import {
+  TEXT_FILE_MAX_BYTES,
+  atomicWriteTextFile,
+  readTextFileSnapshot,
+  sha256,
+} from "./edit-utils";
+import { assertGuardAllowed } from "./file-guardrails";
+import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
+
+export function createReplaceTextTool(workspaceRoot?: string) {
+  return tool({
+    description:
+      "Replace one exact text span in an existing UTF-8 file when expectedHash matches. Prefer this for small targeted edits. Requires user approval.",
+    inputSchema: z.object({
+      path: z.string().describe("File path relative to the workspace root."),
+      expectedHash: z
+        .string()
+        .min(1)
+        .describe("SHA-256 from the most recent read_file result."),
+      find: z.string().min(1).describe("Exact text to find in the file."),
+      replace: z.string().describe("Replacement text."),
+      replaceAll: z
+        .boolean()
+        .optional()
+        .describe(
+          "Replace every occurrence. Defaults to false and requires exactly one match.",
+        ),
+      allowGuarded: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set true only when intentionally editing a guarded target such as a lockfile, migration, generated file, binary file, or large file.",
+        ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: "json",
+      value: compactReplaceTextModelOutput(output),
+    }),
+    execute: async ({
+      path: relPath,
+      expectedHash,
+      find,
+      replace,
+      replaceAll = false,
+      allowGuarded = false,
+    }) => {
+      try {
+        const abs = resolveInWorkspace(relPath, workspaceRoot);
+        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
+        if (previous.sha256 !== expectedHash) {
+          return structuredReplaceError({
+            code: "HASH_MISMATCH",
+            path: relPath,
+            expectedHash,
+            currentHash: previous.sha256,
+            message: `hash mismatch for ${relPath}: expected ${expectedHash}, found ${previous.sha256}`,
+          });
+        }
+
+        const occurrences = countOccurrences(previous.content, find);
+        if (occurrences === 0) {
+          return structuredReplaceError({
+            code: "FIND_NOT_FOUND",
+            path: relPath,
+            expectedHash,
+            message: `${relPath} exists and hash matched, but the find snippet was not found`,
+            find,
+            content: previous.content,
+          });
+        }
+        if (!replaceAll && occurrences > 1) {
+          return structuredReplaceError({
+            code: "FIND_NOT_UNIQUE",
+            path: relPath,
+            expectedHash,
+            message: `find text occurs ${occurrences} times in ${relPath}; set replaceAll: true or narrow find`,
+          });
+        }
+
+        const nextContent = replaceAll
+          ? previous.content.split(find).join(replace)
+          : previous.content.replace(find, replace);
+        if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
+          return structuredReplaceError({
+            code: "WRITE_FAILED",
+            path: relPath,
+            expectedHash,
+            message: `patched content exceeds ${TEXT_FILE_MAX_BYTES} byte cap`,
+          });
+        }
+
+        await atomicWriteTextFile(abs, nextContent);
+        return {
+          ok: true as const,
+          path: relPath,
+          replacementCount: replaceAll ? occurrences : 1,
+          previousHash: previous.sha256,
+          nextHash: sha256(nextContent),
+          bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+        };
+      } catch (err) {
+        if (err instanceof SandboxError && err.message.includes("guard")) {
+          return structuredReplaceError({
+            code: "GUARD_REJECTED",
+            path: relPath,
+            expectedHash,
+            message: err.message,
+          });
+        }
+        return structuredReplaceError({
+          code: "WRITE_FAILED",
+          path: relPath,
+          expectedHash,
+          message: errorMessage(err),
+        });
+      }
+    },
+  });
+}
+
+export const replaceTextTool = createReplaceTextTool();
+
+function countOccurrences(source: string, find: string): number {
+  if (find.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while (index <= source.length - find.length) {
+    const next = source.indexOf(find, index);
+    if (next === -1) break;
+    count += 1;
+    index = next + find.length;
+  }
+  return count;
+}
+
+function structuredReplaceError(input: {
+  code:
+    | "HASH_MISMATCH"
+    | "FIND_NOT_FOUND"
+    | "FIND_NOT_UNIQUE"
+    | "GUARD_REJECTED"
+    | "WRITE_FAILED";
+  path: string;
+  expectedHash: string;
+  currentHash?: string;
+  message: string;
+  find?: string;
+  content?: string;
+}) {
+  const diagnostics =
+    input.code === "FIND_NOT_FOUND" && input.find && input.content
+      ? {
+          findPreview: findPreview(input.find),
+          nearMatches: nearMatchesForFind(input.content, input.find),
+        }
+      : {};
+  return {
+    ok: false as const,
+    code: input.code,
+    path: input.path,
+    expectedHash: input.expectedHash,
+    ...(input.currentHash ? { currentHash: input.currentHash } : {}),
+    message: input.message,
+    error: input.message,
+    noChangesApplied: true as const,
+    ...diagnostics,
+  };
+}
+
+function compactReplaceTextModelOutput(output: unknown): JSONValue {
+  if (!isRecord(output)) {
+    return { ok: false, error: "unexpected replace_text output" };
+  }
+  if (output.ok !== true) {
+    return {
+      ok: false,
+      code: stringValue(output.code),
+      path: stringValue(output.path),
+      expectedHash: stringValue(output.expectedHash),
+      currentHash: stringValue(output.currentHash),
+      message: stringValue(output.message) || stringValue(output.error),
+      noChangesApplied: true,
+      ...(stringValue(output.findPreview)
+        ? { findPreview: stringValue(output.findPreview) }
+        : {}),
+      ...(Array.isArray(output.nearMatches)
+        ? { nearMatches: output.nearMatches.slice(0, 5) }
+        : {}),
+    };
+  }
+  return {
+    ok: true,
+    path: stringValue(output.path),
+    replacementCount: numberValue(output.replacementCount),
+    previousHash: stringValue(output.previousHash),
+    nextHash: stringValue(output.nextHash),
+    bytesWritten: numberValue(output.bytesWritten),
+  };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof SandboxError) return err.message;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/src/agent/tools/text-edits.ts
+++ b/src/agent/tools/text-edits.ts
@@ -1,0 +1,150 @@
+export type TextEdit = {
+  oldText: string;
+  newText: string;
+  replaceAll?: boolean;
+};
+
+export type ApplyTextEditsResult =
+  | { ok: true; content: string; appliedCount: number }
+  | { ok: false; index: number; code: "FIND_NOT_FOUND" | "FIND_NOT_UNIQUE"; message: string };
+
+const MODEL_DIFF_MAX_CHARS = 4_000;
+
+export function detectLineEnding(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+export function normalizeToLF(text: string): string {
+  return text.replace(/\r\n/g, "\n");
+}
+
+export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string {
+  if (ending === "\n") return text;
+  return text.replace(/\n/g, "\r\n");
+}
+
+export function applyTextEditsToContent(
+  source: string,
+  edits: readonly TextEdit[],
+): ApplyTextEditsResult {
+  const lineEnding = detectLineEnding(source);
+  let content = normalizeToLF(source);
+  let appliedCount = 0;
+
+  for (let index = 0; index < edits.length; index += 1) {
+    const edit = edits[index];
+    const normalizedOld = normalizeToLF(edit.oldText);
+    const normalizedNew = normalizeToLF(edit.newText);
+    if (normalizedOld === normalizedNew) continue;
+
+    const applied = applySingleEdit(content, {
+      oldText: normalizedOld,
+      newText: normalizedNew,
+      replaceAll: edit.replaceAll,
+    });
+    if (!applied.ok) {
+      return {
+        ok: false,
+        index,
+        code: applied.code,
+        message: formatEditFailureMessage(
+          applied.message,
+          lineEnding,
+          edit.oldText,
+        ),
+      };
+    }
+    content = applied.content;
+    appliedCount += applied.replacementCount;
+  }
+
+  return {
+    ok: true,
+    content: restoreLineEndings(content, lineEnding),
+    appliedCount,
+  };
+}
+
+function formatEditFailureMessage(
+  baseMessage: string,
+  fileLineEnding: "\r\n" | "\n",
+  oldText: string,
+): string {
+  if (
+    fileLineEnding === "\r\n" &&
+    !oldText.includes("\r\n") &&
+    oldText.includes("\n")
+  ) {
+    return `${baseMessage}; line endings were normalized, so CRLF vs LF is not the cause`;
+  }
+  return baseMessage;
+}
+
+function applySingleEdit(
+  content: string,
+  edit: TextEdit,
+):
+  | { ok: true; content: string; replacementCount: number }
+  | { ok: false; code: "FIND_NOT_FOUND" | "FIND_NOT_UNIQUE"; message: string } {
+  const replaceAll = edit.replaceAll === true;
+  const occurrences = countOccurrences(content, edit.oldText);
+  if (occurrences === 0) {
+    return {
+      ok: false,
+      code: "FIND_NOT_FOUND",
+      message: "oldText did not match file content exactly",
+    };
+  }
+  if (!replaceAll && occurrences > 1) {
+    return {
+      ok: false,
+      code: "FIND_NOT_UNIQUE",
+      message: `oldText occurs ${occurrences} times; set replaceAll: true or include more surrounding context`,
+    };
+  }
+  const next = replaceAll
+    ? content.split(edit.oldText).join(edit.newText)
+    : content.replace(edit.oldText, edit.newText);
+  return {
+    ok: true,
+    content: next,
+    replacementCount: replaceAll ? occurrences : 1,
+  };
+}
+
+function countOccurrences(source: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while (index <= source.length - needle.length) {
+    const next = source.indexOf(needle, index);
+    if (next === -1) break;
+    count += 1;
+    index = next + needle.length;
+  }
+  return count;
+}
+
+export function buildDisplayDiff(
+  oldContent: string,
+  newContent: string,
+  maxChars = MODEL_DIFF_MAX_CHARS,
+): string {
+  const oldLines = normalizeToLF(oldContent).split("\n");
+  const newLines = normalizeToLF(newContent).split("\n");
+  const maxLen = Math.max(oldLines.length, newLines.length);
+  const lines: string[] = [];
+  for (let index = 0; index < maxLen; index += 1) {
+    const oldLine = oldLines[index];
+    const newLine = newLines[index];
+    if (oldLine === newLine) {
+      if (oldLine !== undefined) lines.push(`  ${oldLine}`);
+      continue;
+    }
+    if (oldLine !== undefined) lines.push(`- ${oldLine}`);
+    if (newLine !== undefined) lines.push(`+ ${newLine}`);
+  }
+  const diff = lines.join("\n");
+  if (diff.length <= maxChars) return diff;
+  return `${diff.slice(0, maxChars)}\n… (diff truncated)`;
+}

--- a/src/agent/tools/todos.ts
+++ b/src/agent/tools/todos.ts
@@ -50,6 +50,7 @@ export function createUpdateTodosTool() {
 
       return {
         ok: true as const,
+        items: normalized,
         itemCount: normalized.length,
         completedCount,
         inProgressId: inProgress?.id ?? null,

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -1,6 +1,7 @@
-import { tool } from "ai";
+import { tool, type JSONValue } from "ai";
 import { z } from "zod";
 
+import type { AgentRunProfile } from "../loop";
 import {
   ensureWorkspaceRoot,
   ensureWorkspaceRootAt,
@@ -12,8 +13,11 @@ import {
   type PackageManager,
 } from "./package-manager";
 import { runWorkspaceProcess } from "./process";
+import {
+  compactVerifyForModel,
+  verifyDefaultsForProfile,
+} from "./model-output";
 
-const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 300_000;
 const MODEL_OUTPUT_TEXT_CAP = 8_000;
 
@@ -62,7 +66,11 @@ const DEFAULT_TARGETS: readonly VerificationTarget[] = [
   "build",
 ];
 
-export function createVerifyTool(workspaceRoot?: string) {
+export function createVerifyTool(
+  workspaceRoot?: string,
+  profile: AgentRunProfile = "general-chat",
+) {
+  const defaults = verifyDefaultsForProfile(profile);
   return tool({
     description:
       "Run the repository's available verification scripts after edits. Detects the package manager and runs typecheck, lint, and build scripts when present. Requires approval.",
@@ -71,7 +79,7 @@ export function createVerifyTool(workspaceRoot?: string) {
         .array(verificationTargetSchema)
         .min(1)
         .optional()
-        .describe("Verification targets to run. Defaults to typecheck, lint, and build."),
+        .describe("Verification targets to run. Defaults to profile-aware targets."),
       timeoutMs: z
         .number()
         .int()
@@ -79,15 +87,24 @@ export function createVerifyTool(workspaceRoot?: string) {
         .max(MAX_TIMEOUT_MS)
         .optional()
         .describe(
-          `Per-command timeout in milliseconds. Defaults to ${DEFAULT_TIMEOUT_MS}ms.`,
+          `Per-command timeout in milliseconds. Defaults to ${defaults.timeoutMs}ms for this profile.`,
         ),
+    }),
+    toModelOutput: ({ output }) => ({
+      type: "json",
+      value: compactVerifyForModel(output) as JSONValue,
     }),
     execute: async ({ targets, timeoutMs }) => {
       const root = workspaceRoot
         ? ensureWorkspaceRootAt(workspaceRoot)
         : ensureWorkspaceRoot();
+      const resolvedTargets =
+        targets ??
+        defaultTargetsForProfile(root, profile) ??
+        defaults.targets ??
+        DEFAULT_TARGETS;
       const plan = planVerification(root, {
-        targets: targets ?? DEFAULT_TARGETS,
+        targets: resolvedTargets,
       });
       if (!plan.ok) return plan;
 
@@ -115,7 +132,7 @@ export function createVerifyTool(workspaceRoot?: string) {
         }
 
         const result = await runWorkspaceProcess(file, args, root, {
-          timeoutMs: timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          timeoutMs: timeoutMs ?? defaults.timeoutMs,
         });
         const ok = result.exitCode === 0;
         results.push({
@@ -158,6 +175,20 @@ export function createVerifyTool(workspaceRoot?: string) {
       };
     },
   });
+}
+
+function defaultTargetsForProfile(
+  workspaceRoot: string,
+  profile: AgentRunProfile,
+): readonly VerificationTarget[] | undefined {
+  if (profile !== "localized-edit") return undefined;
+  const packageJson = readPackageJson(workspaceRoot);
+  if (!packageJson.ok) return ["lint"];
+  const scripts = packageJson.value.scripts ?? {};
+  const hasTypecheck =
+    typeof scripts.typecheck === "string" ||
+    typeof scripts["type-check"] === "string";
+  return hasTypecheck ? ["typecheck"] : ["lint"];
 }
 
 function capOutput(value: string): string {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -107,6 +107,22 @@ export type ProjectRunDetailsStepUsage = {
   finishReason?: string;
 };
 
+export type ProjectRunDetailsPromptCache = {
+  modelId: string;
+  providerId: string;
+  systemPromptHash: string;
+  toolSchemaHash: string;
+  nativeToolNamesHash: string;
+  mcpToolNamesHash: string;
+  workspaceContextHash: string;
+  messagePrefixHash: string;
+  cachedInputTokens?: number;
+  cacheWriteTokens?: number;
+  cacheHitRate?: number;
+  likelyCacheMissReasons: string[];
+  cacheBreakReasons: string[];
+};
+
 export type ProjectRunDetailsTokenUsage = {
   rawInputTokens?: number;
   uncachedInputTokens?: number;
@@ -137,6 +153,15 @@ export type ProjectRunDetailsRun = {
   tokenUsage?: ProjectRunDetailsTokenUsage;
   contextComposition?: ProjectRunDetailsContextComposition;
   stepUsage?: ProjectRunDetailsStepUsage[];
+  promptCache?: ProjectRunDetailsPromptCache;
+  profile?: string | null;
+  mode?: string | null;
+  tokenBudgetMultiplier?: number | null;
+  cacheHitRate?: number | null;
+  loopGuardCount?: number | null;
+  verificationSummary?: string | null;
+  rawTotalTokens?: number | null;
+  effectiveTokens?: number | null;
 };
 
 export type ProjectRunDetailsEvent = {

--- a/src/lib/run-details-serializers.ts
+++ b/src/lib/run-details-serializers.ts
@@ -20,6 +20,7 @@ import type {
   ProjectRunDetailsContextFile,
   ProjectRunDetailsContextTool,
   ProjectRunDetailsEvent,
+  ProjectRunDetailsPromptCache,
   ProjectRunDetailsRun,
   ProjectRunDetailsStepUsage,
   ProjectRunDetailsSummary,
@@ -103,9 +104,13 @@ function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
     : null;
   const contextComposition = contextCompositionFromTokenAudit(tokenAudit);
   const stepUsage = stepUsageFromTokenAudit(tokenAudit);
+  const promptCache = promptCacheFromTokenAudit(tokenAudit);
   const reasoningTokens = finiteNumber(
     isRecord(tokenAudit?.usage) ? tokenAudit.usage.reasoningTokens : undefined,
   );
+  const execution = isRecord(costMetadata?.execution)
+    ? costMetadata.execution
+    : null;
 
   return {
     id: run.id,
@@ -157,6 +162,38 @@ function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
       : {}),
     ...(contextComposition ? { contextComposition } : {}),
     ...(stepUsage.length > 0 ? { stepUsage } : {}),
+    ...(promptCache ? { promptCache } : {}),
+    ...(typeof execution?.profile === "string" ? { profile: execution.profile } : {}),
+    ...(typeof execution?.mode === "string" ? { mode: execution.mode } : {}),
+    ...(finiteNumber(execution?.tokenBudgetMultiplier) !== undefined
+      ? { tokenBudgetMultiplier: finiteNumber(execution?.tokenBudgetMultiplier) }
+      : {}),
+    ...(finiteNumber(execution?.cacheHitRate) !== undefined
+      ? { cacheHitRate: finiteNumber(execution?.cacheHitRate) }
+      : {}),
+    ...(finiteNumber(execution?.loopGuardCount) !== undefined
+      ? { loopGuardCount: finiteNumber(execution?.loopGuardCount) }
+      : {}),
+    ...(typeof execution?.verificationSummary === "string"
+      ? { verificationSummary: execution.verificationSummary }
+      : {}),
+    ...(typeof execution?.promotionReason === "string"
+      ? { promotionReason: execution.promotionReason }
+      : {}),
+    ...(typeof execution?.effectiveProfile === "string"
+      ? { effectiveProfile: execution.effectiveProfile }
+      : {}),
+    ...(execution?.hadSuccessfulEdit === true || execution?.hadSuccessfulEdit === false
+      ? { hadSuccessfulEdit: execution.hadSuccessfulEdit === true }
+      : {}),
+    ...(tokenUsage?.rawTotalTokens !== undefined
+      ? { rawTotalTokens: tokenUsage.rawTotalTokens }
+      : run.totalTokens !== null
+        ? { rawTotalTokens: run.totalTokens }
+        : {}),
+    ...(tokenUsage?.effectiveTokens !== undefined
+      ? { effectiveTokens: tokenUsage.effectiveTokens }
+      : {}),
   };
 }
 
@@ -395,6 +432,42 @@ function stepUsageFromTokenAudit(
       },
     ];
   });
+}
+
+function promptCacheFromTokenAudit(
+  tokenAudit: Record<string, unknown> | null,
+): ProjectRunDetailsPromptCache | undefined {
+  if (!tokenAudit || !isRecord(tokenAudit.promptCache)) return undefined;
+  const cache = tokenAudit.promptCache;
+  const modelId = stringValue(cache.modelId);
+  const providerId = stringValue(cache.providerId);
+  if (!modelId || !providerId) return undefined;
+  const likelyCacheMissReasons = Array.isArray(cache.likelyCacheMissReasons)
+    ? cache.likelyCacheMissReasons.flatMap((reason) =>
+        typeof reason === "string" ? [reason] : [],
+      )
+    : [];
+  return {
+    modelId,
+    providerId,
+    systemPromptHash: stringValue(cache.systemPromptHash) ?? "—",
+    toolSchemaHash: stringValue(cache.toolSchemaHash) ?? "—",
+    nativeToolNamesHash: stringValue(cache.nativeToolNamesHash) ?? "—",
+    mcpToolNamesHash: stringValue(cache.mcpToolNamesHash) ?? "—",
+    workspaceContextHash: stringValue(cache.workspaceContextHash) ?? "—",
+    messagePrefixHash: stringValue(cache.messagePrefixHash) ?? "—",
+    ...(finiteNumber(cache.cachedInputTokens) !== undefined
+      ? { cachedInputTokens: finiteNumber(cache.cachedInputTokens) }
+      : {}),
+    ...(finiteNumber(cache.cacheWriteTokens) !== undefined
+      ? { cacheWriteTokens: finiteNumber(cache.cacheWriteTokens) }
+      : {}),
+    ...(finiteNumber(cache.cacheHitRate) !== undefined
+      ? { cacheHitRate: finiteNumber(cache.cacheHitRate) }
+      : {}),
+    likelyCacheMissReasons,
+    cacheBreakReasons: stringArray(cache.cacheBreakReasons),
+  };
 }
 
 function finiteNumber(value: unknown): number | undefined {

--- a/src/lib/tool-summaries.ts
+++ b/src/lib/tool-summaries.ts
@@ -75,7 +75,7 @@ export function summarizeToolOutput(
   }
 
   if (
-    (toolName === "write_file" || toolName === "edit_file") &&
+    (toolName === "write_file" || toolName === "edit_file" || toolName === "edit_text" || toolName === "replace_text" || toolName === "replace_lines" || toolName === "multi_replace_text") &&
     output.ok === true
   ) {
     const bytesWritten = numberValue(output.bytesWritten);

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -55,6 +55,8 @@ export type AntonRunData = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  rawTotalTokens?: number;
+  effectiveTokens?: number;
   costUsd?: number;
   costMetadata?: Record<string, unknown> | null;
   stepCount?: number;
@@ -63,6 +65,15 @@ export type AntonRunData = {
   maxStepLimitReached?: boolean;
   maxCostUsd?: number;
   costBudgetReached?: boolean;
+  profile?: string;
+  mode?: string;
+  tokenBudgetMultiplier?: number;
+  cacheHitRate?: number;
+  loopGuardCount?: number;
+  verificationSummary?: string;
+  promotionReason?: string;
+  effectiveProfile?: string;
+  hadSuccessfulEdit?: boolean;
 };
 
 export type AntonRunMetricSnapshot = {
@@ -127,17 +138,22 @@ export type AntonTodoSnapshot = {
   updatedAt: number;
 };
 
-export type TokenBudgetMultiplierOption = 2 | 3 | 5;
+export type TokenBudgetMultiplierOption = 2 | 3;
 
 export type AntonBudgetGateData = {
   runId: string;
   status: "open" | "resolved" | "exhausted";
   tokensUsed: number;
+  effectiveTokensUsed?: number;
+  cachedInputTokens?: number;
+  uncachedInputTokens?: number;
   baseMaxTotalTokens: number;
   currentMaxTotalTokens: number;
+  currentMaxEffectiveTokens?: number;
   currentMultiplier: number;
   options: readonly TokenBudgetMultiplierOption[];
   selectedMultiplier?: TokenBudgetMultiplierOption;
+  lastFailedToolReason?: string;
 };
 
 export type AntonDataParts = {
@@ -321,6 +337,8 @@ export function hasFailedToolOutput(message: AntonUIMessage): boolean {
 
 export function failedToolOutputMessage(output: unknown): string | undefined {
   if (!isRecord(output)) return undefined;
+  const message = output.message;
+  if (typeof message === "string" && message.trim().length > 0) return message.trim();
   const error = output.error;
   if (typeof error === "string" && error.trim().length > 0) return error.trim();
   const failedReason = output.failedReason;
@@ -332,6 +350,43 @@ export function failedToolOutputMessage(output: unknown): string | undefined {
     return `Command exited with code ${exitCode}.`;
   }
   return undefined;
+}
+
+const STATE_CHANGING_TOOL_NAMES = new Set([
+  "edit_file",
+  "edit_text",
+  "replace_text",
+  "replace_lines",
+  "multi_replace_text",
+  "write_file",
+]);
+
+export function messageHadSuccessfulStateChangingEdit(
+  message: AntonUIMessage,
+): boolean {
+  return getToolTraceEntries([message]).some((entry) => {
+    if (entry.state !== "output-available") return false;
+    if (!STATE_CHANGING_TOOL_NAMES.has(entry.name)) return false;
+    return isRecord(entry.output) && entry.output.ok === true;
+  });
+}
+
+export function messageIsLoopGuardIncomplete(message: AntonUIMessage): boolean {
+  return getRunDataList(message).some(
+    (run) => run.finishReason === "loop_guard_incomplete",
+  );
+}
+
+export function messageIsUnverifiedEdit(message: AntonUIMessage): boolean {
+  return getRunDataList(message).some(
+    (run) => run.finishReason === "unverified_edit",
+  );
+}
+
+export function messageIsVerificationFailed(message: AntonUIMessage): boolean {
+  return getRunDataList(message).some(
+    (run) => run.finishReason === "verification_failed",
+  );
 }
 
 function isFailedToolOutput(output: unknown): boolean {
@@ -1206,15 +1261,18 @@ export function cumulativeRunCostUsd(message: AntonUIMessage): number {
 export function priorSegmentUsage(
   message: AntonUIMessage,
   excludeRunId?: string,
-): { tokensUsed: number; costUsd: number } {
+): { tokensUsed: number; effectiveTokensUsed: number; costUsd: number } {
   return getRunDataList(message)
     .filter((run) => run.runId !== excludeRunId)
     .reduce(
       (totals, run) => ({
-        tokensUsed: totals.tokensUsed + (run.totalTokens ?? 0),
+        tokensUsed: totals.tokensUsed + (run.rawTotalTokens ?? run.totalTokens ?? 0),
+        effectiveTokensUsed:
+          totals.effectiveTokensUsed +
+          (run.effectiveTokens ?? run.totalTokens ?? 0),
         costUsd: totals.costUsd + (run.costUsd ?? 0),
       }),
-      { tokensUsed: 0, costUsd: 0 },
+      { tokensUsed: 0, effectiveTokensUsed: 0, costUsd: 0 },
     );
 }
 


### PR DESCRIPTION
﻿## Summary
- Adds task-scale execution profiles, active tool filtering, and localized edit tooling so small coding tasks avoid broad-agent overhead.
- Improves edit recovery with targeted diagnostics, text replacement tools, post-edit linting, and clearer failed/unverified verification states.
- Adds cache-aware budget tracking, prompt-cache audit telemetry, continuation/profile metadata, provider routing defaults, and run-trace usage UI.
- Marks roadmap item #118 complete.

## Why
Recent traces showed simple edit tasks escalating into broad exploration after edit failures and loop guards, causing token waste and poor cache behavior. This change keeps the stable prompt/tool prefix smaller for localized tasks, promotes only when behavior indicates the task needs it, and makes edit failures actionable without forcing unnecessary verification loops.

## Verification
- `pnpm typecheck` passed
- `pnpm lint` passed

## Notes
Visual verification was not run because this is primarily harness/control-plane work. The run-trace UI changes were typechecked and linted with the rest of the branch.
