### PR TITLE
[codex] Show diffs in expandable file rows

### DIFF
--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -39,6 +39,7 @@ import type { SessionTokenUsage } from "@/src/lib/token-usage";
 import { BranchSwitcher } from "@/components/features/projects/branch-switcher";
 import { ProjectPicker } from "@/components/features/projects/project-picker";
 import { ModelPicker } from "./model-picker";
+import { SessionMetricsHoverCard } from "./metrics-hover-card";
 
 interface ComposerProps {
   onSend: (text: string) => boolean | Promise<boolean>;
@@ -451,57 +452,6 @@ function TokenCounter({
   tokenUsage: SessionTokenUsage;
   pending: boolean;
 }) {
-  const tokens = tokenUsage.effectiveTokens;
-  if (tokens <= 0 && !pending) return null;
-  return (
-    <span
-      className="inline-flex h-5 items-center gap-1 rounded-md bg-secondary px-1.5 text-[11px] font-mono text-muted-foreground"
-      title={tokenUsageTitle(tokenUsage)}
-    >
-      <span className="size-1.5 rounded-full bg-muted-foreground/50" aria-hidden />
-      <span className="text-muted-foreground/70">session</span>
-      {formatTokens(tokens)}
-      <span className="text-muted-foreground/70">tok</span>
-    </span>
-  );
-}
-
-function tokenUsageTitle(usage: SessionTokenUsage): string {
-  const lines = [
-    "Effective session usage",
-    `Effective: ${formatInteger(usage.effectiveTokens)} tokens`,
-    `Raw: ${formatInteger(usage.rawTokens)} tokens`,
-    `Cached input: ${formatInteger(usage.cachedInputTokens)} tokens`,
-  ];
-  if (usage.cacheWriteTokens > 0) {
-    lines.push(`Cache write: ${formatInteger(usage.cacheWriteTokens)} tokens`);
-  }
-  if (usage.costUsd !== undefined) {
-    lines.push(`Cost: ${formatCost(usage.costUsd)}`);
-  }
-  if (!usage.hasEffectiveMetrics) {
-    lines.push("Effective value falls back to raw tokens for older runs.");
-  }
-  return lines.join("\n");
-}
-
-function formatTokens(n: number): string {
-  if (n < 1000) return String(n);
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
-  return `${(n / 1_000_000).toFixed(1)}M`;
-}
-
-function formatInteger(n: number): string {
-  return new Intl.NumberFormat().format(Math.round(n));
-}
-
-function formatCost(n: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    currencyDisplay: "symbol",
-    maximumFractionDigits: 4,
-  })
-    .format(n)
-    .replace("US$", "$");
+  if (tokenUsage.effectiveTokens <= 0 && !pending) return null;
+  return <SessionMetricsHoverCard tokenUsage={tokenUsage} />;
 }

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -3,14 +3,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
-  ArrowDownToLine,
-  ArrowUpFromLine,
   Check,
-  Clock,
   Copy,
-  Cpu,
-  DollarSign,
-  Hash,
   Pencil,
   Play,
 } from "lucide-react";
@@ -36,20 +30,13 @@ import { Markdown } from "./markdown";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  formatMetricCost,
-  formatMetricDuration,
-  formatMetricNumber,
   messageMetrics,
   type ResponseMetrics,
 } from "./message-metrics";
+import { ResponseMetricsHoverCard } from "./metrics-hover-card";
 import { RunTraceAccordion } from "@/components/features/run-trace/run-trace";
 import { isFailedToolOutput } from "@/components/features/run-trace/tool-display";
 import { getTodoTraceDisplay } from "@/components/features/run-trace/trace-data";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 
 interface MessageListProps {
   messages: AntonUIMessage[];
@@ -441,7 +428,7 @@ function MessageActions({
   return (
     <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover/msg:opacity-100 focus-within:opacity-100">
       <CopyMessageButton text={text} />
-      {metrics && <StatsHoverCard metrics={metrics} />}
+      {metrics && <ResponseMetricsHoverCard metrics={metrics} />}
       {responseTime && (
         <span className="px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
           {responseTime}
@@ -449,87 +436,6 @@ function MessageActions({
       )}
     </div>
   );
-}
-
-function StatsHoverCard({ metrics }: { metrics: ResponseMetrics }) {
-  const modelName = formatModelName(metrics.model);
-  return (
-    <HoverCard openDelay={150} closeDelay={80}>
-      <HoverCardTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground focus:outline-none"
-          aria-label="Response metrics"
-        >
-          <Cpu className="size-3" />
-        </button>
-      </HoverCardTrigger>
-      <HoverCardContent className="w-64 px-2.5 py-2">
-        <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
-          <Cpu className="size-3" />
-          {modelName}
-        </div>
-        <div className="space-y-1.5 text-[10px]">
-          <div className="flex items-center gap-1.5 text-muted-foreground">
-            <Hash className="size-3" />
-            <span>Total</span>
-            <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.totalTokens)}</span>
-          </div>
-          {metrics.effectiveTokens !== undefined && (
-            <div className="flex items-center gap-1.5 text-muted-foreground">
-              <Hash className="size-3" />
-              <span>Effective</span>
-              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.effectiveTokens)}</span>
-            </div>
-          )}
-          <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-            <div className="flex items-center gap-1.5">
-              <ArrowDownToLine className="size-3 text-muted-foreground" />
-              <span className="text-muted-foreground">In</span>
-              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.inputTokens)}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <ArrowUpFromLine className="size-3 text-muted-foreground" />
-              <span className="text-muted-foreground">Out</span>
-              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.outputTokens)}</span>
-            </div>
-          </div>
-          {(metrics.cachedInputTokens !== undefined ||
-            metrics.cacheWriteTokens !== undefined) && (
-            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-              <div className="flex items-center gap-1.5">
-                <Hash className="size-3 text-muted-foreground" />
-                <span className="text-muted-foreground">Cached</span>
-                <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.cachedInputTokens)}</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <Hash className="size-3 text-muted-foreground" />
-                <span className="text-muted-foreground">Write</span>
-                <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricNumber(metrics.cacheWriteTokens)}</span>
-              </div>
-            </div>
-          )}
-          <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-            <div className="flex items-center gap-1.5">
-              <DollarSign className="size-3 text-muted-foreground" />
-              <span className="text-muted-foreground">Cost</span>
-              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricCost(metrics.costUsd)}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <Clock className="size-3 text-muted-foreground" />
-              <span className="text-muted-foreground">Duration</span>
-              <span className="ml-auto whitespace-nowrap font-mono text-foreground">{formatMetricDuration(metrics.durationMs)}</span>
-            </div>
-          </div>
-        </div>
-      </HoverCardContent>
-    </HoverCard>
-  );
-}
-
-function formatModelName(value: string | undefined): string {
-  if (!value) return "—";
-  return value.split("/").at(-1) ?? value;
 }
 
 function CopyMessageButton({ text }: { text: string }) {

--- a/components/features/chat/metrics-hover-card.tsx
+++ b/components/features/chat/metrics-hover-card.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Clock,
+  Cpu,
+  DollarSign,
+  Hash,
+} from "lucide-react";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import {
+  formatMetricCost,
+  formatMetricDuration,
+  formatMetricNumber,
+  type ResponseMetrics,
+} from "./message-metrics";
+import type { SessionTokenUsage } from "@/src/lib/token-usage";
+
+function MetricRow({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Hash;
+  label: string;
+  value: number | undefined;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-muted-foreground">
+      <Icon className="size-3" />
+      <span>{label}</span>
+      <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+        {formatMetricNumber(value)}
+      </span>
+    </div>
+  );
+}
+
+function MetricsHoverCardShell({
+  trigger,
+  headerIcon: HeaderIcon,
+  headerLabel,
+  children,
+}: {
+  trigger: ReactNode;
+  headerIcon?: typeof Cpu;
+  headerLabel: string;
+  children: ReactNode;
+}) {
+  return (
+    <HoverCard openDelay={150} closeDelay={80}>
+      <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
+      <HoverCardContent className="w-64 px-2.5 py-2">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+          {HeaderIcon ? <HeaderIcon className="size-3" /> : null}
+          {headerLabel}
+        </div>
+        <div className="space-y-1.5 text-[10px]">{children}</div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+export function ResponseMetricsHoverCard({
+  metrics,
+}: {
+  metrics: ResponseMetrics;
+}) {
+  const modelName = formatModelName(metrics.model);
+  return (
+    <MetricsHoverCardShell
+      headerIcon={Cpu}
+      headerLabel={modelName}
+      trigger={
+        <button
+          type="button"
+          className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:bg-accent focus:text-foreground focus:outline-none"
+          aria-label="Response metrics"
+        >
+          <Cpu className="size-3" />
+        </button>
+      }
+    >
+      <MetricRow icon={Hash} label="Total" value={metrics.totalTokens} />
+      {metrics.effectiveTokens !== undefined ? (
+        <MetricRow
+          icon={Hash}
+          label="Effective"
+          value={metrics.effectiveTokens}
+        />
+      ) : null}
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+        <div className="flex items-center gap-1.5">
+          <ArrowDownToLine className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">In</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricNumber(metrics.inputTokens)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <ArrowUpFromLine className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">Out</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricNumber(metrics.outputTokens)}
+          </span>
+        </div>
+      </div>
+      {metrics.cachedInputTokens !== undefined ||
+      metrics.cacheWriteTokens !== undefined ? (
+        <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+          <div className="flex items-center gap-1.5">
+            <Hash className="size-3 text-muted-foreground" />
+            <span className="text-muted-foreground">Cached</span>
+            <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+              {formatMetricNumber(metrics.cachedInputTokens)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Hash className="size-3 text-muted-foreground" />
+            <span className="text-muted-foreground">Write</span>
+            <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+              {formatMetricNumber(metrics.cacheWriteTokens)}
+            </span>
+          </div>
+        </div>
+      ) : null}
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+        <div className="flex items-center gap-1.5">
+          <DollarSign className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">Cost</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricCost(metrics.costUsd)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Clock className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">Duration</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricDuration(metrics.durationMs)}
+          </span>
+        </div>
+      </div>
+    </MetricsHoverCardShell>
+  );
+}
+
+export function SessionMetricsHoverCard({
+  tokenUsage,
+}: {
+  tokenUsage: SessionTokenUsage;
+}) {
+  return (
+    <MetricsHoverCardShell
+      headerLabel="Session"
+      trigger={
+        <button
+          type="button"
+          className="inline-flex h-5 items-center gap-1 rounded-md bg-secondary px-1.5 text-[11px] font-mono text-muted-foreground transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Session token usage"
+        >
+          <span
+            className="size-1.5 rounded-full bg-muted-foreground/50"
+            aria-hidden
+          />
+          <span className="text-muted-foreground/70">session</span>
+          {formatCompactSessionTokens(tokenUsage.effectiveTokens)}
+          <span className="text-muted-foreground/70">tok</span>
+        </button>
+      }
+    >
+      <MetricRow icon={Hash} label="Raw" value={tokenUsage.rawTokens} />
+      <MetricRow
+        icon={Hash}
+        label="Effective"
+        value={tokenUsage.effectiveTokens}
+      />
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+        <div className="flex items-center gap-1.5">
+          <Hash className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">Cached</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricNumber(tokenUsage.cachedInputTokens)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Hash className="size-3 text-muted-foreground" />
+          <span className="text-muted-foreground">Write</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {tokenUsage.cacheWriteTokens > 0
+              ? formatMetricNumber(tokenUsage.cacheWriteTokens)
+              : "-"}
+          </span>
+        </div>
+      </div>
+      {tokenUsage.costUsd !== undefined ? (
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <DollarSign className="size-3" />
+          <span>Cost</span>
+          <span className="ml-auto whitespace-nowrap font-mono text-foreground">
+            {formatMetricCost(tokenUsage.costUsd)}
+          </span>
+        </div>
+      ) : null}
+      {!tokenUsage.hasEffectiveMetrics ? (
+        <p className="border-t border-border/40 pt-1.5 text-[9px] leading-snug text-muted-foreground/80">
+          Effective value falls back to raw tokens for older runs.
+        </p>
+      ) : null}
+    </MetricsHoverCardShell>
+  );
+}
+
+function formatModelName(value: string | undefined): string {
+  if (!value) return "-";
+  return value.split("/").at(-1) ?? value;
+}
+
+function formatCompactSessionTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Clock,
   ExternalLink,
   FileText,
@@ -70,12 +71,6 @@ export function PullRequestPanel({
   onRefresh: () => void;
   onSelectPullRequest: (number: number) => void;
 }) {
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const selected =
-    pullRequest.files.find((file) => file.filename === selectedFile) ??
-    pullRequest.files[0] ??
-    null;
-
   return (
     <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
       <section className="border-b border-border px-3 py-3">
@@ -161,11 +156,7 @@ export function PullRequestPanel({
           </TabsList>
         </div>
         <TabsContent value="changes" className="m-0 min-w-0">
-          <LocalChangesView
-            files={pullRequest.files}
-            selected={selected}
-            onSelect={setSelectedFile}
-          />
+          <LocalChangesView files={pullRequest.files} />
         </TabsContent>
         <TabsContent value="description" className="m-0">
           <DescriptionView description={pullRequest.description} />
@@ -320,13 +311,36 @@ function emptyPullRequestMessage(gitStatus: ProjectGitStatusSummary | null): str
 
 export function LocalChangesView({
   files,
-  selected,
-  onSelect,
 }: {
   files: ProjectPullRequestFileSummary[];
-  selected: ProjectPullRequestFileSummary | null;
-  onSelect: (filename: string) => void;
 }) {
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(() => new Set());
+  const [expandedTouched, setExpandedTouched] = useState(false);
+
+  const visibleExpandedFiles = useMemo(() => {
+    const filenames = new Set(files.map((file) => file.filename));
+    const next = new Set(
+      [...expandedFiles].filter((filename) => filenames.has(filename)),
+    );
+    if (!expandedTouched && next.size === 0 && files[0]) {
+      next.add(files[0].filename);
+    }
+    return next;
+  }, [expandedFiles, expandedTouched, files]);
+
+  const toggleFile = (filename: string) => {
+    setExpandedTouched(true);
+    setExpandedFiles(() => {
+      const next = new Set(visibleExpandedFiles);
+      if (next.has(filename)) {
+        next.delete(filename);
+      } else {
+        next.add(filename);
+      }
+      return next;
+    });
+  };
+
   if (files.length === 0) {
     return (
       <div className="px-3 py-8 text-center text-xs text-muted-foreground">
@@ -336,39 +350,50 @@ export function LocalChangesView({
   }
 
   return (
-    <div className="grid min-h-0 min-w-0 grid-rows-[auto_1fr] overflow-hidden">
-      <ol className="max-h-56 min-w-0 overflow-y-auto border-b border-border px-2 py-2">
-        {files.map((file) => (
-          <li key={file.filename}>
-            <button
-              type="button"
-              onClick={() => onSelect(file.filename)}
-              className={cn(
-                "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
-                selected?.filename === file.filename
-                  ? "bg-accent/70"
-                  : "hover:bg-accent/40",
-              )}
+    <div className="min-h-0 min-w-0 overflow-y-auto px-2 py-2">
+      <ol className="grid min-w-0 gap-1.5">
+        {files.map((file) => {
+          const expanded = visibleExpandedFiles.has(file.filename);
+          return (
+            <li
+              key={file.filename}
+              className="min-w-0 overflow-hidden rounded-md bg-background/35 ring-1 ring-border/70"
             >
-              <FileStatusBadge status={file.status} />
-              <span className="min-w-0">
-                <span className="block truncate font-medium">{file.filename}</span>
-                {file.previousFilename ? (
-                  <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                    from {file.previousFilename}
-                  </span>
-                ) : null}
-              </span>
-              <span className="font-mono text-[10px] tabular-nums">
-                <span className="text-emerald-500">+{file.additions}</span>
-                <span className="mx-1 text-muted-foreground/50">/</span>
-                <span className="text-destructive">-{file.deletions}</span>
-              </span>
-            </button>
-          </li>
-        ))}
+              <button
+                type="button"
+                onClick={() => toggleFile(file.filename)}
+                aria-expanded={expanded}
+                aria-controls={diffPanelId(file.filename)}
+                className={cn(
+                  "grid w-full grid-cols-[0.75rem_1rem_minmax(0,1fr)_auto] items-center gap-2 px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  expanded && "bg-accent/35",
+                )}
+              >
+                {expanded ? (
+                  <ChevronDown className="size-3 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="size-3 text-muted-foreground" />
+                )}
+                <FileStatusBadge status={file.status} />
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">{file.filename}</span>
+                  {file.previousFilename ? (
+                    <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                      from {file.previousFilename}
+                    </span>
+                  ) : null}
+                </span>
+                <span className="font-mono text-[10px] tabular-nums">
+                  <span className="text-emerald-500">+{file.additions}</span>
+                  <span className="mx-1 text-muted-foreground/50">/</span>
+                  <span className="text-destructive">-{file.deletions}</span>
+                </span>
+              </button>
+              {expanded ? <PatchView file={file} /> : null}
+            </li>
+          );
+        })}
       </ol>
-      {selected ? <PatchView file={selected} /> : null}
     </div>
   );
 }
@@ -432,15 +457,23 @@ function fileStatusMeta(status: string): {
 
 function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
   return (
-    <div className="min-w-0 max-w-full overflow-hidden p-2">
+    <div
+      id={diffPanelId(file.filename)}
+      className="min-w-0 max-w-full overflow-hidden border-t border-border/60"
+    >
       <PatchDiffView
         patch={file.patch}
         filename={file.filename}
         previousFilename={file.previousFilename}
         status={file.status}
+        className="rounded-none ring-0"
       />
     </div>
   );
+}
+
+function diffPanelId(filename: string): string {
+  return `diff-${filename.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 }
 
 function ChecksView({
@@ -562,10 +595,10 @@ function CheckRunRow({
           type="button"
           onClick={toggleExpand}
           disabled={!canLoadLogs}
-          className="grid min-w-0 flex-1 grid-cols-[0.875rem_1fr] items-center gap-2 text-left"
+          className="grid min-w-0 flex-1 grid-cols-[0.875rem_1fr] items-start gap-2 text-left"
           title={canLoadLogs ? "View logs" : "No workflow job logs available for this check"}
         >
-          <runMeta.Icon className={cn("size-3.5 shrink-0", runMeta.className)} />
+          <runMeta.Icon className={cn("size-3.5 shrink-0 pt-0.5", runMeta.className)} />
           <span className="min-w-0">
             <span className="block truncate font-medium">{run.name}</span>
             <span className="block truncate font-mono text-[10px] text-muted-foreground">

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -88,12 +88,19 @@ export function PullRequestPanel({
               {pullRequest.title}
             </h2>
             <div className="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
-              <span className="rounded bg-secondary px-1.5 py-0.5">
-                {pullRequest.baseBranch}
-              </span>
-              <span>&lt;-</span>
-              <span className="rounded bg-secondary px-1.5 py-0.5">
-                {pullRequest.headBranch}
+              <span className="inline-flex items-center gap-1">
+                <span className="rounded bg-secondary px-1.5 py-0.5">
+                  {pullRequest.baseBranch}
+                </span>
+                <span
+                  aria-hidden
+                  className="inline-flex w-3.5 ml-1 shrink-0 items-center justify-center"
+                >
+                  &lt;-
+                </span>
+                <span className="rounded bg-secondary px-1.5 py-0.5">
+                  {pullRequest.headBranch}
+                </span>
               </span>
               <span className="text-muted-foreground/50">|</span>
               <InlineStat value={pullRequest.changedFiles} label="files" />
@@ -365,17 +372,19 @@ export function LocalChangesView({
                 aria-expanded={expanded}
                 aria-controls={diffPanelId(file.filename)}
                 className={cn(
-                  "grid w-full grid-cols-[0.75rem_1rem_minmax(0,1fr)_auto] items-center gap-2 px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  "grid w-full grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-1 px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                   expanded && "bg-accent/35",
                 )}
               >
-                {expanded ? (
-                  <ChevronDown className="size-3 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="size-3 text-muted-foreground" />
-                )}
+                <span className="inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-accent/50">
+                  {expanded ? (
+                    <ChevronDown className="size-3 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="size-3 text-muted-foreground" />
+                  )}
+                </span>
                 <FileStatusBadge status={file.status} />
-                <span className="min-w-0">
+                <span className="min-w-0 pl-1.5">
                   <span className="block truncate font-medium">{file.filename}</span>
                   {file.previousFilename ? (
                     <span className="block truncate font-mono text-[10px] text-muted-foreground">
@@ -403,7 +412,7 @@ function FileStatusBadge({ status }: { status: string }) {
   return (
     <span
       className={cn(
-        "inline-flex size-4 items-center justify-center rounded-sm font-mono text-[10px] font-semibold ring-1",
+        "inline-flex size-3.5 items-center justify-center rounded-sm font-mono text-[9px] font-semibold leading-none ring-1",
         meta.className,
       )}
       title={meta.label}

--- a/components/features/run-trace/project-diff-panel.tsx
+++ b/components/features/run-trace/project-diff-panel.tsx
@@ -33,7 +33,6 @@ export function ProjectDiffPanel({
   const [localDiff, setLocalDiff] = useState<ProjectLocalDiffSummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
   const projectId = project?.status === "ready" ? project.id : null;
 
@@ -112,8 +111,6 @@ export function ProjectDiffPanel({
   }
 
   const files = localDiff?.files ?? [];
-  const selected =
-    files.find((file) => file.filename === selectedFile) ?? files[0] ?? null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -173,11 +170,7 @@ export function ProjectDiffPanel({
         </div>
       ) : files.length > 0 ? (
         <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
-          <LocalChangesView
-            files={files}
-            selected={selected}
-            onSelect={setSelectedFile}
-          />
+          <LocalChangesView files={files} />
         </div>
       ) : (
         <div className="px-3 py-4">

--- a/components/features/run-trace/project-diff-panel.tsx
+++ b/components/features/run-trace/project-diff-panel.tsx
@@ -124,12 +124,6 @@ export function ProjectDiffPanel({
                 </span>
                 <span>·</span>
                 <span>{gitStatus.dirtyCount} dirty</span>
-                {gitStatus.upstream ? (
-                  <>
-                    <span>·</span>
-                    <span className="font-mono">{gitStatus.upstream}</span>
-                  </>
-                ) : null}
                 {gitStatus.ahead !== null && gitStatus.behind !== null ? (
                   <>
                     <span>·</span>

--- a/components/features/run-trace/project-run-details.tsx
+++ b/components/features/run-trace/project-run-details.tsx
@@ -516,7 +516,7 @@ function ToolCallExpandPanel({
   return (
     <div
       className={cn(
-        "mt-1.5 rounded-md border border-border/50 bg-background/30 px-2 py-1.5 text-[10px]",
+        "rounded-md border border-border/50 bg-background/30 px-2 py-1.5 text-[10px]",
         errored && "border-destructive/25 bg-destructive/[0.03]",
         denied && "border-border/40 bg-secondary/15",
       )}

--- a/components/features/run-trace/trace-timeline-ui.tsx
+++ b/components/features/run-trace/trace-timeline-ui.tsx
@@ -233,11 +233,11 @@ export function TraceTimelineRow({
               {summary}
             </p>
           ) : null}
-
-          {expandable && expanded && children ? (
-            <div className="mt-1.5">{children}</div>
-          ) : null}
         </div>
+
+        {expandable && expanded && children ? (
+          <div className="col-span-2 mt-1.5 min-w-0">{children}</div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render PR Changes and local Diff tabs as one expandable changed-file list
- move each file patch inline under its own row instead of using a separate selected-file diff area
- keep the shared `LocalChangesView` so both tabs stay visually consistent

## Issue
Refs #125

## Verification
- pnpm typecheck
- pnpm lint

## Notes
- This is stacked on `codex/123-github-pat-auth` because it builds on the active run trace and PR panel changes.
- Browser automation was not available in this session; the local dev server was reachable at `http://localhost:3000`.