### PR TITLE
[codex] Harden verification recovery policy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Polished trace workspace file tabs, headers, and Pierre code view scrolling/gutter behavior.
 - [✔️] Synced file tree git status badges with local `git status`, including header dirty counts and refresh on focus.
 - [✔️] Replaced global active-project localStorage with session-scoped composer project picker that locks after the first message (#107).
+- [✔️] Hardened verification classification and post-edit rollback for cache-safe agent recovery.
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/src/agent/tool-policy.ts
+++ b/src/agent/tool-policy.ts
@@ -49,6 +49,7 @@ export type ToolPolicySeed = {
   recoveryReadUsedByPath?: string[];
   verifyCompleted?: boolean;
   verifyFixPending?: boolean;
+  verifyRecoveryUsed?: boolean;
   lastVerifyFailureSummary?: string;
   editedPaths?: string[];
   promoted?: boolean;
@@ -137,6 +138,7 @@ export class ToolPolicyEngine {
   private verifyNudgeCount = 0;
   private verifyFixPending = false;
   private verifyFixNoteCount = 0;
+  private verifyRecoveryUsed = false;
   private lastVerifyFailureSummary: string | undefined;
   private editedPaths = new Set<string>();
   private pendingStaleReadNote: string | undefined;
@@ -203,6 +205,10 @@ export class ToolPolicyEngine {
       this.hadStateChangingSuccess &&
       !this.verifyCompleted
     );
+  }
+
+  getEditedPathsSnapshot(): string[] {
+    return [...this.editedPaths];
   }
 
   consumeVerifyReminder(): string | undefined {
@@ -291,8 +297,11 @@ export class ToolPolicyEngine {
         this.lastVerifyFailureSummary = input.lastVerifyFailureSummary;
       }
     }
+    if (input.verifyRecoveryUsed === true) {
+      this.verifyRecoveryUsed = true;
+    }
     for (const path of input.editedPaths ?? []) {
-      this.editedPaths.add(path);
+      this.editedPaths.add(normalizeToolPath(path) ?? path);
     }
   }
 
@@ -405,12 +414,31 @@ export class ToolPolicyEngine {
     }
 
     if (this.needsVerifyFix()) {
+      const path = pathFromInput(input);
+      const normalizedPath = normalizeToolPath(path);
+      if (
+        toolName === "edit_text" &&
+        normalizedPath &&
+        !this.editedPaths.has(normalizedPath)
+      ) {
+        this.recordBlockedAttempt();
+        return blockedOutput(
+          `Verification recovery is limited to edited files. \`${path}\` was not edited in this run.`,
+          "edit_text",
+          { phase: this.phase, affectedPath: path },
+        );
+      }
       if (
         toolName === "bash" ||
         toolName === "grep" ||
         toolName === "glob" ||
         toolName === "inspect_project" ||
-        toolName === "delegate_task"
+        toolName === "delegate_task" ||
+        toolName === "edit_file" ||
+        toolName === "replace_text" ||
+        toolName === "replace_lines" ||
+        toolName === "multi_replace_text" ||
+        toolName === "write_file"
       ) {
         this.recordBlockedAttempt();
         return blockedOutput(
@@ -784,9 +812,12 @@ export class ToolPolicyEngine {
       const nextHash =
         typeof output.nextHash === "string" ? output.nextHash : undefined;
       if (path && nextHash) {
+        if (this.verifyFixPending) {
+          this.verifyRecoveryUsed = true;
+        }
         this.lastSuccessfulEdit = { path, nextHash };
         this.lastHashByPath.set(path, nextHash);
-        this.editedPaths.add(path);
+        this.editedPaths.add(normalizeToolPath(path) ?? path);
         this.fullCoveragePaths.delete(path);
         for (const key of [...this.lastReadHashByRange.keys()]) {
           if (key.startsWith(`read_file:${path}:`)) {
@@ -879,14 +910,27 @@ export class ToolPolicyEngine {
       }
     }
 
-    if (toolName === "verify" && success && isRecord(output)) {
-      if (output.ok === true) {
+    if (toolName === "verify" && isRecord(output)) {
+      const status = typeof output.status === "string" ? output.status : undefined;
+      const failureScope =
+        typeof output.failureScope === "string" ? output.failureScope : undefined;
+      const recoverableEditedFailure =
+        status === "failed" &&
+        failureScope === "edited_file" &&
+        !this.verifyRecoveryUsed;
+
+      if (output.ok === true || status === "passed" || status === "skipped") {
         this.verifyCompleted = true;
         this.verifyFixPending = false;
         this.verifyFixNoteCount = 0;
         this.lastVerifyFailureSummary = undefined;
         this.phase = "final";
-      } else {
+        if (status === "skipped") {
+          this.forceFinalReason =
+            extractVerifyFailureSummary(output) ??
+            "Verification was skipped. Write the final answer with that reason.";
+        }
+      } else if (recoverableEditedFailure) {
         this.verifyCompleted = false;
         this.verifyFixPending = true;
         this.phase = "recoverEdit";
@@ -895,6 +939,15 @@ export class ToolPolicyEngine {
         for (const editedPath of this.editedPaths) {
           this.recoveryReadAllowedByPath.add(editedPath);
         }
+      } else {
+        this.verifyCompleted = true;
+        this.verifyFixPending = false;
+        this.verifyFixNoteCount = 0;
+        this.phase = "final";
+        this.lastVerifyFailureSummary = extractVerifyFailureSummary(output);
+        this.forceFinalReason =
+          this.lastVerifyFailureSummary ??
+          "Verification did not pass. Write the final answer with the latest verification result.";
       }
     }
 
@@ -958,6 +1011,7 @@ export function seedFromPriorToolRecords(
   let lastSuccessfulEdit: { path: string; nextHash: string } | undefined;
   let phase: ToolPolicyPhase = "explore";
   let verifyFixPending = false;
+  let verifyRecoveryUsed = false;
   let lastVerifyFailureSummary: string | undefined;
   const editedPaths = new Set<string>();
 
@@ -999,7 +1053,8 @@ export function seedFromPriorToolRecords(
       if (path && nextHash) {
         lastSuccessfulEdit = { path, nextHash };
         lastHashByPath[path] = nextHash;
-        editedPaths.add(path);
+        if (verifyFixPending) verifyRecoveryUsed = true;
+        editedPaths.add(normalizeToolPath(path) ?? path);
         phase = "postEdit";
       }
     }
@@ -1033,12 +1088,27 @@ export function seedFromPriorToolRecords(
         if (path && hash) multiReplaceBlockedKeys.push(`${path}:${hash}`);
       }
     }
-    if (record.toolName === "verify" && record.success && isRecord(record.output)) {
-      if (record.output.ok === true) {
+    if (record.toolName === "verify" && isRecord(record.output)) {
+      const status =
+        typeof record.output.status === "string" ? record.output.status : undefined;
+      const failureScope =
+        typeof record.output.failureScope === "string"
+          ? record.output.failureScope
+          : undefined;
+      const recoverableEditedFailure =
+        status === "failed" &&
+        failureScope === "edited_file" &&
+        !verifyRecoveryUsed;
+      if (record.output.ok === true || status === "passed" || status === "skipped") {
         phase = "final";
-      } else {
-        phase = "postEdit";
+        verifyFixPending = false;
+      } else if (recoverableEditedFailure) {
+        phase = "recoverEdit";
         verifyFixPending = true;
+        lastVerifyFailureSummary = extractVerifyFailureSummary(record.output);
+      } else {
+        phase = "final";
+        verifyFixPending = false;
         lastVerifyFailureSummary = extractVerifyFailureSummary(record.output);
       }
     }
@@ -1047,9 +1117,13 @@ export function seedFromPriorToolRecords(
   const verifyCompleted = records.some(
     (record) =>
       record.toolName === "verify" &&
-      record.success &&
       isRecord(record.output) &&
-      record.output.ok === true,
+      (record.output.ok === true ||
+        record.output.status === "passed" ||
+        record.output.status === "skipped" ||
+        (record.output.status === "failed" &&
+          record.output.failureScope !== "edited_file") ||
+        record.output.status === "command_broken"),
   );
 
   return {
@@ -1068,6 +1142,7 @@ export function seedFromPriorToolRecords(
             ? { lastVerifyFailureSummary }
             : {}),
           editedPaths: [...editedPaths],
+          ...(verifyRecoveryUsed ? { verifyRecoveryUsed: true } : {}),
         }
       : {}),
     ...(lastSuccessfulEdit ? { lastSuccessfulEdit } : {}),

--- a/src/agent/tools/edit-text.ts
+++ b/src/agent/tools/edit-text.ts
@@ -76,8 +76,12 @@ export function createEditTextTool(workspaceRoot?: string) {
         }
 
         await atomicWriteTextFile(abs, result.content);
+        const diff = buildDisplayDiff(previous.content, result.content);
+        const patch = createPatch(relPath, previous.content, result.content);
+        const patchPreview =
+          patch.length > 8_000 ? `${patch.slice(0, 8_000)}\n...` : patch;
         const lint = await lintEditedFile(relPath, workspaceRoot);
-        if (!lint.ok && !lint.skipped) {
+        if (!lint.ok && !lint.skipped && lint.blocking) {
           await atomicWriteTextFile(abs, previous.content);
           return structuredError({
             code: "SYNTAX_OR_LINT_FAILED",
@@ -86,11 +90,12 @@ export function createEditTextTool(workspaceRoot?: string) {
             currentHash: previous.sha256,
             lintIssues: lint.issues,
             lintSummary: lint.summary,
+            failedPatchPreview: patchPreview,
+            postEditLint: "failed_blocking",
+            rolledBack: true,
           });
         }
 
-        const diff = buildDisplayDiff(previous.content, result.content);
-        const patch = createPatch(relPath, previous.content, result.content);
         return {
           ok: true as const,
           path: relPath,
@@ -100,11 +105,17 @@ export function createEditTextTool(workspaceRoot?: string) {
           nextHash: sha256(result.content),
           bytesWritten: Buffer.byteLength(result.content, "utf8"),
           diff,
-          patchPreview: patch.length > 8_000 ? `${patch.slice(0, 8_000)}\n…` : patch,
+          patchPreview,
           priorReadStale: true as const,
           ...(lint.skipped
             ? { postEditLint: "skipped" as const, postEditLintReason: lint.reason }
-            : { postEditLint: "passed" as const }),
+            : lint.ok
+              ? { postEditLint: "passed" as const }
+              : {
+                  postEditLint: "failed_non_blocking" as const,
+                  postEditLintSummary: lint.summary,
+                  postEditLintIssues: lint.issues.slice(0, 5),
+                }),
         };
       } catch (err) {
         if (err instanceof SandboxError && err.message.includes("guard")) {
@@ -143,9 +154,15 @@ function structuredError(input: {
     line: number;
     column: number;
     message: string;
+    severity?: string;
+    category?: string;
+    blocking?: boolean;
     ruleId?: string;
   }[];
   lintSummary?: string;
+  failedPatchPreview?: string;
+  postEditLint?: "failed_blocking";
+  rolledBack?: boolean;
 }) {
   const diagnostics =
     input.code === "FIND_NOT_FOUND" && input.find && input.content
@@ -161,6 +178,8 @@ function structuredError(input: {
     message: input.message,
     error: input.message,
     noChangesApplied: true as const,
+    ...(input.rolledBack ? { rolledBack: true as const } : {}),
+    ...(input.postEditLint ? { postEditLint: input.postEditLint } : {}),
     ...(input.failedEditIndex !== undefined
       ? { failedEditIndex: input.failedEditIndex }
       : {}),
@@ -168,6 +187,9 @@ function structuredError(input: {
     ...(input.lintSummary ? { lintSummary: input.lintSummary } : {}),
     ...(input.lintIssues?.length
       ? { lintIssues: input.lintIssues.slice(0, 5) }
+      : {}),
+    ...(input.failedPatchPreview
+      ? { failedPatchPreview: input.failedPatchPreview }
       : {}),
     ...diagnostics,
   };
@@ -184,6 +206,10 @@ function compactEditTextModelOutput(output: unknown): JSONValue {
       path: stringValue(output.path),
       message: stringValue(output.message) || stringValue(output.error),
       noChangesApplied: true,
+      ...(output.rolledBack === true ? { rolledBack: true } : {}),
+      ...(stringValue(output.postEditLint)
+        ? { postEditLint: stringValue(output.postEditLint) }
+        : {}),
       ...(typeof output.failedEditIndex === "number"
         ? { failedEditIndex: output.failedEditIndex }
         : {}),
@@ -209,6 +235,15 @@ function compactEditTextModelOutput(output: unknown): JSONValue {
     nextHash: stringValue(output.nextHash),
     diff: stringValue(output.diff),
     priorReadStale: true,
+    ...(stringValue(output.postEditLint)
+      ? { postEditLint: stringValue(output.postEditLint) }
+      : {}),
+    ...(stringValue(output.postEditLintSummary)
+      ? { postEditLintSummary: stringValue(output.postEditLintSummary) }
+      : {}),
+    ...(Array.isArray(output.postEditLintIssues)
+      ? { postEditLintIssues: output.postEditLintIssues.slice(0, 5) }
+      : {}),
   };
 }
 

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -165,7 +165,9 @@ export function createAntonTools({
     revert_changes: createRevertChangesTool(workspaceRoot),
     bash: createBashTool(workspaceRoot),
     inspect_project: createInspectProjectTool(workspaceRoot),
-    verify: createVerifyTool(workspaceRoot, profile),
+    verify: createVerifyTool(workspaceRoot, profile, {
+      getEditedPaths: () => toolPolicy?.getEditedPathsSnapshot() ?? [],
+    }),
     grep: createGrepTool(workspaceRoot),
     glob: createGlobTool(workspaceRoot),
     list_skills: createListSkillsTool(workspaceRoot),

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -157,6 +157,23 @@ export function compactVerifyForModel(output: unknown): unknown {
     ? results.find((result) => isRecord(result) && result.ok === false)
     : undefined;
   const failureSummary = extractVerifyFailureSummary(output);
+  const base = {
+    ok: output.ok,
+    status: output.status,
+    failureScope: output.failureScope,
+    recommendedNext: output.recommendedNext,
+    summary: output.summary,
+    packageManager: output.packageManager,
+    ranCount: output.ranCount,
+    skippedCount: output.skippedCount,
+    editedPaths: Array.isArray(output.editedPaths)
+      ? output.editedPaths.slice(0, 10)
+      : output.editedPaths,
+    pathHints: Array.isArray(output.pathHints)
+      ? output.pathHints.slice(0, 5)
+      : output.pathHints,
+    ...(failureSummary ? { failureSummary } : {}),
+  };
   const parseIssues =
     failed && isRecord(failed)
       ? extractParseIssuesFromText(
@@ -168,12 +185,8 @@ export function compactVerifyForModel(output: unknown): unknown {
 
   if (output.ok === false) {
     return {
+      ...base,
       ok: false,
-      summary: output.summary,
-      packageManager: output.packageManager,
-      ranCount: output.ranCount,
-      skippedCount: output.skippedCount,
-      ...(failureSummary ? { failureSummary } : {}),
       ...(parseIssues.length > 0 ? { parseIssues: parseIssues.slice(0, 5) } : {}),
       ...(failed && isRecord(failed)
         ? {
@@ -186,17 +199,19 @@ export function compactVerifyForModel(output: unknown): unknown {
   }
 
   return {
-    ok: output.ok,
-    summary: output.summary,
-    packageManager: output.packageManager,
-    ranCount: output.ranCount,
-    skippedCount: output.skippedCount,
+    ...base,
     results,
   };
 }
 
 export function extractVerifyFailureSummary(output: unknown): string | undefined {
   if (!isRecord(output)) return undefined;
+  if (
+    typeof output.failureSummary === "string" &&
+    output.failureSummary.trim().length > 0
+  ) {
+    return output.failureSummary.trim();
+  }
   if (typeof output.summary === "string" && output.summary.trim().length > 0) {
     const base = output.summary.trim();
     if (!Array.isArray(output.results)) return base;

--- a/src/agent/tools/post-edit-lint.ts
+++ b/src/agent/tools/post-edit-lint.ts
@@ -15,6 +15,9 @@ export type PostEditLintIssue = {
   line: number;
   column: number;
   message: string;
+  severity: "error" | "warning" | "unknown";
+  category: "parser" | "syntax" | "unused" | "formatting" | "style" | "other";
+  blocking: boolean;
   ruleId?: string;
 };
 
@@ -24,6 +27,7 @@ export type PostEditLintResult =
   | {
       ok: false;
       skipped: false;
+      blocking: boolean;
       issues: PostEditLintIssue[];
       summary: string;
       rawOutput?: string;
@@ -105,13 +109,14 @@ export async function lintEditedFile(
       (issue) =>
         `${normalizedPath}:${issue.line}:${issue.column} ${issue.message}${
           issue.ruleId ? ` (${issue.ruleId})` : ""
-        }`,
+        } [${issue.severity}/${issue.category}]`,
     )
     .join("; ");
 
   return {
     ok: false,
     skipped: false,
+    blocking: issues.some((issue) => issue.blocking),
     issues,
     summary,
     ...(combined.trim().length > 0 ? { rawOutput: combined.slice(0, 4_000) } : {}),
@@ -145,7 +150,24 @@ function parseJsonLintOutput(output: string, relPath: string): PostEditLintIssue
             : "eslint reported an issue on the edited file.";
         const ruleId =
           typeof message.ruleId === "string" ? message.ruleId : undefined;
-        return [{ line, column, message: text, ...(ruleId ? { ruleId } : {}) }];
+        const severity = lintSeverity(message.severity);
+        const classified = classifyLintIssue({
+          message: text,
+          ruleId,
+          severity,
+          fatal: message.fatal === true,
+        });
+        return [
+          {
+            line,
+            column,
+            message: text,
+            severity,
+            category: classified.category,
+            blocking: classified.blocking,
+            ...(ruleId ? { ruleId } : {}),
+          },
+        ];
       });
     });
   } catch {
@@ -187,6 +209,13 @@ function parseTextLintOutput(output: string, relPath: string): PostEditLintIssue
     const columnText = isUnix ? columnTextOrMessage : lineTextOrColumn;
     const message = isUnix ? messageOrRule : columnTextOrMessage;
     const ruleId = isUnix ? ruleIdOrUndefined : messageOrRule;
+    const severity = /\bwarning\b/i.test(trimmed) ? "warning" : "error";
+    const classified = classifyLintIssue({
+      message: message.trim(),
+      ruleId,
+      severity,
+      fatal: false,
+    });
     if (isUnix) {
       if (!filePart?.includes(basename) && !trimmed.includes(relPath)) continue;
     } else if (!currentFileMatches) {
@@ -196,10 +225,52 @@ function parseTextLintOutput(output: string, relPath: string): PostEditLintIssue
       line: Number.parseInt(lineText, 10),
       column: Number.parseInt(columnText, 10),
       message: message.trim(),
+      severity,
+      category: classified.category,
+      blocking: classified.blocking,
       ...(ruleId ? { ruleId: ruleId.trim() } : {}),
     });
   }
   return issues;
+}
+
+function lintSeverity(value: unknown): PostEditLintIssue["severity"] {
+  if (value === 1) return "warning";
+  if (value === 2) return "error";
+  return "unknown";
+}
+
+function classifyLintIssue(input: {
+  message: string;
+  ruleId?: string;
+  severity: PostEditLintIssue["severity"];
+  fatal: boolean;
+}): Pick<PostEditLintIssue, "category" | "blocking"> {
+  const message = input.message.toLowerCase();
+  const ruleId = input.ruleId?.toLowerCase() ?? "";
+  const parserOrSyntax =
+    input.fatal ||
+    ruleId.includes("parser") ||
+    /\b(parsing error|unexpected token|unexpected end of input|unterminated|string literal|missing initializer|declaration or statement expected|expression expected|identifier expected|invalid character)\b/i.test(
+      input.message,
+    ) ||
+    /('\}' expected|'\)' expected|'\]' expected|',' expected|';' expected|expected corresponding jsx closing tag|has no corresponding closing tag)/i.test(
+      input.message,
+    );
+
+  if (parserOrSyntax) {
+    return { category: ruleId.includes("parser") ? "parser" : "syntax", blocking: true };
+  }
+  if (ruleId.includes("no-unused") || message.includes("is defined but never used")) {
+    return { category: "unused", blocking: false };
+  }
+  if (ruleId.includes("prettier") || message.includes("prettier")) {
+    return { category: "formatting", blocking: false };
+  }
+  if (input.severity === "warning") {
+    return { category: "style", blocking: false };
+  }
+  return { category: "other", blocking: false };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/agent/tools/process.ts
+++ b/src/agent/tools/process.ts
@@ -12,6 +12,7 @@ export type ProcessResult = {
   stdout: string;
   stderr: string;
   timedOut?: boolean;
+  failedToStart?: boolean;
 };
 
 export async function runWorkspaceProcess(
@@ -39,6 +40,7 @@ export async function runWorkspaceProcess(
       stdout: truncate(outputText(err, "stdout")),
       stderr: truncate(outputText(err, "stderr") || errorMessage(err)),
       timedOut: timedOut(err),
+      failedToStart: failedToStart(err),
     };
   }
 }
@@ -67,6 +69,17 @@ function timedOut(err: unknown): boolean {
   if (typeof err !== "object" || err === null || !("killed" in err)) return false;
   const record = err as { killed?: unknown; signal?: unknown };
   return record.killed === true && record.signal === "SIGTERM";
+}
+
+function failedToStart(err: unknown): boolean {
+  if (typeof err !== "object" || err === null || !("code" in err)) return false;
+  const code = (err as { code: unknown }).code;
+  return (
+    code === "ENOENT" ||
+    code === "EACCES" ||
+    code === "EPERM" ||
+    code === "UNKNOWN"
+  );
 }
 
 function errorMessage(err: unknown): string {

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { tool, type JSONValue } from "ai";
 import { z } from "zod";
 
@@ -20,10 +22,35 @@ import {
 
 const MAX_TIMEOUT_MS = 300_000;
 const MODEL_OUTPUT_TEXT_CAP = 8_000;
+const PATH_HINT_CAP = 20;
 
 const verificationTargetSchema = z.enum(["typecheck", "lint", "build"]);
 
 export type VerificationTarget = z.infer<typeof verificationTargetSchema>;
+
+export type VerificationStatus =
+  | "passed"
+  | "failed"
+  | "skipped"
+  | "command_broken";
+
+export type VerificationFailureScope =
+  | "edited_file"
+  | "unrelated"
+  | "unknown";
+
+export type VerificationRecommendedNext =
+  | "final"
+  | "fix_edited_file"
+  | "report_unrelated"
+  | "report_skipped"
+  | "report_command_broken";
+
+export type VerificationPathHint = {
+  path: string;
+  line?: number;
+  column?: number;
+};
 
 export type VerificationPlan =
   | {
@@ -58,7 +85,12 @@ type VerificationResult =
       stdout?: string;
       stderr?: string;
       error?: string;
+      commandBroken?: boolean;
     };
+
+type CreateVerifyToolOptions = {
+  getEditedPaths?: () => readonly string[];
+};
 
 const DEFAULT_TARGETS: readonly VerificationTarget[] = [
   "typecheck",
@@ -69,6 +101,7 @@ const DEFAULT_TARGETS: readonly VerificationTarget[] = [
 export function createVerifyTool(
   workspaceRoot?: string,
   profile: AgentRunProfile = "general-chat",
+  options: CreateVerifyToolOptions = {},
 ) {
   const defaults = verifyDefaultsForProfile(profile);
   return tool({
@@ -98,6 +131,7 @@ export function createVerifyTool(
       const root = workspaceRoot
         ? ensureWorkspaceRootAt(workspaceRoot)
         : ensureWorkspaceRoot();
+      const editedPaths = normalizeUniquePaths(options.getEditedPaths?.() ?? []);
       const resolvedTargets =
         targets ??
         defaultTargetsForProfile(root, profile) ??
@@ -106,7 +140,15 @@ export function createVerifyTool(
       const plan = planVerification(root, {
         targets: resolvedTargets,
       });
-      if (!plan.ok) return plan;
+      if (!plan.ok) {
+        return buildVerificationOutput({
+          editedPaths,
+          packageManager: undefined,
+          results: [],
+          planError: plan.error,
+          workspaceRoot: root,
+        });
+      }
 
       const results: VerificationResult[] = [];
       for (const step of plan.steps) {
@@ -127,6 +169,7 @@ export function createVerifyTool(
             skipped: false,
             ok: false,
             error: "Verification command is empty.",
+            commandBroken: true,
           });
           break;
         }
@@ -144,6 +187,7 @@ export function createVerifyTool(
           timedOut: result.timedOut ?? false,
           stdout: capOutput(result.stdout),
           stderr: capOutput(result.stderr),
+          ...(result.failedToStart ? { commandBroken: true as const } : {}),
           ...(ok
             ? {}
             : {
@@ -158,23 +202,226 @@ export function createVerifyTool(
         if (!ok) break;
       }
 
-      const ranCount = results.filter((result) => !result.skipped).length;
-      const failed = results.filter((result) => !result.ok);
-      return {
-        ok: failed.length === 0,
+      return buildVerificationOutput({
+        editedPaths,
         packageManager: plan.packageManager,
-        ranCount,
-        skippedCount: results.length - ranCount,
         results,
-        summary:
-          ranCount === 0
-            ? "No verification scripts were available."
-            : failed.length === 0
-              ? `Verification passed for ${ranCount} target${ranCount === 1 ? "" : "s"}.`
-              : `Verification failed for ${failed.length} target${failed.length === 1 ? "" : "s"}.`,
-      };
+        workspaceRoot: root,
+      });
     },
   });
+}
+
+function buildVerificationOutput(input: {
+  editedPaths: readonly string[];
+  packageManager: PackageManager | undefined;
+  results: readonly VerificationResult[];
+  planError?: string;
+  workspaceRoot: string;
+}) {
+  const ranCount = input.results.filter((result) => !result.skipped).length;
+  const failed = input.results.filter((result) => !result.ok);
+  const status = verificationStatus(input.results, input.planError);
+  const failedText = failed
+    .map((result) => failedResultText(result))
+    .filter((text) => text.length > 0)
+    .join("\n");
+  const pathHints = extractPathHints(
+    failedText,
+    input.editedPaths,
+    input.workspaceRoot,
+  );
+  const failureScope = failureScopeForHints(pathHints, input.editedPaths);
+  const recommendedNext = recommendedNextForStatus(status, failureScope);
+  const failureSummary = failureSummaryForStatus({
+    status,
+    failed,
+    planError: input.planError,
+    pathHints,
+  });
+
+  return {
+    ok: status === "passed" || status === "skipped",
+    status,
+    failureScope,
+    recommendedNext,
+    editedPaths: input.editedPaths,
+    pathHints,
+    ...(failureSummary ? { failureSummary } : {}),
+    ...(input.packageManager ? { packageManager: input.packageManager } : {}),
+    ranCount,
+    skippedCount: input.results.length - ranCount,
+    results: input.results,
+    summary:
+      status === "passed"
+        ? `Verification passed for ${ranCount} target${ranCount === 1 ? "" : "s"}.`
+        : status === "skipped"
+          ? (input.planError ?? "No verification scripts were available.")
+          : status === "command_broken"
+            ? "Verification command could not be executed."
+            : `Verification failed for ${failed.length} target${failed.length === 1 ? "" : "s"}.`,
+  };
+}
+
+function verificationStatus(
+  results: readonly VerificationResult[],
+  planError: string | undefined,
+): VerificationStatus {
+  if (planError) return "skipped";
+  const ran = results.filter((result) => !result.skipped);
+  if (ran.length === 0) return "skipped";
+  if (ran.some((result) => !result.ok && result.commandBroken === true)) {
+    return "command_broken";
+  }
+  if (ran.some((result) => !result.ok)) return "failed";
+  return "passed";
+}
+
+function recommendedNextForStatus(
+  status: VerificationStatus,
+  failureScope: VerificationFailureScope,
+): VerificationRecommendedNext {
+  if (status === "passed") return "final";
+  if (status === "skipped") return "report_skipped";
+  if (status === "command_broken") return "report_command_broken";
+  if (failureScope === "edited_file") return "fix_edited_file";
+  if (failureScope === "unrelated") return "report_unrelated";
+  return "final";
+}
+
+function failureScopeForHints(
+  pathHints: readonly VerificationPathHint[],
+  editedPaths: readonly string[],
+): VerificationFailureScope {
+  if (pathHints.length === 0) return "unknown";
+  const edited = new Set(editedPaths.map(normalizeToolPath));
+  return pathHints.some((hint) => edited.has(normalizeToolPath(hint.path)))
+    ? "edited_file"
+    : "unrelated";
+}
+
+function failureSummaryForStatus(input: {
+  status: VerificationStatus;
+  failed: readonly VerificationResult[];
+  planError?: string;
+  pathHints: readonly VerificationPathHint[];
+}): string | undefined {
+  if (input.status === "passed") return undefined;
+  if (input.status === "skipped") {
+    return input.planError ?? "No verification scripts were available.";
+  }
+  const firstFailed = input.failed.find((result) => !result.skipped);
+  if (!firstFailed || firstFailed.skipped) return undefined;
+  const text = failedResultText(firstFailed);
+  const primaryLine = firstMeaningfulLine(text);
+  const hint = input.pathHints[0];
+  const location = hint
+    ? `${hint.path}${hint.line !== undefined ? `:${hint.line}` : ""}${
+        hint.column !== undefined ? `:${hint.column}` : ""
+      }`
+    : undefined;
+  const prefix =
+    input.status === "command_broken"
+      ? "Verification command could not be executed"
+      : "Verification failed";
+  if (location && primaryLine) return `${prefix} at ${location}: ${primaryLine}`;
+  if (primaryLine) return `${prefix}: ${primaryLine}`;
+  return prefix;
+}
+
+function failedResultText(result: VerificationResult): string {
+  if (result.skipped) return result.reason;
+  return [result.stderr, result.stdout, result.error]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join("\n");
+}
+
+function firstMeaningfulLine(text: string): string | undefined {
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^>/.test(trimmed)) continue;
+    return trimmed.length > 240 ? `${trimmed.slice(0, 240)}...` : trimmed;
+  }
+  return undefined;
+}
+
+function extractPathHints(
+  text: string,
+  editedPaths: readonly string[],
+  workspaceRoot: string,
+): VerificationPathHint[] {
+  const hints: VerificationPathHint[] = [];
+  const seen = new Set<string>();
+  const editedBasenames = new Set(
+    editedPaths.map((editedPath) => path.posix.basename(normalizeToolPath(editedPath))),
+  );
+  const regex =
+    /((?:[A-Za-z]:)?(?:[./\\]|\w)[\w .@()[\]/\\-]*\.(?:ts|tsx|js|jsx|mjs|cjs|json|css|md|mdx|yml|yaml))(?:[:(](\d+))?(?::(\d+))?/g;
+
+  for (const match of text.matchAll(regex)) {
+    const rawPath = match[1];
+    if (!rawPath) continue;
+    const normalized = normalizeHintPath(rawPath, workspaceRoot);
+    if (!normalized) continue;
+    const basename = path.posix.basename(normalized);
+    if (
+      normalized.includes("node_modules/") &&
+      !editedBasenames.has(basename)
+    ) {
+      continue;
+    }
+    const line = parsePositiveInt(match[2]);
+    const column = parsePositiveInt(match[3]);
+    const key = `${normalized}:${line ?? ""}:${column ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    hints.push({
+      path: normalized,
+      ...(line !== undefined ? { line } : {}),
+      ...(column !== undefined ? { column } : {}),
+    });
+    if (hints.length >= PATH_HINT_CAP) break;
+  }
+  return hints;
+}
+
+function normalizeHintPath(value: string, workspaceRoot: string): string | undefined {
+  const trimmed = value
+    .replace(/^file:\/\//, "")
+    .replace(/^["'`([{<]+/, "")
+    .replace(/[)"'`>\],;]+$/, "")
+    .replace(/\\/g, "/");
+  const withoutDot = trimmed.replace(/^\.\//, "");
+  if (withoutDot.length === 0) return undefined;
+  if (isAbsolutePath(withoutDot)) {
+    const relative = path.win32.isAbsolute(withoutDot)
+      ? path.win32.relative(workspaceRoot, withoutDot)
+      : path.posix.relative(workspaceRoot.replace(/\\/g, "/"), withoutDot);
+    if (!relative.startsWith("..") && !isAbsolutePath(relative)) {
+      return normalizeToolPath(relative);
+    }
+  }
+  return normalizeToolPath(withoutDot);
+}
+
+function normalizeUniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.map(normalizeToolPath).filter(Boolean))];
+}
+
+function normalizeToolPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\//, "");
+  return normalized;
+}
+
+function isAbsolutePath(value: string): boolean {
+  return path.win32.isAbsolute(value) || path.posix.isAbsolute(value);
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function defaultTargetsForProfile(


### PR DESCRIPTION
﻿## Summary

Refs #130.

- Adds stable verification classification fields for status, failure scope, recommended next step, edited paths, path hints, and short failure summaries.
- Wires edited-path context into `verify` from `ToolPolicyEngine` without changing the verify input schema or active tool sets.
- Updates recovery policy so edited-file failures get one fix cycle, while unrelated, unknown, skipped, and command-broken verification outcomes finalize honestly.
- Makes post-edit lint rollback conservative: syntax/parser diagnostics roll back; non-blocking lint issues keep the edit with compact output.
- Records the completed Phase 3 work in `ROADMAP.md`.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- Manual temporary-workspace scenarios: skipped verify, edited-file verification failure, unrelated verification failure, command-broken verify, one-cycle recovery policy, syntax rollback, non-blocking lint retention, and normal passed verification.

## Notes

No tool input schemas, profile toolsets, or dynamic active-tool filtering were changed.
