### PR TITLE
Keep chat, Worklog, and Status run traces in sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Polished trace workspace file tabs, headers, and Pierre code view scrolling/gutter behavior.
 - [✔️] Synced file tree git status badges with local `git status`, including header dirty counts and refresh on focus.
 - [✔️] Replaced global active-project localStorage with session-scoped composer project picker that locks after the first message (#107).
+- [✔️] Made verification run independent targets in parallel with build-safe timeout reporting (#134).
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Polished trace workspace file tabs, headers, and Pierre code view scrolling/gutter behavior.
 - [✔️] Synced file tree git status badges with local `git status`, including header dirty counts and refresh on focus.
 - [✔️] Replaced global active-project localStorage with session-scoped composer project picker that locks after the first message (#107).
+- [✔️] Kept chat, Worklog, and Status reasoning traces aligned across live and persisted run views.
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1199,6 +1199,8 @@ function createTraceWriter({
   const effectiveProfile: AgentRunProfile = profile;
   const events = new Map<string, AntonActivityEvent>();
   const reasoningBuffers = new Map<string, string>();
+  const activeReasoningEventIds = new Map<string, string>();
+  const reasoningOccurrences = new Map<string, number>();
 
   const metadata = (
     status: AntonRunStatus,
@@ -1964,22 +1966,36 @@ function createTraceWriter({
     },
     handleStreamPart(part: TextStreamPart<ToolSet>) {
       if (part.type === "reasoning-delta") {
+        const eventId = activeReasoningEventIds.get(part.id);
+        const bufferId = eventId ?? `${runId}:reasoning:${part.id}`;
         reasoningBuffers.set(
-          part.id,
-          `${reasoningBuffers.get(part.id) ?? ""}${part.text}`,
+          bufferId,
+          `${reasoningBuffers.get(bufferId) ?? ""}${part.text}`,
         );
       }
       if (part.type === "reasoning-start") {
+        const occurrence = (reasoningOccurrences.get(part.id) ?? 0) + 1;
+        reasoningOccurrences.set(part.id, occurrence);
+        const eventId = `${runId}:reasoning:${part.id}:${occurrence}`;
+        activeReasoningEventIds.set(part.id, eventId);
         startEvent({
-          id: `${runId}:reasoning:${part.id}`,
+          id: eventId,
           kind: "reasoning",
           label: "Thinking",
+          details: {
+            reasoningPartId: part.id,
+            reasoningOccurrence: occurrence,
+          },
         });
       }
       if (part.type === "reasoning-end") {
-        const summary = reasoningBuffers.get(part.id)?.trim();
-        reasoningBuffers.delete(part.id);
-        finishEvent(`${runId}:reasoning:${part.id}`, {
+        const eventId =
+          activeReasoningEventIds.get(part.id) ??
+          `${runId}:reasoning:${part.id}`;
+        const summary = reasoningBuffers.get(eventId)?.trim();
+        reasoningBuffers.delete(eventId);
+        activeReasoningEventIds.delete(part.id);
+        finishEvent(eventId, {
           status: "completed",
           label: "Thought",
           ...(summary ? { summary: redactText(summary) } : {}),

--- a/components/features/run-trace/project-run-details.tsx
+++ b/components/features/run-trace/project-run-details.tsx
@@ -483,12 +483,19 @@ function buildStatusTraceRunGroups(
       steps: groupTimelineItemsByStep<StatusTraceTimelineEvent>(
         segmentEvents.map((event) => ({
           ...event,
-          durationMs: event.durationMs ?? undefined,
+          durationMs: statusEventDurationMs(event),
           startedAt: event.startedAt,
         })),
       ),
     };
   });
+}
+
+function statusEventDurationMs(
+  event: ProjectRunDetailsEvent,
+): number | undefined {
+  if (event.durationMs !== null) return event.durationMs;
+  return event.status === "running" ? undefined : 0;
 }
 
 function PermissionLabel({ label }: { label: string }) {

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -632,6 +632,141 @@ export function getTodoTraceDisplay(
   return displayByFirstPart;
 }
 
+type PartSequenceMarker = {
+  partIndex: number;
+  sequence: number;
+};
+
+function reasoningPartIdFromDetails(
+  event: AntonActivityEvent,
+): string | undefined {
+  const details = event.details;
+  if (!details) return undefined;
+  const value = details.reasoningPartId;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function buildPartSequenceMarkers(
+  message: AntonUIMessage,
+  toolEntries: ToolTraceEntry[],
+  activities: AntonActivityEvent[],
+): PartSequenceMarker[] {
+  const markers: PartSequenceMarker[] = [];
+  const seenKeys = new Set<string>();
+
+  const noteMarker = (partIndex: number, sequence: number, key: string) => {
+    if (seenKeys.has(key)) return;
+    seenKeys.add(key);
+    markers.push({ partIndex, sequence });
+  };
+
+  message.parts.forEach((part, index) => {
+    const toolCallId = toolCallIdForPart(part);
+    if (!toolCallId) return;
+    const tool = toolEntries.find((entry) => entry.id === toolCallId);
+    if (tool?.activity?.sequence !== undefined) {
+      noteMarker(index, tool.activity.sequence, `tool:${tool.id}`);
+    }
+  });
+
+  const reasoningEvents = activities
+    .filter((event) => event.kind === "reasoning")
+    .slice()
+    .sort((left, right) => left.sequence - right.sequence);
+  const matchedReasoningIds = new Set<string>();
+  message.parts.forEach((part, index) => {
+    if (!isReasoningPart(part)) return;
+    if (!("id" in part) || typeof part.id !== "string") return;
+    const event =
+      reasoningEvents.find(
+        (candidate) =>
+          !matchedReasoningIds.has(candidate.id) &&
+          reasoningPartIdFromDetails(candidate) === part.id,
+      ) ??
+      reasoningEvents.find(
+        (candidate) =>
+          !matchedReasoningIds.has(candidate.id) &&
+          candidate.id.endsWith(`:reasoning:${part.id}`),
+      );
+    if (!event) return;
+    matchedReasoningIds.add(event.id);
+    noteMarker(index, event.sequence, `reasoning:${event.id}`);
+  });
+
+  for (const event of activities) {
+    if (event.kind === "step") continue;
+    if (
+      event.kind === "tool" &&
+      toolEntries.some((entry) => entry.activity?.id === event.id)
+    ) {
+      continue;
+    }
+    if (
+      event.kind === "reasoning" &&
+      matchedReasoningIds.has(event.id)
+    ) {
+      continue;
+    }
+    noteMarker(-1, event.sequence, `activity:${event.id}`);
+  }
+
+  return markers.sort(
+    (left, right) =>
+      left.partIndex - right.partIndex || left.sequence - right.sequence,
+  );
+}
+
+function orderForPartIndex(
+  partIndex: number,
+  markers: readonly PartSequenceMarker[],
+): number {
+  const before = [...markers]
+    .reverse()
+    .find((marker) => marker.partIndex < partIndex);
+  const after = markers.find((marker) => marker.partIndex > partIndex);
+
+  if (before && after) {
+    const indexSpan = after.partIndex - before.partIndex;
+    const sequenceSpan = after.sequence - before.sequence;
+    if (indexSpan > 0 && sequenceSpan > 0) {
+      const fraction = (partIndex - before.partIndex) / indexSpan;
+      return before.sequence + fraction * sequenceSpan;
+    }
+    return before.sequence + 0.001;
+  }
+  if (before) return before.sequence + 0.001;
+  if (after) return after.sequence - 0.001;
+  return partIndex;
+}
+
+function isProgressTextPart(
+  message: AntonUIMessage,
+  partIndex: number,
+  isPlanResponse: boolean,
+): boolean {
+  if (isPlanResponse) return false;
+  const part = message.parts[partIndex];
+  if (part.type !== "text") return false;
+  if (stripLeakedProviderMarkup(part.text).length === 0) return false;
+
+  const hasToolAfter = message.parts
+    .slice(partIndex + 1)
+    .some((candidate) => toolCallIdForPart(candidate) !== undefined);
+  if (hasToolAfter) return true;
+
+  const lastToolIndex = message.parts.findLastIndex((candidate) =>
+    Boolean(toolCallIdForPart(candidate)),
+  );
+  if (lastToolIndex !== -1 && partIndex < lastToolIndex) return true;
+
+  if (!isAssistantTurnActive(message)) return false;
+
+  const lastTextPartIndex = message.parts.findLastIndex(
+    (candidate) => candidate.type === "text",
+  );
+  return lastTextPartIndex !== partIndex;
+}
+
 export function getTraceRows(
   message: AntonUIMessage,
   todoDisplay?: TodoTraceDisplay,
@@ -642,15 +777,15 @@ export function getTraceRows(
   );
   const reasoningByEventId = buildReasoningTextByEventId(message);
   const toolEntries = getToolTraceEntries([message]);
+  const partSequenceMarkers = buildPartSequenceMarkers(
+    message,
+    toolEntries,
+    activities,
+  );
   const rows: TraceRow[] = [];
   const representedActivityIds = new Set<string>();
   const isPlanResponse = message.metadata?.responseKind === "plan";
   let reasoningIndex = 0;
-  const lastToolIndex = message.parts.findLastIndex((part) =>
-    toolCallIdForPart(part)
-      ? toolEntries.some((entry) => entry.id === toolCallIdForPart(part))
-      : false,
-  );
   const latestToolPartIndexes = getLatestToolPartIndexes(message);
   const latestTodoPartIndexes = todoDisplay
     ? undefined
@@ -673,17 +808,12 @@ export function getTraceRows(
       return;
     }
 
-    if (
-      part.type === "text" &&
-      !isPlanResponse &&
-      lastToolIndex !== -1 &&
-      index < lastToolIndex
-    ) {
+    if (part.type === "text" && isProgressTextPart(message, index, isPlanResponse)) {
       const text = stripLeakedProviderMarkup(part.text);
       if (!text) return;
       rows.push({
         id: `${message.id}:progress:${index}`,
-        order: index,
+        order: orderForPartIndex(index, partSequenceMarkers),
         kind: "progress",
         text,
       });
@@ -699,7 +829,7 @@ export function getTraceRows(
       if (!todoSnapshot) return;
       rows.push({
         id: part.id ?? `${message.id}:todos:${index}`,
-        order: index,
+        order: orderForPartIndex(index, partSequenceMarkers),
         kind: "todos",
         snapshot: todoSnapshot,
       });
@@ -724,12 +854,8 @@ export function getTraceRows(
   for (const event of activities) {
     if (representedActivityIds.has(event.id)) continue;
     if (event.kind === "reasoning") {
-      const text = reasoningTextForEvent(
-        message,
-        event,
-        reasoningByEventId,
-      );
-      if (!text) continue;
+      const text =
+        reasoningTextForEvent(message, event, reasoningByEventId) ?? "";
       rows.push({
         id: event.id,
         order: event.sequence,

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -329,7 +329,7 @@ function buildRunTimelineItems(
         kind: "tool",
         label: event.label,
         summary: event.summary,
-        durationMs: event.durationMs,
+        durationMs: activityDisplayDurationMs(event),
         status: event.status,
         tool,
         expandable: true,
@@ -343,14 +343,15 @@ function buildRunTimelineItems(
         event,
         reasoningByEventId,
       );
+      const durationMs = activityDisplayDurationMs(event);
       items.push({
         ...base,
         kind: "reasoning",
         label:
-          event.durationMs !== undefined
-            ? `Thought for ${formatDuration(event.durationMs)}`
+          durationMs !== undefined
+            ? `Thought for ${formatDuration(durationMs)}`
             : event.label,
-        durationMs: event.durationMs,
+        durationMs,
         status: event.status,
         reasoningText,
         expandable: Boolean(reasoningText),
@@ -365,7 +366,7 @@ function buildRunTimelineItems(
         kind: "todos",
         label: event.label || "Todos updated",
         summary: event.summary,
-        durationMs: event.durationMs,
+        durationMs: activityDisplayDurationMs(event),
         status: event.status,
         todoSnapshot,
         expandable: Boolean(todoSnapshot),
@@ -378,7 +379,7 @@ function buildRunTimelineItems(
       kind: event.kind,
       label: event.label,
       summary: event.summary,
-      durationMs: event.durationMs,
+      durationMs: activityDisplayDurationMs(event),
       status: event.status,
       expandable:
         (event.kind === "error" && Boolean(event.summary)) ||
@@ -397,7 +398,9 @@ function buildRunTimelineItems(
       runId: run.runId,
       kind: "tool",
       label: tool.activity?.label ?? label,
-      durationMs: tool.activity?.durationMs,
+      durationMs: tool.activity
+        ? activityDisplayDurationMs(tool.activity)
+        : undefined,
       status:
         tool.activity?.status ??
         (runStatus === "running" ? "running" : "completed"),
@@ -409,6 +412,17 @@ function buildRunTimelineItems(
   }
 
   return items.sort(compareTimelineItems);
+}
+
+export function activityDisplayDurationMs(
+  event: AntonActivityEvent,
+): number | undefined {
+  if (event.durationMs !== undefined) return event.durationMs;
+  if (event.finishedAt !== undefined) {
+    return Math.max(0, event.finishedAt - event.startedAt);
+  }
+  if (event.status !== "running") return 0;
+  return undefined;
 }
 
 function compareTimelineEvents(
@@ -442,6 +456,9 @@ function reasoningTextForEvent(
   event: AntonActivityEvent,
   reasoningByEventId?: ReadonlyMap<string, string>,
 ): string | undefined {
+  const summary = event.summary?.trim();
+  if (summary) return summary;
+  if (event.status === "running") return undefined;
   const map = reasoningByEventId ?? buildReasoningTextByEventId(message);
   return map.get(event.id);
 }
@@ -623,8 +640,10 @@ export function getTraceRows(
   const reasoningActivities = activities.filter(
     (event) => event.kind === "reasoning",
   );
+  const reasoningByEventId = buildReasoningTextByEventId(message);
   const toolEntries = getToolTraceEntries([message]);
   const rows: TraceRow[] = [];
+  const representedActivityIds = new Set<string>();
   const isPlanResponse = message.metadata?.responseKind === "plan";
   let reasoningIndex = 0;
   const lastToolIndex = message.parts.findLastIndex((part) =>
@@ -638,6 +657,7 @@ export function getTraceRows(
       : getLatestTodoPartIndexes(message);
   message.parts.forEach((part, index) => {
     if (isReasoningPart(part)) {
+      if (reasoningActivities.length > 0) return;
       const text = part.text.trim();
       if (!text) return;
       const event = reasoningActivities[reasoningIndex];
@@ -649,6 +669,7 @@ export function getTraceRows(
         event,
         text,
       });
+      if (event) representedActivityIds.add(event.id);
       return;
     }
 
@@ -697,10 +718,36 @@ export function getTraceRows(
       kind: "tool",
       tool,
     });
+    if (tool.activity) representedActivityIds.add(tool.activity.id);
   });
 
   for (const event of activities) {
-    if (event.kind === "tool" || event.kind === "reasoning") continue;
+    if (representedActivityIds.has(event.id)) continue;
+    if (event.kind === "reasoning") {
+      const text = reasoningTextForEvent(
+        message,
+        event,
+        reasoningByEventId,
+      );
+      if (!text) continue;
+      rows.push({
+        id: event.id,
+        order: event.sequence,
+        kind: "reasoning",
+        event,
+        text,
+      });
+      continue;
+    }
+    if (event.kind === "tool") {
+      rows.push({
+        id: event.id,
+        order: event.sequence,
+        kind: "activity",
+        event,
+      });
+      continue;
+    }
     if (event.kind === "step") continue;
     if (event.kind === "progress" && eventHasTodos(event)) continue;
     if (isTokenBudgetActivity(event)) continue;

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -176,11 +176,13 @@ function ReasoningRow({
         </span>
       )}
     >
-      <div className="min-h-0 overflow-hidden">
-        <pre className="ml-5 mt-1 max-h-40 overflow-y-auto pr-2 font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
-          {text}
-        </pre>
-      </div>
+      {text.trim().length > 0 ? (
+        <div className="min-h-0 overflow-hidden">
+          <pre className="ml-5 mt-1 max-h-40 overflow-y-auto pr-2 font-mono text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap">
+            {text}
+          </pre>
+        </div>
+      ) : null}
     </Disclosure>
   );
 }

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -18,7 +18,12 @@ import {
   type AntonRunStatus,
 } from "@/src/lib/trace";
 
-import { formatDuration, type TraceRow, type StepGroup } from "./trace-data";
+import {
+  activityDisplayDurationMs,
+  formatDuration,
+  type TraceRow,
+  type StepGroup,
+} from "./trace-data";
 import { ToolTraceRow } from "./tool-trace-row";
 import { TodoCard } from "./todo-card";
 import { BudgetGateCard } from "@/components/features/chat/budget-gate-card";
@@ -248,10 +253,16 @@ function displayEventForRun(
   event: AntonActivityEvent,
   runStatus: AntonRunStatus,
 ): AntonActivityEvent {
-  if (event.status !== "running" || runStatus === "running") return event;
+  const durationMs =
+    activityDisplayDurationMs(event) ??
+    (runStatus === "running" ? undefined : 0);
+  if (event.status !== "running" || runStatus === "running") {
+    return durationMs === event.durationMs ? event : { ...event, durationMs };
+  }
   return {
     ...event,
     status: runStatus === "completed" ? "completed" : "error",
+    durationMs,
   };
 }
 

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -171,6 +171,7 @@ export function compactVerifyForModel(output: unknown): unknown {
       ok: false,
       summary: output.summary,
       packageManager: output.packageManager,
+      parallel: output.parallel,
       ranCount: output.ranCount,
       skippedCount: output.skippedCount,
       ...(failureSummary ? { failureSummary } : {}),
@@ -179,6 +180,8 @@ export function compactVerifyForModel(output: unknown): unknown {
         ? {
             failedTarget: failed.target,
             failedCommand: failed.command,
+            timedOut: failed.timedOut,
+            timeoutMs: failed.timeoutMs,
             exitCode: failed.exitCode,
           }
         : {}),
@@ -189,6 +192,7 @@ export function compactVerifyForModel(output: unknown): unknown {
     ok: output.ok,
     summary: output.summary,
     packageManager: output.packageManager,
+    parallel: output.parallel,
     ranCount: output.ranCount,
     skippedCount: output.skippedCount,
     results,
@@ -270,6 +274,7 @@ function compactVerifyResultForModel(result: unknown): unknown {
       ? { reason: result.reason }
       : {
           command: result.command,
+          timeoutMs: result.timeoutMs,
           exitCode: result.exitCode,
           timedOut: result.timedOut,
           stdout: tailText(result.stdout),

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -19,6 +19,7 @@ import {
 } from "./model-output";
 
 const MAX_TIMEOUT_MS = 300_000;
+const DEFAULT_BUILD_TIMEOUT_MS = MAX_TIMEOUT_MS;
 const MODEL_OUTPUT_TEXT_CAP = 8_000;
 
 const verificationTargetSchema = z.enum(["typecheck", "lint", "build"]);
@@ -53,6 +54,7 @@ type VerificationResult =
       skipped: false;
       ok: boolean;
       command?: string;
+      timeoutMs?: number;
       exitCode?: number;
       timedOut?: boolean;
       stdout?: string;
@@ -87,7 +89,7 @@ export function createVerifyTool(
         .max(MAX_TIMEOUT_MS)
         .optional()
         .describe(
-          `Per-command timeout in milliseconds. Defaults to ${defaults.timeoutMs}ms for this profile.`,
+          `Per-command timeout in milliseconds. Defaults to ${defaults.timeoutMs}ms for typecheck/lint and ${DEFAULT_BUILD_TIMEOUT_MS}ms for build in this profile.`,
         ),
     }),
     toModelOutput: ({ output }) => ({
@@ -108,61 +110,66 @@ export function createVerifyTool(
       });
       if (!plan.ok) return plan;
 
-      const results: VerificationResult[] = [];
-      for (const step of plan.steps) {
-        if (step.skipped || !step.command) {
-          results.push({
-            target: step.target,
-            skipped: true,
-            ok: true,
-            reason: step.reason ?? "No matching package script found.",
-          });
-          continue;
-        }
+      const results = await Promise.all(
+        plan.steps.map(async (step): Promise<VerificationResult> => {
+          if (step.skipped || !step.command) {
+            return {
+              target: step.target,
+              skipped: true,
+              ok: true,
+              reason: step.reason ?? "No matching package script found.",
+            };
+          }
 
-        const [file, ...args] = step.command;
-        if (!file) {
-          results.push({
+          const [file, ...args] = step.command;
+          const stepTimeoutMs = timeoutForTarget(
+            step.target,
+            defaults.timeoutMs,
+            timeoutMs,
+          );
+          if (!file) {
+            return {
+              target: step.target,
+              skipped: false,
+              ok: false,
+              timeoutMs: stepTimeoutMs,
+              error: "Verification command is empty.",
+            };
+          }
+
+          const result = await runWorkspaceProcess(file, args, root, {
+            timeoutMs: stepTimeoutMs,
+          });
+          const ok = result.exitCode === 0;
+          return {
             target: step.target,
             skipped: false,
-            ok: false,
-            error: "Verification command is empty.",
-          });
-          break;
-        }
-
-        const result = await runWorkspaceProcess(file, args, root, {
-          timeoutMs: timeoutMs ?? defaults.timeoutMs,
-        });
-        const ok = result.exitCode === 0;
-        results.push({
-          target: step.target,
-          skipped: false,
-          ok,
-          command: step.command.join(" "),
-          exitCode: result.exitCode,
-          timedOut: result.timedOut ?? false,
-          stdout: capOutput(result.stdout),
-          stderr: capOutput(result.stderr),
-          ...(ok
-            ? {}
-            : {
-                error:
-                  result.stderr ||
-                  result.stdout ||
-                  (result.timedOut
-                    ? "Verification command timed out."
-                    : "Verification command failed."),
-              }),
-        });
-        if (!ok) break;
-      }
+            ok,
+            command: step.command.join(" "),
+            timeoutMs: stepTimeoutMs,
+            exitCode: result.exitCode,
+            timedOut: result.timedOut ?? false,
+            stdout: capOutput(result.stdout),
+            stderr: capOutput(result.stderr),
+            ...(ok
+              ? {}
+              : {
+                  error: result.timedOut
+                    ? `Verification command timed out after ${formatDuration(stepTimeoutMs)}.`
+                    : result.stderr ||
+                      result.stdout ||
+                      "Verification command failed.",
+                }),
+          };
+        }),
+      );
 
       const ranCount = results.filter((result) => !result.skipped).length;
       const failed = results.filter((result) => !result.ok);
       return {
         ok: failed.length === 0,
         packageManager: plan.packageManager,
+        parallel: true,
         ranCount,
         skippedCount: results.length - ranCount,
         results,
@@ -175,6 +182,21 @@ export function createVerifyTool(
       };
     },
   });
+}
+
+function timeoutForTarget(
+  target: VerificationTarget,
+  defaultTimeoutMs: number,
+  requestedTimeoutMs: number | undefined,
+): number {
+  if (requestedTimeoutMs !== undefined) return requestedTimeoutMs;
+  if (target === "build") return Math.max(defaultTimeoutMs, DEFAULT_BUILD_TIMEOUT_MS);
+  return defaultTimeoutMs;
+}
+
+function formatDuration(timeoutMs: number): string {
+  if (timeoutMs % 1_000 !== 0) return `${timeoutMs}ms`;
+  return `${timeoutMs / 1_000}s`;
 }
 
 function defaultTargetsForProfile(

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -1186,6 +1186,15 @@ export function buildReasoningTextByEventId(
         left.sequence - right.sequence ||
         left.id.localeCompare(right.id),
     );
+  const eventsByPartId = new Map<string, AntonActivityEvent[]>();
+  for (const event of reasoningActivities) {
+    const partId = reasoningPartIdFromEvent(event);
+    if (!partId) continue;
+    const events = eventsByPartId.get(partId) ?? [];
+    events.push(event);
+    eventsByPartId.set(partId, events);
+  }
+  const matchedEventIds = new Set<string>();
   let reasoningIndex = 0;
 
   for (const part of message.parts) {
@@ -1194,21 +1203,41 @@ export function buildReasoningTextByEventId(
     if (!text) continue;
 
     if ("id" in part && typeof part.id === "string") {
-      for (const event of reasoningActivities) {
-        if (event.id.endsWith(`:reasoning:${part.id}`)) {
-          map.set(event.id, text);
-        }
+      const matchingEvent =
+        eventsByPartId
+          .get(part.id)
+          ?.find((event) => !matchedEventIds.has(event.id)) ??
+        reasoningActivities.find(
+          (event) =>
+            !matchedEventIds.has(event.id) &&
+            event.id.endsWith(`:reasoning:${part.id}`),
+        );
+      if (matchingEvent) {
+        map.set(matchingEvent.id, text);
+        matchedEventIds.add(matchingEvent.id);
+        reasoningIndex += 1;
+        continue;
       }
     }
 
-    const event = reasoningActivities[reasoningIndex];
+    const event = reasoningActivities
+      .slice(reasoningIndex)
+      .find((candidate) => !matchedEventIds.has(candidate.id));
     if (event && !map.has(event.id)) {
       map.set(event.id, text);
+      matchedEventIds.add(event.id);
     }
     reasoningIndex += 1;
   }
 
   return map;
+}
+
+function reasoningPartIdFromEvent(event: AntonActivityEvent): string | undefined {
+  const details = event.details;
+  if (!details) return undefined;
+  const value = details.reasoningPartId;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 export function isReasoningPart(


### PR DESCRIPTION
## Summary

Closes #132.

- Makes provider reasoning trace event IDs occurrence-unique, while retaining the provider reasoning part ID in event details for text matching.
- Updates reasoning text matching so repeated provider part IDs map to the correct durable events in order.
- Lets the chat inline trace render durable reasoning summaries when reasoning UI parts are absent after persistence/refresh.
- Anchors chat progress/todo trace rows to activity sequence instead of message.parts index so live ordering matches Worklog and does not snap back on completion.
- Shows interim progress text during active runs before later tools arrive, and keeps running thoughts in the trace timeline as step boundaries.
- Adds duration fallbacks for completed trace events so completed thoughts do not remain visually running or lose timing display.
- Updates Status last-run trace grouping to retain completed-event duration fallbacks.
- Records the completed trace-sync work in ROADMAP.md.

## Root cause

Reasoning activity IDs were derived only from the provider reasoning part ID. When a provider reused the same part ID across multiple steps, durable un_events upserted later thoughts into the first event row. That made Status collapse to one thought and place it under the first step. The chat inline trace also depended too heavily on transient reasoning UI parts and message.parts ordering, so live rows could diverge from Worklog during streaming and reorder when the run finished.

## Test plan

- [x] pnpm typecheck
- [x] pnpm lint
- [ ] Manual browser run with an agent task that includes reasoning, read/edit/verify tools, and a final response; compare chat inline trace vs Worklog vs Status last-run trace during streaming and after completion
- [ ] Confirm interim progress bubbles stay in chronological order and do not jump when the final response renders