### PR TITLE
[codex] Add cache-first profile handoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # OpenRouter API key — create one at https://openrouter.ai/keys
 OPENROUTER_API_KEY=sk-or-v1-...
 
-# Default model (OpenRouter slug). See https://openrouter.ai/models
-DEFAULT_MODEL=anthropic/claude-sonnet-4.5
+# OpenCode Go API key — subscribe at https://opencode.ai/auth
+OPENCODE_GO_API_KEY=sk-...
+
+# Default model (provider-qualified id). See https://opencode.ai/docs/go/#endpoints
+DEFAULT_MODEL=opencode-go/deepseek-v4-flash
 
 # Absolute path to the directory the agent is allowed to read/write/bash in.
 # Defaults to ./workspace (created if missing).

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -66,6 +66,7 @@ import {
   getSession,
   getWorkspaceSettings,
   getToolCall,
+  listRunsForSession,
   MessagePersistenceConflictError,
   saveMessagesIncrementally,
   sessionHasStoredMessages,
@@ -80,7 +81,7 @@ import {
 } from "@/src/db/queries";
 import { registerActiveChatStream } from "@/src/lib/chat-stream-registry";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
-import { isSupportedModelId } from "@/src/lib/models";
+import { isSupportedModelId, getProviderId, resolveModelId } from "@/src/lib/models";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import { redactText, redactValue } from "@/src/lib/redaction";
 import {
@@ -136,6 +137,11 @@ const bodySchema = z.object({
       multiplier: z.union([z.literal(2), z.literal(3)]),
     })
     .optional(),
+  continueProfileHandoff: z
+    .object({
+      runId: z.string().min(1),
+    })
+    .optional(),
   messages: z.array(z.unknown()).min(1),
 });
 
@@ -153,21 +159,37 @@ export async function POST(req: Request) {
   const uiMessages = parsed.data.messages as AntonUIMessage[];
   const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
   const budgetExtension = parsed.data.extendTokenBudget;
+  const profileHandoffContinuation = parsed.data.continueProfileHandoff;
+  if (budgetExtension && profileHandoffContinuation) {
+    return Response.json(
+      { error: "choose either token budget continuation or profile handoff continuation" },
+      { status: 400 },
+    );
+  }
   const isBudgetContinuation = budgetExtension !== undefined;
+  const isProfileHandoffContinuation =
+    profileHandoffContinuation !== undefined;
   const approvalContinuation =
-    !isBudgetContinuation && isToolApprovalContinuation(incomingHistory);
-  const mode = approvalContinuation
+    !isBudgetContinuation &&
+    !isProfileHandoffContinuation &&
+    isToolApprovalContinuation(incomingHistory);
+  const mode = approvalContinuation || isProfileHandoffContinuation
     ? "agent"
     : parsed.data.mode ?? DEFAULT_CHAT_MODE;
   const budgetContinuationRun =
     isBudgetContinuation && budgetExtension
       ? getRunById(budgetExtension.runId)
       : undefined;
+  const profileHandoffRun =
+    isProfileHandoffContinuation && profileHandoffContinuation
+      ? getRunById(profileHandoffContinuation.runId)
+      : undefined;
   const profile = resolveRunProfile({
     mode,
     messages: incomingHistory,
     approvalContinuation,
     budgetContinuationRun,
+    profileHandoffRun,
   });
   const needsProject = mode !== "chat";
   const requestBodyBytes = byteLength(JSON.stringify(json ?? {}));
@@ -184,13 +206,14 @@ export async function POST(req: Request) {
     : undefined;
   const continuationModel =
     executionModelFromCostMetadata(budgetContinuationRun?.costMetadata) ??
+    executionModelFromCostMetadata(profileHandoffRun?.costMetadata) ??
     executionModelFromCostMetadata(approvalContinuationRun?.costMetadata);
-  const model = continuationModel ?? requestedModel;
+  const model = resolveModelId(continuationModel ?? requestedModel);
   const modelSelectionNote =
     continuationModel && continuationModel !== requestedModel
       ? `UI selected ${requestedModel}, but this continuation reused ${continuationModel} from the originating run.`
       : undefined;
-  if (!isSupportedModelId(model)) {
+  if (!isSupportedModelId(continuationModel ?? requestedModel)) {
     return Response.json(
       { error: "unsupported model", model },
       { status: 400 },
@@ -228,6 +251,34 @@ export async function POST(req: Request) {
       return Response.json(
         { error: "requested token budget multiplier is not available" },
         { status: 400 },
+      );
+    }
+  }
+
+  if (isProfileHandoffContinuation) {
+    if (
+      !profileHandoffRun ||
+      profileHandoffRun.sessionId !== sessionId ||
+      !runEligibleForProfileHandoffContinuation(profileHandoffRun)
+    ) {
+      return Response.json(
+        { error: "profile handoff continuation requires a completed handoff run in this session" },
+        { status: 400 },
+      );
+    }
+    const existingContinuation = listRunsForSession(sessionId).find(
+      (run) =>
+        run.id !== profileHandoffRun.id &&
+        profileHandoffContinuationOfRunId(run.costMetadata) ===
+          profileHandoffRun.id,
+    );
+    if (existingContinuation) {
+      return Response.json(
+        {
+          error: "profile handoff continuation already started",
+          runId: existingContinuation.id,
+        },
+        { status: 409 },
       );
     }
   }
@@ -281,9 +332,11 @@ export async function POST(req: Request) {
   } else {
     const conflict = getMessagePersistenceConflict(sessionId, incomingHistory, {
       mutableTailCount:
-        approvalContinuation || isBudgetContinuation ? 1 : 0,
+        approvalContinuation || isBudgetContinuation || isProfileHandoffContinuation
+          ? 1
+          : 0,
       allowExtraAssistantTail:
-        approvalContinuation || isBudgetContinuation,
+        approvalContinuation || isBudgetContinuation || isProfileHandoffContinuation,
     });
     if (conflict) {
       return Response.json(
@@ -324,26 +377,43 @@ export async function POST(req: Request) {
     );
   }
 
+  const originatingTokenBudgetMultiplier =
+    isProfileHandoffContinuation && profileHandoffRun
+      ? tokenBudgetMultiplierFromCostMetadata(profileHandoffRun.costMetadata)
+      : undefined;
   const tokenBudgetMultiplier = isBudgetContinuation
     ? Math.max(
         existing?.tokenBudgetMultiplier ?? 1,
         budgetExtension.multiplier,
       )
-    : existing?.tokenBudgetMultiplier ?? 1;
+    : originatingTokenBudgetMultiplier ?? existing?.tokenBudgetMultiplier ?? 1;
 
   if (isBudgetContinuation) {
     setSessionTokenBudgetMultiplier(sessionId, tokenBudgetMultiplier);
   }
+  const permissionMode =
+    (isProfileHandoffContinuation && profileHandoffRun
+      ? permissionModeFromCostMetadata(profileHandoffRun.costMetadata)
+      : undefined) ??
+    parsed.data.permissionMode ??
+    workspaceSettings.defaultPermissionMode ??
+    "auto-review";
+  const thinkingEnabled =
+    (isProfileHandoffContinuation && profileHandoffRun
+      ? thinkingEnabledFromCostMetadata(profileHandoffRun.costMetadata)
+      : undefined) ??
+    parsed.data.thinkingEnabled ??
+    false;
 
   const baseBudget = applyThinkingBudgetAdjustment(
     applyTokenBudgetMultiplier(
       capRunBudget(budgetForProfile(profile), workspaceSettings.defaultMaxSteps),
       tokenBudgetMultiplier,
     ),
-    parsed.data.thinkingEnabled ?? false,
+    thinkingEnabled,
   );
   const budget = baseBudget;
-  const continuationAssistant = isBudgetContinuation
+  const continuationAssistant = isBudgetContinuation || isProfileHandoffContinuation
     ? incomingHistory.findLast((message) => message.role === "assistant")
     : undefined;
   const priorUsage = continuationAssistant
@@ -353,14 +423,24 @@ export async function POST(req: Request) {
     ? priorToolRecordsFromAssistantMessage(continuationAssistant)
     : [];
   const previousPromptCacheAudit = promptCacheAuditFromCostMetadata(
-    budgetContinuationRun?.costMetadata ?? approvalContinuationRun?.costMetadata,
+    budgetContinuationRun?.costMetadata ??
+      profileHandoffRun?.costMetadata ??
+      approvalContinuationRun?.costMetadata,
   );
   const continuationNote = isBudgetContinuation
     ? budgetContinuationHandoffNote()
-    : undefined;
+    : isProfileHandoffContinuation && profileHandoffRun
+      ? profileHandoffContinuationNote(profileHandoffRun.costMetadata)
+      : undefined;
+  const promptCacheIntentionalSegmentTransition =
+    isProfileHandoffContinuation && profileHandoffRun
+      ? profileHandoffTransitionLabel(profileHandoffRun.costMetadata)
+      : undefined;
+  const isSegmentContinuation =
+    isBudgetContinuation || isProfileHandoffContinuation;
   const userText = latestUserText(uiMessages);
   const sessionContextDigest =
-    mode === "chat" || isBudgetContinuation
+    mode === "chat" || isSegmentContinuation
       ? undefined
       : buildSessionContextDigest({
           sessionId,
@@ -368,7 +448,7 @@ export async function POST(req: Request) {
           budgetChars: budget.priorRunContextChars,
         });
   const workspaceContextDigest =
-    mode === "chat" || isBudgetContinuation
+    mode === "chat" || isSegmentContinuation
       ? undefined
       : buildWorkspaceContextDigest({
           workspaceRoot: project?.localPath,
@@ -377,6 +457,7 @@ export async function POST(req: Request) {
         });
   const contextDigestBytes = byteLength(
     isBudgetContinuation
+    || isProfileHandoffContinuation
       ? (continuationNote ?? "")
       : (modelOnlyContextMessageText({
           sessionContextDigest,
@@ -386,12 +467,12 @@ export async function POST(req: Request) {
   const preservation = modelContextPreservation(
     uiMessages,
     profile,
-    isBudgetContinuation,
+    isSegmentContinuation,
   );
   const preparedMessages = prepareMessagesForModel(
     uiMessages,
     profile,
-    isBudgetContinuation,
+    isSegmentContinuation,
   );
   const contextBudget = budgetMessagesForModel({
     messages: preparedMessages,
@@ -415,7 +496,7 @@ export async function POST(req: Request) {
     id: runId,
     sessionId,
     model,
-    provider: "openrouter",
+    provider: getProviderId(model),
     status: "running",
     startedAt: new Date(startedAt),
     stepCount: 0,
@@ -425,6 +506,13 @@ export async function POST(req: Request) {
         mode,
         model,
         tokenBudgetMultiplier,
+        permissionMode,
+        thinkingEnabled,
+        ...(profileHandoffRun
+          ? {
+              profileHandoffContinuationOfRunId: profileHandoffRun.id,
+            }
+          : {}),
       },
     },
   });
@@ -435,6 +523,7 @@ export async function POST(req: Request) {
     startedAt,
   );
   const modelMessages = isBudgetContinuation
+    || isProfileHandoffContinuation
     ? appendModelOnlyContextMessage(convertedMessages, continuationNote ?? "")
     : addModelOnlyContextMessage(convertedMessages, {
         sessionContextDigest,
@@ -478,6 +567,9 @@ export async function POST(req: Request) {
         workspaceRoot: project?.localPath,
         responseKind: mode === "plan" ? "plan" : undefined,
         tokenBudgetMultiplier,
+        permissionMode,
+        thinkingEnabled,
+        profileHandoffContinuationOfRunId: profileHandoffRun?.id,
         tokenBudgetContext: {
           baseMaxTotalTokens: baseBudget.maxTotalTokens,
           baseMaxEffectiveTokens: baseBudget.maxEffectiveTokens,
@@ -501,7 +593,7 @@ export async function POST(req: Request) {
           profile,
           requestBodyBytes,
           contextBudget: contextBudget.report,
-          thinkingEnabled: parsed.data.thinkingEnabled ?? false,
+          thinkingEnabled,
           maxStepsCap: workspaceSettings.defaultMaxSteps,
           tokenBudgetMultiplier,
           priorTokensUsed: priorUsage.tokensUsed,
@@ -509,9 +601,8 @@ export async function POST(req: Request) {
           priorCostUsd: priorUsage.costUsd,
           priorToolHistory,
           previousPromptCacheAudit,
-          permissionMode: parsed.data.permissionMode as
-            | PermissionMode
-            | undefined,
+          promptCacheIntentionalSegmentTransition,
+          permissionMode,
           enabledMcpServerIds: parsed.data.enabledMcpServerIds,
           onStepStart: ({ stepNumber }) => trace.startStep(stepNumber),
           onStepFinish: ({ stepNumber }) => trace.finishStep(stepNumber),
@@ -553,13 +644,18 @@ export async function POST(req: Request) {
             loopGuardIncomplete,
             unverifiedEdit,
             verificationFailed,
+            profileHandoffRequired,
+            profileHandoff,
             tokenAudit,
           }) => {
-            const hardLimitReached = maxStepLimitReached || costBudgetReached;
+            const hardLimitReached =
+              !profileHandoffRequired &&
+              (maxStepLimitReached || costBudgetReached);
             const incompleteRun =
-              loopGuardIncomplete === true ||
-              unverifiedEdit === true ||
-              verificationFailed === true;
+              !profileHandoffRequired &&
+              (loopGuardIncomplete === true ||
+                unverifiedEdit === true ||
+                verificationFailed === true);
             contextTerminalStatus = hardLimitReached || incompleteRun ? "error" : "completed";
             trace.finalize(
               tokenBudgetReached
@@ -585,6 +681,8 @@ export async function POST(req: Request) {
                 loopGuardIncomplete: incompleteRun,
                 unverifiedEdit,
                 verificationFailed,
+                profileHandoffRequired,
+                profileHandoff,
                 tokenAudit,
                 stepProviderMetadata,
               },
@@ -623,6 +721,7 @@ export async function POST(req: Request) {
         const approvalContinuation =
           isToolApprovalContinuation(persistedMessages);
         const budgetContinuation = isBudgetContinuation;
+        const profileHandoffContinuationPersisted = isProfileHandoffContinuation;
         const collapsedContinuations =
           persistedMessages.length < visibleMessages.length;
         saveMessagesIncrementally<AntonUIMessage>(
@@ -630,7 +729,10 @@ export async function POST(req: Request) {
           redactValue(persistedMessages) as AntonUIMessage[],
           {
             pruneExtraAssistantTail:
-              approvalContinuation || budgetContinuation || collapsedContinuations,
+              approvalContinuation ||
+              budgetContinuation ||
+              profileHandoffContinuationPersisted ||
+              collapsedContinuations,
           },
         );
         contextCollector.persist({
@@ -973,6 +1075,9 @@ function createTraceWriter({
   workspaceRoot,
   responseKind,
   tokenBudgetMultiplier,
+  permissionMode,
+  thinkingEnabled,
+  profileHandoffContinuationOfRunId,
   tokenBudgetContext,
 }: {
   writer: UIMessageStreamWriter<AntonUIMessage>;
@@ -984,6 +1089,9 @@ function createTraceWriter({
   workspaceRoot?: string;
   responseKind?: "plan";
   tokenBudgetMultiplier: number;
+  permissionMode: PermissionMode;
+  thinkingEnabled: boolean;
+  profileHandoffContinuationOfRunId?: string;
   tokenBudgetContext: {
     baseMaxTotalTokens: number;
     baseMaxEffectiveTokens: number;
@@ -1000,7 +1108,7 @@ function createTraceWriter({
   let stateChangingEditSucceeded = false;
   let latestFailedToolReason: string | undefined;
   let promotionReason: string | undefined;
-  let effectiveProfile: AgentRunProfile = profile;
+  const effectiveProfile: AgentRunProfile = profile;
   const events = new Map<string, AntonActivityEvent>();
   const reasoningBuffers = new Map<string, string>();
 
@@ -1222,6 +1330,8 @@ function createTraceWriter({
       loopGuardIncomplete?: boolean;
       unverifiedEdit?: boolean;
       verificationFailed?: boolean;
+      profileHandoffRequired?: boolean;
+      profileHandoff?: ProfilePromotionEvent;
       tokenAudit?: TokenAudit;
       stepProviderMetadata?: ProviderMetadata[];
     } = {},
@@ -1262,6 +1372,9 @@ function createTraceWriter({
         mode,
         model,
         tokenBudgetMultiplier,
+        permissionMode,
+        thinkingEnabled,
+        profileHandoffContinuationOfRunId,
         loopGuardCount:
           limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
         verificationSummary,
@@ -1271,10 +1384,16 @@ function createTraceWriter({
         effectiveProfile:
           limits.tokenAudit?.effectiveProfile ?? effectiveProfile,
         hadSuccessfulEdit: stateChangingEditSucceeded,
+        profileHandoffRequired: limits.profileHandoffRequired,
+        handoffFromProfile: limits.profileHandoff?.fromProfile,
+        handoffToProfile: limits.profileHandoff?.toProfile,
+        handoffReason: limits.profileHandoff?.reason,
       },
     );
-    const storedFinishReason = limits.maxStepLimitReached
-      ? "max_step_limit"
+    const storedFinishReason = limits.profileHandoffRequired
+        ? "profile_handoff_required"
+      : limits.maxStepLimitReached
+        ? "max_step_limit"
       : limits.tokenBudgetReached
         ? "token_budget_limit"
       : limits.verificationFailed
@@ -1309,6 +1428,14 @@ function createTraceWriter({
       cacheHitRate: limits.tokenAudit?.promptCache?.cacheHitRate,
       loopGuardCount: limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
       verificationSummary,
+      ...(limits.profileHandoffRequired
+        ? {
+            profileHandoffRequired: true,
+            handoffFromProfile: limits.profileHandoff?.fromProfile,
+            handoffToProfile: limits.profileHandoff?.toProfile,
+            handoffReason: limits.profileHandoff?.reason,
+          }
+        : {}),
       ...(limits.tokenAudit?.promotionReason ?? promotionReason
         ? {
             promotionReason:
@@ -1486,15 +1613,14 @@ function createTraceWriter({
     },
     noteProfilePromotion(event: ProfilePromotionEvent) {
       promotionReason = event.reason;
-      effectiveProfile = event.toProfile;
       startEvent({
         id: `${runId}:profile-promotion:${sequence + 1}`,
         kind: "progress",
         status: "completed",
-        label: "Fast-edit promoted to Agent",
+        label: "Fast-edit needs full Agent segment",
         summary: event.reason,
         details: {
-          promotion: {
+          profileHandoff: {
             fromProfile: event.fromProfile,
             toProfile: event.toProfile,
             reason: event.reason,
@@ -1876,12 +2002,19 @@ function runCostMetadata(
     mode: AgentRunMode;
     model: string;
     tokenBudgetMultiplier: number;
+    permissionMode: PermissionMode;
+    thinkingEnabled: boolean;
+    profileHandoffContinuationOfRunId?: string;
     loopGuardCount: number;
     verificationSummary?: string;
     cacheHitRate?: number;
     promotionReason?: string;
     effectiveProfile?: AgentRunProfile;
     hadSuccessfulEdit?: boolean;
+    profileHandoffRequired?: boolean;
+    handoffFromProfile?: "localized-edit";
+    handoffToProfile?: "general-chat";
+    handoffReason?: string;
   },
 ): Record<string, unknown> | null {
   const providerCostMetadata = openRouterCostMetadata(
@@ -1904,6 +2037,14 @@ function runCostMetadata(
         mode: execution.mode,
         model: execution.model,
         tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
+        permissionMode: execution.permissionMode,
+        thinkingEnabled: execution.thinkingEnabled,
+        ...(execution.profileHandoffContinuationOfRunId
+          ? {
+              profileHandoffContinuationOfRunId:
+                execution.profileHandoffContinuationOfRunId,
+            }
+          : {}),
         loopGuardCount: execution.loopGuardCount,
         ...(execution.verificationSummary
           ? { verificationSummary: execution.verificationSummary }
@@ -1920,6 +2061,18 @@ function runCostMetadata(
         ...(execution.hadSuccessfulEdit !== undefined
           ? { hadSuccessfulEdit: execution.hadSuccessfulEdit }
           : {}),
+        ...(execution.profileHandoffRequired !== undefined
+          ? { profileHandoffRequired: execution.profileHandoffRequired }
+          : {}),
+        ...(execution.handoffFromProfile
+          ? { handoffFromProfile: execution.handoffFromProfile }
+          : {}),
+        ...(execution.handoffToProfile
+          ? { handoffToProfile: execution.handoffToProfile }
+          : {}),
+        ...(execution.handoffReason
+          ? { handoffReason: execution.handoffReason }
+          : {}),
       },
       costBudget: costBudgetMetadata,
     }) as Record<string, unknown>;
@@ -1933,6 +2086,14 @@ function runCostMetadata(
       mode: execution.mode,
       model: execution.model,
       tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
+      permissionMode: execution.permissionMode,
+      thinkingEnabled: execution.thinkingEnabled,
+      ...(execution.profileHandoffContinuationOfRunId
+        ? {
+            profileHandoffContinuationOfRunId:
+              execution.profileHandoffContinuationOfRunId,
+          }
+        : {}),
       loopGuardCount: execution.loopGuardCount,
       ...(execution.verificationSummary
         ? { verificationSummary: execution.verificationSummary }
@@ -1948,6 +2109,18 @@ function runCostMetadata(
         : {}),
       ...(execution.hadSuccessfulEdit !== undefined
         ? { hadSuccessfulEdit: execution.hadSuccessfulEdit }
+        : {}),
+      ...(execution.profileHandoffRequired !== undefined
+        ? { profileHandoffRequired: execution.profileHandoffRequired }
+        : {}),
+      ...(execution.handoffFromProfile
+        ? { handoffFromProfile: execution.handoffFromProfile }
+        : {}),
+      ...(execution.handoffToProfile
+        ? { handoffToProfile: execution.handoffToProfile }
+        : {}),
+      ...(execution.handoffReason
+        ? { handoffReason: execution.handoffReason }
         : {}),
     },
     costBudget: costBudgetMetadata,
@@ -1971,17 +2144,40 @@ function runEligibleForBudgetContinuation(run: {
   return tokenAudit?.tokenBudgetReached === true;
 }
 
+function runEligibleForProfileHandoffContinuation(run: {
+  status: string;
+  finishReason: string | null;
+  costMetadata: unknown;
+}): boolean {
+  if (run.status !== "completed") return false;
+  if (run.finishReason !== "profile_handoff_required") return false;
+  const handoff = profileHandoffFromCostMetadata(run.costMetadata);
+  return (
+    handoff.profileHandoffRequired === true &&
+    handoff.handoffFromProfile === "localized-edit" &&
+    handoff.handoffToProfile === "general-chat"
+  );
+}
+
 function resolveRunProfile({
   mode,
   messages,
   approvalContinuation,
   budgetContinuationRun,
+  profileHandoffRun,
 }: {
   mode: ChatMode;
   messages: AntonUIMessage[];
   approvalContinuation: boolean;
   budgetContinuationRun: ReturnType<typeof getRunById> | undefined;
+  profileHandoffRun: ReturnType<typeof getRunById> | undefined;
 }): AgentRunProfile {
+  if (profileHandoffRun) {
+    return (
+      profileHandoffFromCostMetadata(profileHandoffRun.costMetadata)
+        .handoffToProfile ?? classifyRunProfile(mode, latestUserText(messages))
+    );
+  }
   if (approvalContinuation) {
     const runId = runIdFromAssistantMessage(messages.at(-1));
     const originatingRun = runId ? getRunById(runId) : undefined;
@@ -1998,6 +2194,101 @@ function resolveRunProfile({
     );
   }
   return classifyRunProfile(mode, latestUserText(messages));
+}
+
+function profileHandoffFromCostMetadata(costMetadata: unknown): {
+  profileHandoffRequired?: boolean;
+  handoffFromProfile?: "localized-edit";
+  handoffToProfile?: "general-chat";
+  handoffReason?: string;
+} {
+  if (!isRecord(costMetadata)) return {};
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  if (!execution) return {};
+  return {
+    ...(execution.profileHandoffRequired === true
+      ? { profileHandoffRequired: true }
+      : {}),
+    ...(execution.handoffFromProfile === "localized-edit"
+      ? { handoffFromProfile: "localized-edit" as const }
+      : {}),
+    ...(execution.handoffToProfile === "general-chat"
+      ? { handoffToProfile: "general-chat" as const }
+      : {}),
+    ...(typeof execution.handoffReason === "string"
+      ? { handoffReason: execution.handoffReason }
+      : {}),
+  };
+}
+
+function profileHandoffContinuationOfRunId(
+  costMetadata: unknown,
+): string | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const runId = execution?.profileHandoffContinuationOfRunId;
+  return typeof runId === "string" && runId.length > 0 ? runId : undefined;
+}
+
+function tokenBudgetMultiplierFromCostMetadata(
+  costMetadata: unknown,
+): number | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const multiplier = execution?.tokenBudgetMultiplier;
+  return typeof multiplier === "number" && Number.isFinite(multiplier)
+    ? Math.max(1, Math.floor(multiplier))
+    : undefined;
+}
+
+function permissionModeFromCostMetadata(
+  costMetadata: unknown,
+): PermissionMode | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  const permissionMode = execution?.permissionMode;
+  return permissionMode === "default" ||
+    permissionMode === "auto-review" ||
+    permissionMode === "full-access"
+    ? permissionMode
+    : undefined;
+}
+
+function thinkingEnabledFromCostMetadata(
+  costMetadata: unknown,
+): boolean | undefined {
+  if (!isRecord(costMetadata)) return undefined;
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  return typeof execution?.thinkingEnabled === "boolean"
+    ? execution.thinkingEnabled
+    : undefined;
+}
+
+function profileHandoffContinuationNote(costMetadata: unknown): string {
+  const handoff = profileHandoffFromCostMetadata(costMetadata);
+  return [
+    "Profile handoff continuation preserves the originating transcript prefix and prior tool history for prompt-cache reuse.",
+    `Continue as ${handoff.handoffToProfile ?? "general-chat"} after ${handoff.handoffFromProfile ?? "localized-edit"} needed broader tools.`,
+    handoff.handoffReason
+      ? `Handoff reason: ${handoff.handoffReason}`
+      : "Handoff reason: fast-edit scope exceeded.",
+    "Use the broader Agent tools now; do not repeat completed reads or edits unless current state must be verified.",
+  ].join(" ");
+}
+
+function profileHandoffTransitionLabel(costMetadata: unknown): string {
+  const handoff = profileHandoffFromCostMetadata(costMetadata);
+  return `Intentional profile handoff: ${handoff.handoffFromProfile ?? "localized-edit"} -> ${handoff.handoffToProfile ?? "general-chat"}.`;
 }
 
 function isAcceptedPlanProfile(profile: AgentRunProfile): boolean {

--- a/app/api/workspace-settings/route.ts
+++ b/app/api/workspace-settings/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { getWorkspaceSettings, updateWorkspaceSettings } from "@/src/db/queries";
-import { isSupportedModelId } from "@/src/lib/models";
+import { isSupportedModelId, resolveModelId } from "@/src/lib/models";
 import {
   getLocalWorkspacesRoot,
   setLocalWorkspacesRoot,
@@ -52,7 +52,12 @@ export async function PATCH(req: Request) {
     }
     const agentPatch = {
       ...(parsed.data.defaultModel !== undefined
-        ? { defaultModel: parsed.data.defaultModel }
+        ? {
+            defaultModel:
+              parsed.data.defaultModel === null
+                ? null
+                : resolveModelId(parsed.data.defaultModel),
+          }
         : {}),
       ...(parsed.data.defaultMaxSteps !== undefined
         ? { defaultMaxSteps: parsed.data.defaultMaxSteps }

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { useRouter } from "next/navigation";
 import { useChat } from "@ai-sdk/react";
 import {
@@ -14,11 +21,17 @@ import { PanelLeftOpen, PanelRightClose, PanelRightOpen } from "lucide-react";
 import {
   DEFAULT_MODEL_ID,
   isSupportedModelId,
+  resolveModelId,
   type ModelId,
 } from "@/src/lib/models";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import type { PermissionMode } from "@/src/agent/permissions";
-import { isBudgetGateDataPart, type AntonUIMessage } from "@/src/lib/trace";
+import {
+  getRunDataList,
+  isBudgetGateDataPart,
+  type AntonRunData,
+  type AntonUIMessage,
+} from "@/src/lib/trace";
 import type { McpPreflightServer, McpServerSummary } from "@/src/lib/api-types";
 import { getJson, jsonHeaders, requestJson } from "@/src/lib/client-fetch";
 import { useWorkspaceAgentDefaults } from "@/components/features/settings/use-workspace-agent-defaults";
@@ -75,12 +88,33 @@ type ComposerControlState = {
 
 const composerControlStateBySession = new Map<string, ComposerControlState>();
 const COMPOSER_CONTROLS_STORAGE_PREFIX = "anton:composer-controls:";
+const PROFILE_HANDOFF_STORAGE_PREFIX = "anton:profile-handoff-started:";
 const PERMISSION_MODES = ["default", "auto-review", "full-access"] as const;
 const WORKLOG_OPEN_STORAGE_KEY = "anton-worklog-open";
+const WORKLOG_OPEN_CHANGE_EVENT = "anton-worklog-open-change";
 
 function readStoredWorklogOpen(): boolean {
   if (typeof window === "undefined") return false;
   return window.sessionStorage.getItem(WORKLOG_OPEN_STORAGE_KEY) === "1";
+}
+
+function subscribeStoredWorklogOpen(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === WORKLOG_OPEN_STORAGE_KEY) onStoreChange();
+  };
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(WORKLOG_OPEN_CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(WORKLOG_OPEN_CHANGE_EVENT, onStoreChange);
+  };
+}
+
+function writeStoredWorklogOpen(open: boolean): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(WORKLOG_OPEN_STORAGE_KEY, open ? "1" : "0");
+  window.dispatchEvent(new Event(WORKLOG_OPEN_CHANGE_EVENT));
 }
 
 function ChatSession({
@@ -102,6 +136,9 @@ function ChatSession({
   const resumeAttemptedRef = useRef(false);
 
   const [sessionId] = useState<string>(() => sessionIdProp ?? generateChatId());
+  const profileHandoffStartedRef = useRef<Set<string>>(
+    readStartedProfileHandoffRunIds(sessionId),
+  );
   const isDraftSession = sessionIdProp === undefined;
   const workspaceDefaults = useWorkspaceAgentDefaults();
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
@@ -115,7 +152,20 @@ function ChatSession({
     () => composerControlStateBySession.get(sessionId),
     [sessionId],
   );
-  const [worklogOpen, setWorklogOpen] = useState(readStoredWorklogOpen);
+  const worklogOpen = useSyncExternalStore(
+    subscribeStoredWorklogOpen,
+    readStoredWorklogOpen,
+    () => false,
+  );
+  const setWorklogOpen = useCallback(
+    (nextValue: boolean | ((open: boolean) => boolean)) => {
+      const currentValue = readStoredWorklogOpen();
+      writeStoredWorklogOpen(
+        typeof nextValue === "function" ? nextValue(currentValue) : nextValue,
+      );
+    },
+    [],
+  );
   const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
   const layoutRef = useRef<HTMLDivElement>(null);
   const {
@@ -126,12 +176,6 @@ function ChatSession({
     toggleExpanded: toggleWorklogExpanded,
     startResize: startWorklogResize,
   } = useWorklogWidth(layoutRef);
-  useEffect(() => {
-    window.sessionStorage.setItem(
-      WORKLOG_OPEN_STORAGE_KEY,
-      worklogOpen ? "1" : "0",
-    );
-  }, [worklogOpen]);
   const [restoreVersion, setRestoreVersion] = useState(0);
   const [messageDisplayOverride, setMessageDisplayOverride] = useState<
     AntonUIMessage[] | null
@@ -432,6 +476,29 @@ function ChatSession({
     [mode, requestBodyForMode, sendMessage],
   );
 
+  useEffect(() => {
+    if (status !== "ready") return;
+    const handoffRun = latestPendingProfileHandoffRun(messages);
+    if (!handoffRun) return;
+    if (profileHandoffStartedRef.current.has(handoffRun.runId)) return;
+
+    profileHandoffStartedRef.current.add(handoffRun.runId);
+    writeStartedProfileHandoffRunIds(
+      sessionId,
+      profileHandoffStartedRef.current,
+    );
+    if (lastNonEmptyMessagesRef.current.length > 0) {
+      setMessageDisplayOverride(lastNonEmptyMessagesRef.current);
+    }
+    setStreamingResponseMode("agent");
+    void sendMessage(undefined, {
+      body: {
+        ...requestBodyForMode("agent"),
+        continueProfileHandoff: { runId: handoffRun.runId },
+      },
+    });
+  }, [messages, requestBodyForMode, sendMessage, sessionId, status]);
+
   const sendWithMcp = async (
     text: string,
     requestedMode: ChatMode = mode,
@@ -731,6 +798,54 @@ function writeStoredComposerControlState(
   );
 }
 
+function profileHandoffStorageKey(sessionId: string): string {
+  return `${PROFILE_HANDOFF_STORAGE_PREFIX}${sessionId}`;
+}
+
+function readStartedProfileHandoffRunIds(sessionId: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  const raw = window.sessionStorage.getItem(profileHandoffStorageKey(sessionId));
+  if (!raw) return new Set();
+  const parsed = parseJsonRecord(raw);
+  const runIds = readStringArray(parsed?.runIds);
+  return new Set(runIds ?? []);
+}
+
+function writeStartedProfileHandoffRunIds(
+  sessionId: string,
+  runIds: ReadonlySet<string>,
+): void {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(
+    profileHandoffStorageKey(sessionId),
+    JSON.stringify({ runIds: Array.from(runIds) }),
+  );
+}
+
+function latestPendingProfileHandoffRun(
+  messages: AntonUIMessage[],
+): AntonRunData | undefined {
+  const latestAssistant = messages.findLast(
+    (message) => message.role === "assistant",
+  );
+  if (!latestAssistant) return undefined;
+  const runs = getRunDataList(latestAssistant);
+  const handoffRun = runs.findLast((run) => {
+    return (
+      run.status === "completed" &&
+      run.finishReason === "profile_handoff_required" &&
+      run.profileHandoffRequired === true &&
+      run.handoffFromProfile === "localized-edit" &&
+      run.handoffToProfile === "general-chat"
+    );
+  });
+  if (!handoffRun) return undefined;
+  const hasLaterSegment = runs.some((run) => {
+    return run.runId !== handoffRun.runId && run.startedAt > handoffRun.startedAt;
+  });
+  return hasLaterSegment ? undefined : handoffRun;
+}
+
 function parseJsonRecord(value: string): Record<string, unknown> | undefined {
   try {
     const parsed: unknown = JSON.parse(value);
@@ -754,7 +869,7 @@ function readChatMode(value: unknown): ChatMode | undefined {
 
 function readModelId(value: unknown): ModelId | undefined {
   return typeof value === "string" && isSupportedModelId(value)
-    ? value
+    ? resolveModelId(value)
     : undefined;
 }
 

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -1,21 +1,32 @@
 "use client";
 
-import { MODEL_CATALOG, type ModelId } from "@/src/lib/models";
+import { useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  SelectViewport,
-} from "@/components/ui/select";
+  getModelLabel,
+  getModelsForProvider,
+  getProviderId,
+  PROVIDERS,
+  type ModelId,
+  type ProviderId,
+} from "@/src/lib/models";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 
 interface ModelPickerProps {
   value: ModelId;
   onChange: (value: ModelId) => void;
-  thinkingEnabled: boolean;
-  onThinkingEnabledChange: (enabled: boolean) => void;
+  thinkingEnabled?: boolean;
+  onThinkingEnabledChange?: (enabled: boolean) => void;
+  showThinking?: boolean;
   disabled?: boolean;
   triggerClassName?: string;
 }
@@ -23,49 +34,106 @@ interface ModelPickerProps {
 export function ModelPicker({
   value,
   onChange,
-  thinkingEnabled,
+  thinkingEnabled = false,
   onThinkingEnabledChange,
+  showThinking = true,
   disabled,
   triggerClassName,
 }: ModelPickerProps) {
-  const selected = MODEL_CATALOG.find((model) => model.id === value);
+  const [open, setOpen] = useState(false);
+  const [activeProvider, setActiveProvider] = useState<ProviderId>(() =>
+    getProviderId(value),
+  );
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setActiveProvider(getProviderId(value));
+    }
+    setOpen(nextOpen);
+  };
 
   return (
-    <Select
-      value={value}
-      onValueChange={(next) => onChange(next as ModelId)}
-      disabled={disabled}
-    >
-      <SelectTrigger className={triggerClassName ?? "w-44"}>
-        <SelectValue>{selected?.label ?? value}</SelectValue>
-      </SelectTrigger>
-      <SelectContent align="end">
-        <SelectViewport className="p-0.5">
-          {MODEL_CATALOG.map((model) => (
-            <SelectItem
-              key={model.id}
-              value={model.id}
-              className="py-1 pr-7 pl-1.5"
-            >
-              <span className="text-xs leading-4">{model.label}</span>
-            </SelectItem>
-          ))}
-        </SelectViewport>
-        <div
-          className="flex items-center justify-between gap-4 border-t border-border px-1.5 py-1.5 text-xs"
-          onPointerDown={(event) => event.stopPropagation()}
-          onKeyDown={(event) => event.stopPropagation()}
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={disabled}
+          className={cn(
+            "h-7 min-w-0 justify-between gap-1 rounded-md bg-secondary px-2 text-xs font-medium text-muted-foreground hover:text-foreground",
+            triggerClassName,
+          )}
         >
-          <span className="font-medium text-muted-foreground">Thinking</span>
-          <Switch
-            checked={thinkingEnabled}
-            onCheckedChange={onThinkingEnabledChange}
-            className="h-4 w-7 ring-0 data-[state=checked]:ring-0"
-            thumbClassName="size-3 data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0.5"
-            aria-label="Toggle model thinking"
-          />
-        </div>
-      </SelectContent>
-    </Select>
+          <span className="truncate">{getModelLabel(value)}</span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-70" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-0">
+        <Tabs
+          value={activeProvider}
+          onValueChange={(next) => setActiveProvider(next as ProviderId)}
+        >
+          <TabsList
+            variant="line"
+            size="sm"
+            className="h-7 w-full rounded-none border-b border-border px-1"
+          >
+            {PROVIDERS.map((provider) => (
+              <TabsTrigger
+                key={provider.id}
+                value={provider.id}
+                className="flex-1 px-1 text-[11px]"
+              >
+                {provider.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {PROVIDERS.map((provider) => (
+            <TabsContent
+              key={provider.id}
+              value={provider.id}
+              className="m-0 max-h-48 overflow-y-auto p-0.5"
+            >
+              {getModelsForProvider(provider.id).map((model) => {
+                const selected = model.id === value;
+                return (
+                  <button
+                    key={model.id}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-center justify-between rounded px-1.5 py-1 text-left text-xs leading-4 hover:bg-accent",
+                      selected && "bg-accent text-foreground",
+                    )}
+                    onClick={() => {
+                      onChange(model.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <span>{model.label}</span>
+                    {selected ? <Check className="size-3.5 shrink-0" /> : null}
+                  </button>
+                );
+              })}
+            </TabsContent>
+          ))}
+        </Tabs>
+        {showThinking && onThinkingEnabledChange ? (
+          <div
+            className="flex items-center justify-between gap-4 border-t border-border px-1.5 py-1.5 text-xs"
+            onPointerDown={(event) => event.stopPropagation()}
+            onKeyDown={(event) => event.stopPropagation()}
+          >
+            <span className="font-medium text-muted-foreground">Thinking</span>
+            <Switch
+              checked={thinkingEnabled}
+              onCheckedChange={onThinkingEnabledChange}
+              className="h-4 w-7 ring-0 data-[state=checked]:ring-0"
+              thumbClassName="size-3 data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0.5"
+              aria-label="Toggle model thinking"
+            />
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/components/features/run-trace/trace-usage-ui.tsx
+++ b/components/features/run-trace/trace-usage-ui.tsx
@@ -270,6 +270,11 @@ export function PromptCacheSection({
           </div>
         ))}
       </div>
+      {promptCache.intentionalSegmentTransition ? (
+        <div className="mt-1.5 border-t border-border/30 pt-1.5 text-[9px] leading-snug text-sky-200/80">
+          {promptCache.intentionalSegmentTransition}
+        </div>
+      ) : null}
           {promptCache.cacheBreakReasons.length > 0 ? (
             <ul className="mt-1.5 space-y-0.5 border-t border-border/30 pt-1.5 text-[9px] leading-snug text-sky-200/75">
               {promptCache.cacheBreakReasons.map((reason) => (

--- a/components/features/settings/agent-settings-panel.tsx
+++ b/components/features/settings/agent-settings-panel.tsx
@@ -24,7 +24,7 @@ import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
 import {
   DEFAULT_MODEL_ID,
   isSupportedModelId,
-  MODEL_CATALOG,
+  resolveModelId,
   type ModelId,
 } from "@/src/lib/models";
 import {
@@ -35,6 +35,7 @@ import {
 } from "@/src/lib/client-fetch";
 import { notifyWorkspaceAgentDefaultsChanged } from "@/src/lib/client-state/workspace-agent-defaults";
 
+import { ModelPicker } from "@/components/features/chat/model-picker";
 import { SettingsCard, SettingsPageShell } from "./settings-shell";
 
 const COMPACT_SELECT_TRIGGER_CLASS =
@@ -75,7 +76,7 @@ export function AgentSettingsPanel() {
         setModel(
           data.settings.defaultModel &&
             isSupportedModelId(data.settings.defaultModel)
-            ? data.settings.defaultModel
+            ? resolveModelId(data.settings.defaultModel)
             : DEFAULT_MODEL_ID,
         );
         setMaxSteps(
@@ -150,24 +151,12 @@ export function AgentSettingsPanel() {
         <div className="space-y-3">
           <SettingsCard title="Default model" icon={<SlidersHorizontal />}>
             <div className="max-w-sm">
-              <Select value={model} onValueChange={(value) => setModel(value as ModelId)}>
-                <SelectTrigger className={COMPACT_SELECT_TRIGGER_CLASS}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className={COMPACT_SELECT_CONTENT_CLASS}>
-                  <SelectViewport className={COMPACT_SELECT_VIEWPORT_CLASS}>
-                    {MODEL_CATALOG.map((item) => (
-                      <SelectItem
-                        key={item.id}
-                        value={item.id}
-                        className={COMPACT_SELECT_ITEM_CLASS}
-                      >
-                        <span className="text-xs leading-4">{item.label}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectViewport>
-                </SelectContent>
-              </Select>
+              <ModelPicker
+                value={model}
+                onChange={setModel}
+                showThinking={false}
+                triggerClassName={COMPACT_SELECT_TRIGGER_CLASS}
+              />
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
               Used when a session has no saved composer override.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/mcp": "^1.0.36",
+    "@ai-sdk/openai-compatible": "^2.0.48",
     "@ai-sdk/react": "^3.0.170",
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.79
+        version: 3.0.79(zod@4.3.6)
       '@ai-sdk/mcp':
         specifier: ^1.0.36
         version: 1.0.36(zod@4.3.6)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.48
+        version: 2.0.48(zod@4.3.6)
       '@ai-sdk/react':
         specifier: ^3.0.170
         version: 3.0.170(react@19.2.4)(zod@4.3.6)
@@ -129,6 +135,12 @@ importers:
 
 packages:
 
+  '@ai-sdk/anthropic@3.0.79':
+    resolution: {integrity: sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
     engines: {node: '>=18'}
@@ -141,11 +153,27 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.23':
     resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -3008,6 +3036,10 @@ packages:
     resolution: {integrity: sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
@@ -4917,6 +4949,12 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.79(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -4931,12 +4969,29 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.3.6
 
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.7
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -7736,6 +7791,8 @@ snapshots:
   etag@1.8.1: {}
 
   eventsource-parser@3.0.7: {}
+
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -3,13 +3,19 @@ import {
   type LanguageModelUsage,
   type ModelMessage,
   type ProviderMetadata,
+  type StopCondition,
   type TextStreamPart,
   type ToolSet,
   type FinishReason,
 } from "ai";
 import {
-  openrouter,
+  getProviderId,
+  getProviderModelId,
+  resolveModelId,
+} from "@/src/lib/models";
+import {
   DEFAULT_MODEL,
+  getLanguageModel,
 } from "@/src/lib/providers";
 import {
   buildTokenUsageMetrics,
@@ -91,6 +97,10 @@ export type TokenAudit = {
   loopGuardCount?: number;
   promotionReason?: string;
   effectiveProfile?: AgentRunProfile;
+  profileHandoffRequired?: boolean;
+  handoffFromProfile?: "localized-edit";
+  handoffToProfile?: "general-chat";
+  handoffReason?: string;
   tokenBudgetReached?: boolean;
   usage?: UsageAudit;
   steps: StepUsageAudit[];
@@ -443,6 +453,7 @@ export async function runAgent({
   priorCostUsd = 0,
   priorToolHistory = [],
   previousPromptCacheAudit,
+  promptCacheIntentionalSegmentTransition,
   onStepStart,
   onStepFinish,
   onStepUsageUpdate,
@@ -472,6 +483,7 @@ export async function runAgent({
   priorCostUsd?: number;
   priorToolHistory?: readonly PriorToolCallRecord[];
   previousPromptCacheAudit?: PromptCacheAudit | null;
+  promptCacheIntentionalSegmentTransition?: string;
   onStepStart?: (event: { stepNumber: number }) => void;
   onStepFinish?: (event: { stepNumber: number }) => void;
   onStepUsageUpdate?: (steps: StepUsageAudit[]) => void;
@@ -524,6 +536,8 @@ export async function runAgent({
     loopGuardIncomplete?: boolean;
     unverifiedEdit?: boolean;
     verificationFailed?: boolean;
+    profileHandoffRequired?: boolean;
+    profileHandoff?: ProfilePromotionEvent;
     tokenAudit: TokenAudit;
   }) => void;
 }) {
@@ -542,8 +556,9 @@ export async function runAgent({
     maxCostUsd: budget.maxCostUsd,
     rawTokenSanityCap: budget.rawTokenSanityCap,
   };
-  let effectiveProfile: AgentRunProfile = profile;
+  const effectiveProfile: AgentRunProfile = profile;
   let promotionReason: string | undefined;
+  let profileHandoff: ProfilePromotionEvent | undefined;
   const nativeToolNames = isFastEditStart
     ? NATIVE_ANTON_TOOL_NAMES
     : PROFILE_NATIVE_TOOLS[profile];
@@ -563,7 +578,7 @@ export async function runAgent({
     await mcpTools.close();
   };
 
-  const selectedModel = model ?? DEFAULT_MODEL;
+  const selectedModel = resolveModelId(model ?? DEFAULT_MODEL);
   let observedStepCount = 0;
   const stepUsage: StepUsageAudit[] = [];
   const stepProviderMetadata: ProviderMetadata[] = [];
@@ -586,11 +601,10 @@ export async function runAgent({
     profile: isFastEditStart ? "localized-edit" : profile,
     toolPolicy,
   });
-  const allActiveToolNames: string[] = Object.keys(tools);
   const initialActiveToolNames = initialActiveNativeToolNames.filter((name) =>
     Object.prototype.hasOwnProperty.call(tools, name),
   );
-  let currentActiveToolNames: string[] = [...initialActiveToolNames];
+  const currentActiveToolNames: string[] = [...initialActiveToolNames];
   const systemParts =
     profile === "pure-chat"
       ? {
@@ -647,15 +661,43 @@ export async function runAgent({
     contextComposition,
     ...(contextBudget ? { contextBudget } : {}),
   };
+  const profileHandoffStopCondition: StopCondition<ToolSet> = ({ steps }) => {
+    if (!isFastEditStart) return false;
+    toolPolicy.observeSteps(steps);
+    if (profileHandoff) return true;
+    const segmentEffective = effectiveTokensForSteps(steps);
+    const promotion = toolPolicy.checkPromotion(
+      priorEffectiveTokens + segmentEffective,
+      budgetState.maxEffectiveTokens,
+    );
+    if (!promotion) return false;
+    profileHandoff = promotion;
+    promotionReason = promotion.reason;
+    onProfilePromotion?.(promotion);
+    return true;
+  };
+
+  const openRouterOptions =
+    getProviderId(selectedModel) === "openrouter"
+      ? {
+          openrouter: openRouterProviderOptions(
+            profile,
+            thinkingEnabled,
+            getProviderModelId(selectedModel),
+          ),
+        }
+      : undefined;
 
   return streamText({
-    model: openrouter(selectedModel),
+    model: getLanguageModel(selectedModel),
     system,
     messages,
     maxOutputTokens: budget.maxOutputTokens,
     tools,
     activeTools: currentActiveToolNames,
+    ...(openRouterOptions ? { providerOptions: openRouterOptions } : {}),
     stopWhen: [
+      profileHandoffStopCondition,
       mutableStepBudgetStopCondition(() => budgetState.maxSteps),
       mutableEffectiveTokenBudgetStopCondition(
         () => budgetState.maxEffectiveTokens,
@@ -667,66 +709,9 @@ export async function runAgent({
       ),
       mutableCostBudgetStopCondition(() => budgetState.maxCostUsd, priorCostUsd),
     ],
-    providerOptions: {
-      openrouter: openRouterProviderOptions(
-        profile,
-        thinkingEnabled,
-        selectedModel,
-      ),
-    },
     prepareStep: ({ messages: stepMessages, steps }) => {
       toolPolicy.observeSteps(steps);
-      const segmentEffective = steps.reduce((sum, step) => {
-        const metrics = buildTokenUsageMetrics({
-          usage: step.usage,
-          providerMetadata: step.providerMetadata,
-        });
-        if (metrics?.effectiveTokens !== undefined) {
-          return sum + metrics.effectiveTokens;
-        }
-        const total = finiteNumber(step.usage?.totalTokens);
-        if (total !== undefined) return sum + total;
-        return (
-          sum +
-          (finiteNumber(step.usage?.inputTokens) ?? 0) +
-          (finiteNumber(step.usage?.outputTokens) ?? 0)
-        );
-      }, 0);
-      const promotion = toolPolicy.checkPromotion(
-        priorEffectiveTokens + segmentEffective,
-        budgetState.maxEffectiveTokens,
-      );
-
       let nextMessages = stepMessages;
-      if (promotion && isFastEditStart && !toolPolicy.wasPromoted) {
-        toolPolicy.markPromoted();
-        effectiveProfile = promotion.toProfile;
-        promotionReason = promotion.reason;
-        currentActiveToolNames = [...allActiveToolNames];
-        const promotedBudget = applyThinkingBudgetAdjustment(
-          applyTokenBudgetMultiplier(
-            capRunBudget(budgetForProfile("general-chat"), maxStepsCap),
-            tokenBudgetMultiplier,
-          ),
-          thinkingEnabled,
-        );
-        budgetState.maxSteps = Math.max(budgetState.maxSteps, promotedBudget.maxSteps);
-        budgetState.maxEffectiveTokens = promotedBudget.maxEffectiveTokens;
-        budgetState.maxCostUsd = promotedBudget.maxCostUsd;
-        budgetState.rawTokenSanityCap = promotedBudget.rawTokenSanityCap;
-        onProfilePromotion?.(promotion);
-        nextMessages = [
-          ...stepMessages,
-          {
-            role: "assistant" as const,
-            content: [
-              "Model-only profile promotion note:",
-              promotion.reason,
-              "Full Agent tools and budget are now available for the remainder of this run.",
-            ].join("\n"),
-          },
-        ];
-      }
 
       const verifyReminder = toolPolicy.consumeVerifyReminder();
       if (verifyReminder) {
@@ -782,7 +767,6 @@ export async function runAgent({
         !forceFinalReason &&
         !duplicateReplay &&
         nextMessages === stepMessages &&
-        !promotion &&
         !verifyReminder &&
         !verifyFixNote &&
         !staleReadNote &&
@@ -793,7 +777,7 @@ export async function runAgent({
       return {
         ...(duplicateReplay && compacted !== nextMessages
           ? { messages: compacted }
-          : promotion || verifyReminder || verifyFixNote || staleReadNote
+          : verifyReminder || verifyFixNote || staleReadNote
             ? { messages: compacted }
           : {}),
         activeTools: currentActiveToolNames,
@@ -924,6 +908,7 @@ export async function runAgent({
         messages,
         tokenUsage,
         previousAudit: previousPromptCacheAudit,
+        intentionalSegmentTransition: promptCacheIntentionalSegmentTransition,
       });
       const segmentTokens = finiteNumber(totalUsage.totalTokens) ?? 0;
       const segmentEffective = tokenUsage?.effectiveTokens ?? segmentTokens;
@@ -932,7 +917,16 @@ export async function runAgent({
       const tokenAudit: TokenAudit = {
         ...tokenAuditBase,
         profile: effectiveProfile,
-        ...(promotionReason ? { promotionReason, effectiveProfile } : {}),
+        ...(promotionReason ? { promotionReason } : {}),
+        ...(promotionReason && !profileHandoff ? { effectiveProfile } : {}),
+        ...(profileHandoff
+          ? {
+              profileHandoffRequired: true,
+              handoffFromProfile: profileHandoff.fromProfile,
+              handoffToProfile: profileHandoff.toProfile,
+              handoffReason: profileHandoff.reason,
+            }
+          : {}),
         tokenBudgetReached,
         promptCache,
         loopGuardCount: toolPolicy.loopGuardCount,
@@ -963,11 +957,17 @@ export async function runAgent({
           priorCostUsd + segmentCost >= budgetState.maxCostUsd &&
           segmentCost > 0,
         loopGuardIncomplete:
-          toolPolicy.endedWithoutStateChange ||
-          toolPolicy.endedUnverified ||
-          toolPolicy.endedWithFailedVerification,
-        unverifiedEdit: toolPolicy.endedUnverified,
-        verificationFailed: toolPolicy.endedWithFailedVerification,
+          profileHandoff
+            ? false
+            : toolPolicy.endedWithoutStateChange ||
+              toolPolicy.endedUnverified ||
+              toolPolicy.endedWithFailedVerification,
+        unverifiedEdit: profileHandoff ? false : toolPolicy.endedUnverified,
+        verificationFailed: profileHandoff
+          ? false
+          : toolPolicy.endedWithFailedVerification,
+        profileHandoffRequired: profileHandoff !== undefined,
+        profileHandoff,
         tokenAudit,
       });
       await closeMcpTools();
@@ -1130,6 +1130,30 @@ function usageAudit(
     result.cachedInputTokens = cachedInputTokens;
   }
   return result;
+}
+
+function effectiveTokensForSteps(
+  steps: readonly {
+    usage?: LanguageModelUsage;
+    providerMetadata?: ProviderMetadata;
+  }[],
+): number {
+  return steps.reduce((sum, step) => {
+    const metrics = buildTokenUsageMetrics({
+      usage: step.usage,
+      providerMetadata: step.providerMetadata,
+    });
+    if (metrics?.effectiveTokens !== undefined) {
+      return sum + metrics.effectiveTokens;
+    }
+    const total = finiteNumber(step.usage?.totalTokens);
+    if (total !== undefined) return sum + total;
+    return (
+      sum +
+      (finiteNumber(step.usage?.inputTokens) ?? 0) +
+      (finiteNumber(step.usage?.outputTokens) ?? 0)
+    );
+  }, 0);
 }
 
 function messagesHaveDuplicateToolReplay(messages: ModelMessage[]): boolean {

--- a/src/agent/profile-promotion.ts
+++ b/src/agent/profile-promotion.ts
@@ -1,8 +1,8 @@
 import type { AgentRunProfile } from "./loop";
 
 export type ProfilePromotionEvent = {
-  fromProfile: AgentRunProfile;
-  toProfile: AgentRunProfile;
+  fromProfile: "localized-edit";
+  toProfile: "general-chat";
   reason: string;
 };
 

--- a/src/agent/prompt-cache-audit.ts
+++ b/src/agent/prompt-cache-audit.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { ModelMessage, ToolSet } from "ai";
 
 import type { TokenUsageMetrics } from "@/src/lib/token-usage";
+import { getProviderId } from "@/src/lib/models";
 
 export type PromptCacheAudit = {
   modelId: string;
@@ -15,6 +16,7 @@ export type PromptCacheAudit = {
   cachedInputTokens?: number;
   cacheWriteTokens?: number;
   cacheHitRate?: number;
+  intentionalSegmentTransition?: string;
   likelyCacheMissReasons: string[];
   cacheBreakReasons: string[];
 };
@@ -30,6 +32,7 @@ export function buildPromptCacheAudit({
   messages,
   tokenUsage,
   previousAudit,
+  intentionalSegmentTransition,
 }: {
   modelId: string;
   system: string;
@@ -41,6 +44,7 @@ export function buildPromptCacheAudit({
   messages: ModelMessage[];
   tokenUsage?: TokenUsageMetrics;
   previousAudit?: PromptCacheAudit | null;
+  intentionalSegmentTransition?: string;
 }): PromptCacheAudit {
   const cachedInputTokens = tokenUsage?.cachedInputTokens;
   const cacheWriteTokens = tokenUsage?.cacheWriteTokens;
@@ -61,7 +65,7 @@ export function buildPromptCacheAudit({
 
   const auditBase = {
     modelId,
-    providerId: "openrouter",
+    providerId: getProviderId(modelId),
     systemPromptHash: hashText(system),
     toolSchemaHash: hashText(stableJson(toolSchemas(tools, activeToolNames))),
     nativeToolNamesHash: hashText((activeToolNames ?? nativeToolNames).join("\n")),
@@ -77,6 +81,7 @@ export function buildPromptCacheAudit({
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
     ...(cacheWriteTokens !== undefined ? { cacheWriteTokens } : {}),
     ...(cacheHitRate !== undefined ? { cacheHitRate } : {}),
+    ...(intentionalSegmentTransition ? { intentionalSegmentTransition } : {}),
     likelyCacheMissReasons,
     cacheBreakReasons,
   };
@@ -160,6 +165,12 @@ export function promptCacheAuditFromCostMetadata(
     messagePrefixHash: stringValue(promptCache.messagePrefixHash) ?? "—",
     likelyCacheMissReasons: stringArray(promptCache.likelyCacheMissReasons),
     cacheBreakReasons: stringArray(promptCache.cacheBreakReasons),
+    ...(typeof promptCache.intentionalSegmentTransition === "string"
+      ? {
+          intentionalSegmentTransition:
+            promptCache.intentionalSegmentTransition,
+        }
+      : {}),
     ...(finiteNumber(promptCache.cachedInputTokens) !== undefined
       ? { cachedInputTokens: finiteNumber(promptCache.cachedInputTokens) }
       : {}),

--- a/src/agent/tools/delegate.ts
+++ b/src/agent/tools/delegate.ts
@@ -2,8 +2,12 @@ import { generateText, stepCountIs, tool } from "ai";
 import { z } from "zod";
 
 import {
+  getProviderId,
+  resolveModelId,
+} from "@/src/lib/models";
+import {
   DEFAULT_MODEL,
-  openrouter,
+  getLanguageModel,
 } from "@/src/lib/providers";
 import { listMemories } from "@/src/db/queries";
 import { listSkills } from "../skills";
@@ -62,17 +66,22 @@ export function createDelegateTaskTool({
     }),
     execute: async ({ task, maxSteps }) => {
       try {
+        const selectedModel = resolveModelId(model ?? DEFAULT_MODEL);
+        const openRouterOptions =
+          getProviderId(selectedModel) === "openrouter"
+            ? {
+                openrouter: {
+                  usage: { include: true },
+                },
+              }
+            : undefined;
         const result = await generateText({
-          model: openrouter(model ?? DEFAULT_MODEL),
+          model: getLanguageModel(selectedModel),
           system: childSystemPrompt(workspaceRoot),
           prompt: task,
           tools: readOnlyTools,
           stopWhen: stepCountIs(maxSteps ?? DEFAULT_MAX_STEPS),
-          providerOptions: {
-            openrouter: {
-              usage: { include: true },
-            },
-          },
+          ...(openRouterOptions ? { providerOptions: openRouterOptions } : {}),
         });
 
         return {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -228,6 +228,15 @@ export function getRunById(id: string): Run | undefined {
   return db.select().from(runs).where(eq(runs.id, id)).get();
 }
 
+export function listRunsForSession(sessionId: string): Run[] {
+  return db
+    .select()
+    .from(runs)
+    .where(eq(runs.sessionId, sessionId))
+    .orderBy(asc(runs.startedAt))
+    .all();
+}
+
 export function setSessionTokenBudgetMultiplier(
   sessionId: string,
   multiplier: number,

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -119,6 +119,7 @@ export type ProjectRunDetailsPromptCache = {
   cachedInputTokens?: number;
   cacheWriteTokens?: number;
   cacheHitRate?: number;
+  intentionalSegmentTransition?: string;
   likelyCacheMissReasons: string[];
   cacheBreakReasons: string[];
 };
@@ -160,6 +161,10 @@ export type ProjectRunDetailsRun = {
   cacheHitRate?: number | null;
   loopGuardCount?: number | null;
   verificationSummary?: string | null;
+  profileHandoffRequired?: boolean | null;
+  handoffFromProfile?: string | null;
+  handoffToProfile?: string | null;
+  handoffReason?: string | null;
   rawTotalTokens?: number | null;
   effectiveTokens?: number | null;
 };

--- a/src/lib/client-state/workspace-agent-defaults.ts
+++ b/src/lib/client-state/workspace-agent-defaults.ts
@@ -5,6 +5,7 @@ import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
 import {
   DEFAULT_MODEL_ID,
   isSupportedModelId,
+  resolveModelId,
   type ModelId,
 } from "@/src/lib/models";
 import { getJson } from "@/src/lib/client-fetch";
@@ -24,7 +25,7 @@ export function workspaceDefaultsFromSettings(
   return {
     model:
       settings.defaultModel && isSupportedModelId(settings.defaultModel)
-        ? settings.defaultModel
+        ? resolveModelId(settings.defaultModel)
         : DEFAULT_MODEL_ID,
     permissionMode: settings.defaultPermissionMode ?? "auto-review",
     maxSteps: settings.defaultMaxSteps,

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,16 +1,111 @@
-export const DEFAULT_MODEL_ID = "deepseek/deepseek-v4-flash";
-
-export const MODEL_CATALOG = [
-  { id: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
-  { id: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
-  { id: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
-  { id: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
-  { id: "openai/gpt-5", label: "GPT-5" },
-  { id: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+export const PROVIDERS = [
+  { id: "opencode-go", label: "OpenCode Go" },
+  { id: "openrouter", label: "OpenRouter" },
 ] as const;
 
-export type ModelId = (typeof MODEL_CATALOG)[number]["id"];
+export type ProviderId = (typeof PROVIDERS)[number]["id"];
+
+export const DEFAULT_PROVIDER_ID: ProviderId = "opencode-go";
+export const DEFAULT_MODEL_ID = "opencode-go/deepseek-v4-flash";
+
+const OPENCODE_GO_MODELS = [
+  { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+  { slug: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { slug: "glm-5.1", label: "GLM 5.1" },
+  { slug: "glm-5", label: "GLM 5" },
+  { slug: "kimi-k2.6", label: "Kimi K2.6" },
+  { slug: "kimi-k2.5", label: "Kimi K2.5" },
+  { slug: "qwen3.6-plus", label: "Qwen3.6 Plus" },
+  { slug: "qwen3.5-plus", label: "Qwen3.5 Plus" },
+  { slug: "minimax-m2.7", label: "MiniMax M2.7" },
+  { slug: "minimax-m2.5", label: "MiniMax M2.5" },
+  { slug: "mimo-v2.5-pro", label: "MiMo V2.5 Pro" },
+  { slug: "mimo-v2.5", label: "MiMo V2.5" },
+] as const;
+
+const OPENROUTER_MODELS = [
+  { slug: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+  { slug: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { slug: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { slug: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
+  { slug: "openai/gpt-5", label: "GPT-5" },
+  { slug: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+] as const;
+
+export const MODEL_CATALOG = [
+  ...OPENCODE_GO_MODELS.map((model) => ({
+    id: `opencode-go/${model.slug}`,
+    provider: "opencode-go" as const,
+    providerModelId: model.slug,
+    label: model.label,
+  })),
+  ...OPENROUTER_MODELS.map((model) => ({
+    id: `openrouter/${model.slug}`,
+    provider: "openrouter" as const,
+    providerModelId: model.slug,
+    label: model.label,
+  })),
+] as const;
+
+export type ModelCatalogEntry = (typeof MODEL_CATALOG)[number];
+export type ModelId = ModelCatalogEntry["id"];
+
+function normalizeModelId(modelId: string): ModelId | null {
+  if (MODEL_CATALOG.some((model) => model.id === modelId)) {
+    return modelId as ModelId;
+  }
+
+  const opencodeId = `opencode-go/${modelId}`;
+  if (MODEL_CATALOG.some((model) => model.id === opencodeId)) {
+    return opencodeId as ModelId;
+  }
+
+  if (
+    modelId.includes("/") &&
+    !modelId.startsWith("opencode-go/") &&
+    !modelId.startsWith("openrouter/")
+  ) {
+    const openrouterId = `openrouter/${modelId}`;
+    if (MODEL_CATALOG.some((model) => model.id === openrouterId)) {
+      return openrouterId as ModelId;
+    }
+  }
+
+  return null;
+}
 
 export function isSupportedModelId(modelId: string): modelId is ModelId {
-  return MODEL_CATALOG.some((model) => model.id === modelId);
+  return normalizeModelId(modelId) !== null;
+}
+
+export function resolveModelId(modelId: string): ModelId {
+  return normalizeModelId(modelId) ?? DEFAULT_MODEL_ID;
+}
+
+export function getProviderId(modelId: string): ProviderId {
+  const resolved = resolveModelId(modelId);
+  const entry = MODEL_CATALOG.find((model) => model.id === resolved);
+  return entry?.provider ?? DEFAULT_PROVIDER_ID;
+}
+
+export function getProviderModelId(modelId: string): string {
+  const resolved = resolveModelId(modelId);
+  const entry = MODEL_CATALOG.find((model) => model.id === resolved);
+  return entry?.providerModelId ?? resolved;
+}
+
+export function getModelsForProvider(provider: ProviderId): ModelCatalogEntry[] {
+  return MODEL_CATALOG.filter((model) => model.provider === provider);
+}
+
+export function getModelLabel(modelId: string): string {
+  const resolved = resolveModelId(modelId);
+  return (
+    MODEL_CATALOG.find((model) => model.id === resolved)?.label ?? resolved
+  );
+}
+
+export function getDefaultModelForProvider(provider: ProviderId): ModelId {
+  const models = getModelsForProvider(provider);
+  return models[0]?.id ?? DEFAULT_MODEL_ID;
 }

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,23 +1,55 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { DEFAULT_MODEL_ID } from "./models";
+import type { LanguageModel } from "ai";
 
-const apiKey = process.env.OPENROUTER_API_KEY;
+import {
+  DEFAULT_MODEL_ID,
+  getProviderId,
+  getProviderModelId,
+  resolveModelId,
+} from "./models";
 
-if (!apiKey) {
+const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go";
+
+const opencodeApiKey = process.env.OPENCODE_GO_API_KEY;
+const openrouterApiKey = process.env.OPENROUTER_API_KEY;
+
+if (!opencodeApiKey) {
   console.warn(
-    "[providers] OPENROUTER_API_KEY is not set — requests to /api/chat will fail.",
+    "[providers] OPENCODE_GO_API_KEY is not set — OpenCode Go requests will fail.",
   );
 }
 
-export const openrouter = createOpenRouter({
-  apiKey: apiKey ?? "",
+if (!openrouterApiKey) {
+  console.warn(
+    "[providers] OPENROUTER_API_KEY is not set — OpenRouter requests will fail.",
+  );
+}
+
+const chatCompletionsProvider = createOpenAICompatible({
+  name: "opencode-go",
+  baseURL: `${OPENCODE_GO_BASE_URL}/v1`,
+  apiKey: opencodeApiKey ?? "",
 });
 
-const OPENROUTER_ROUTING_SUFFIXES = new Set(["floor", "free", "nitro"]);
+const messagesProvider = createAnthropic({
+  baseURL: OPENCODE_GO_BASE_URL,
+  apiKey: opencodeApiKey ?? "",
+});
 
-export const DEFAULT_MODEL = stripOpenRouterRoutingSuffix(
-  process.env.DEFAULT_MODEL ?? DEFAULT_MODEL_ID,
-);
+export const openrouter = createOpenRouter({
+  apiKey: openrouterApiKey ?? "",
+});
+
+const ANTHROPIC_ENDPOINT_MODELS = new Set([
+  "minimax-m2.7",
+  "minimax-m2.5",
+  "qwen3.6-plus",
+  "qwen3.5-plus",
+]);
+
+const OPENROUTER_ROUTING_SUFFIXES = new Set(["floor", "free", "nitro"]);
 
 export function stripOpenRouterRoutingSuffix(modelId: string): string {
   const suffix = openRouterRoutingSuffix(modelId);
@@ -29,3 +61,23 @@ function openRouterRoutingSuffix(modelId: string): string | null {
   if (!suffix || suffix === modelId) return null;
   return OPENROUTER_ROUTING_SUFFIXES.has(suffix) ? suffix : null;
 }
+
+export function getLanguageModel(modelId: string): LanguageModel {
+  const resolved = resolveModelId(modelId);
+  const provider = getProviderId(resolved);
+  const providerModelId = getProviderModelId(resolved);
+
+  if (provider === "openrouter") {
+    return openrouter(stripOpenRouterRoutingSuffix(providerModelId));
+  }
+
+  if (ANTHROPIC_ENDPOINT_MODELS.has(providerModelId)) {
+    return messagesProvider(providerModelId);
+  }
+
+  return chatCompletionsProvider.chatModel(providerModelId);
+}
+
+export const DEFAULT_MODEL = resolveModelId(
+  process.env.DEFAULT_MODEL ?? DEFAULT_MODEL_ID,
+);

--- a/src/lib/run-details-serializers.ts
+++ b/src/lib/run-details-serializers.ts
@@ -177,6 +177,19 @@ function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
     ...(typeof execution?.verificationSummary === "string"
       ? { verificationSummary: execution.verificationSummary }
       : {}),
+    ...(execution?.profileHandoffRequired === true ||
+    execution?.profileHandoffRequired === false
+      ? { profileHandoffRequired: execution.profileHandoffRequired === true }
+      : {}),
+    ...(typeof execution?.handoffFromProfile === "string"
+      ? { handoffFromProfile: execution.handoffFromProfile }
+      : {}),
+    ...(typeof execution?.handoffToProfile === "string"
+      ? { handoffToProfile: execution.handoffToProfile }
+      : {}),
+    ...(typeof execution?.handoffReason === "string"
+      ? { handoffReason: execution.handoffReason }
+      : {}),
     ...(typeof execution?.promotionReason === "string"
       ? { promotionReason: execution.promotionReason }
       : {}),
@@ -464,6 +477,9 @@ function promptCacheFromTokenAudit(
       : {}),
     ...(finiteNumber(cache.cacheHitRate) !== undefined
       ? { cacheHitRate: finiteNumber(cache.cacheHitRate) }
+      : {}),
+    ...(typeof cache.intentionalSegmentTransition === "string"
+      ? { intentionalSegmentTransition: cache.intentionalSegmentTransition }
       : {}),
     likelyCacheMissReasons,
     cacheBreakReasons: stringArray(cache.cacheBreakReasons),

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -43,6 +43,10 @@ export type AntonMessageMetadata = {
   maxStepLimitReached?: boolean;
   maxCostUsd?: number;
   costBudgetReached?: boolean;
+  profileHandoffRequired?: boolean;
+  handoffFromProfile?: "localized-edit";
+  handoffToProfile?: "general-chat";
+  handoffReason?: string;
 };
 
 export type AntonRunData = {
@@ -73,6 +77,10 @@ export type AntonRunData = {
   verificationSummary?: string;
   promotionReason?: string;
   effectiveProfile?: string;
+  profileHandoffRequired?: boolean;
+  handoffFromProfile?: "localized-edit";
+  handoffToProfile?: "general-chat";
+  handoffReason?: string;
   hadSuccessfulEdit?: boolean;
 };
 
@@ -873,6 +881,18 @@ function hydrateMetricRecord<T>(
     next ??= { ...record };
     next.costBudgetReached = true;
   }
+  if (run.finishReason === "profile_handoff_required") {
+    if (record.profileHandoffRequired !== true) {
+      next ??= { ...record };
+      next.profileHandoffRequired = true;
+    }
+    const handoff = profileHandoffDataFromMetadata(run.costMetadata);
+    for (const [key, value] of Object.entries(handoff)) {
+      if (record[key] === value) continue;
+      next ??= { ...record };
+      next[key] = value;
+    }
+  }
 
   return (next ?? value) as T;
 }
@@ -951,6 +971,40 @@ function runDataFromSnapshot(run: AntonRunMetricSnapshot): AntonRunData {
       : {}),
     ...(run.finishReason === "cost_budget_limit"
       ? { costBudgetReached: true }
+      : {}),
+    ...(run.finishReason === "profile_handoff_required"
+      ? { profileHandoffRequired: true }
+      : {}),
+    ...profileHandoffDataFromMetadata(run.costMetadata),
+  };
+}
+
+function profileHandoffDataFromMetadata(
+  costMetadata: unknown,
+): Pick<
+  AntonRunData,
+  | "profileHandoffRequired"
+  | "handoffFromProfile"
+  | "handoffToProfile"
+  | "handoffReason"
+> {
+  if (!isRecord(costMetadata)) return {};
+  const execution = isRecord(costMetadata.execution)
+    ? costMetadata.execution
+    : undefined;
+  if (!execution) return {};
+  return {
+    ...(execution.profileHandoffRequired === true
+      ? { profileHandoffRequired: true }
+      : {}),
+    ...(execution.handoffFromProfile === "localized-edit"
+      ? { handoffFromProfile: "localized-edit" as const }
+      : {}),
+    ...(execution.handoffToProfile === "general-chat"
+      ? { handoffToProfile: "general-chat" as const }
+      : {}),
+    ...(typeof execution.handoffReason === "string"
+      ? { handoffReason: execution.handoffReason }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary

- add the cache-first profile handoff path for localized-edit runs that need a broader agent segment
- preserve stable active tool sets within a run segment and record profile handoffs in run metadata/events
- support provider-prefixed model IDs across model selection, settings, provider routing, and run metadata
- fix the Worklog open-state hydration mismatch by reading session storage through a stable client store

Closes #120

## Verification

- pnpm typecheck
- pnpm lint
- git diff --cached --check before commit

## Notes

Manual fast-edit, promotion, cache-transition, and reconnect duplicate-guard scenarios still need browser verification before merge.