### PR TITLE
Make verify build checks timeout-safe and parallel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,6 +59,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Polished trace workspace file tabs, headers, and Pierre code view scrolling/gutter behavior.
 - [✔️] Synced file tree git status badges with local `git status`, including header dirty counts and refresh on focus.
 - [✔️] Replaced global active-project localStorage with session-scoped composer project picker that locks after the first message (#107).
+- [✔️] Made verification run independent targets in parallel with build-safe timeout reporting (#134).
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -171,6 +171,7 @@ export function compactVerifyForModel(output: unknown): unknown {
       ok: false,
       summary: output.summary,
       packageManager: output.packageManager,
+      parallel: output.parallel,
       ranCount: output.ranCount,
       skippedCount: output.skippedCount,
       ...(failureSummary ? { failureSummary } : {}),
@@ -179,6 +180,8 @@ export function compactVerifyForModel(output: unknown): unknown {
         ? {
             failedTarget: failed.target,
             failedCommand: failed.command,
+            timedOut: failed.timedOut,
+            timeoutMs: failed.timeoutMs,
             exitCode: failed.exitCode,
           }
         : {}),
@@ -189,6 +192,7 @@ export function compactVerifyForModel(output: unknown): unknown {
     ok: output.ok,
     summary: output.summary,
     packageManager: output.packageManager,
+    parallel: output.parallel,
     ranCount: output.ranCount,
     skippedCount: output.skippedCount,
     results,
@@ -270,6 +274,7 @@ function compactVerifyResultForModel(result: unknown): unknown {
       ? { reason: result.reason }
       : {
           command: result.command,
+          timeoutMs: result.timeoutMs,
           exitCode: result.exitCode,
           timedOut: result.timedOut,
           stdout: tailText(result.stdout),

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -19,6 +19,7 @@ import {
 } from "./model-output";
 
 const MAX_TIMEOUT_MS = 300_000;
+const DEFAULT_BUILD_TIMEOUT_MS = MAX_TIMEOUT_MS;
 const MODEL_OUTPUT_TEXT_CAP = 8_000;
 
 const verificationTargetSchema = z.enum(["typecheck", "lint", "build"]);
@@ -53,6 +54,7 @@ type VerificationResult =
       skipped: false;
       ok: boolean;
       command?: string;
+      timeoutMs?: number;
       exitCode?: number;
       timedOut?: boolean;
       stdout?: string;
@@ -87,7 +89,7 @@ export function createVerifyTool(
         .max(MAX_TIMEOUT_MS)
         .optional()
         .describe(
-          `Per-command timeout in milliseconds. Defaults to ${defaults.timeoutMs}ms for this profile.`,
+          `Per-command timeout in milliseconds. Defaults to ${defaults.timeoutMs}ms for typecheck/lint and ${DEFAULT_BUILD_TIMEOUT_MS}ms for build in this profile.`,
         ),
     }),
     toModelOutput: ({ output }) => ({
@@ -108,61 +110,66 @@ export function createVerifyTool(
       });
       if (!plan.ok) return plan;
 
-      const results: VerificationResult[] = [];
-      for (const step of plan.steps) {
-        if (step.skipped || !step.command) {
-          results.push({
-            target: step.target,
-            skipped: true,
-            ok: true,
-            reason: step.reason ?? "No matching package script found.",
-          });
-          continue;
-        }
+      const results = await Promise.all(
+        plan.steps.map(async (step): Promise<VerificationResult> => {
+          if (step.skipped || !step.command) {
+            return {
+              target: step.target,
+              skipped: true,
+              ok: true,
+              reason: step.reason ?? "No matching package script found.",
+            };
+          }
 
-        const [file, ...args] = step.command;
-        if (!file) {
-          results.push({
+          const [file, ...args] = step.command;
+          const stepTimeoutMs = timeoutForTarget(
+            step.target,
+            defaults.timeoutMs,
+            timeoutMs,
+          );
+          if (!file) {
+            return {
+              target: step.target,
+              skipped: false,
+              ok: false,
+              timeoutMs: stepTimeoutMs,
+              error: "Verification command is empty.",
+            };
+          }
+
+          const result = await runWorkspaceProcess(file, args, root, {
+            timeoutMs: stepTimeoutMs,
+          });
+          const ok = result.exitCode === 0;
+          return {
             target: step.target,
             skipped: false,
-            ok: false,
-            error: "Verification command is empty.",
-          });
-          break;
-        }
-
-        const result = await runWorkspaceProcess(file, args, root, {
-          timeoutMs: timeoutMs ?? defaults.timeoutMs,
-        });
-        const ok = result.exitCode === 0;
-        results.push({
-          target: step.target,
-          skipped: false,
-          ok,
-          command: step.command.join(" "),
-          exitCode: result.exitCode,
-          timedOut: result.timedOut ?? false,
-          stdout: capOutput(result.stdout),
-          stderr: capOutput(result.stderr),
-          ...(ok
-            ? {}
-            : {
-                error:
-                  result.stderr ||
-                  result.stdout ||
-                  (result.timedOut
-                    ? "Verification command timed out."
-                    : "Verification command failed."),
-              }),
-        });
-        if (!ok) break;
-      }
+            ok,
+            command: step.command.join(" "),
+            timeoutMs: stepTimeoutMs,
+            exitCode: result.exitCode,
+            timedOut: result.timedOut ?? false,
+            stdout: capOutput(result.stdout),
+            stderr: capOutput(result.stderr),
+            ...(ok
+              ? {}
+              : {
+                  error: result.timedOut
+                    ? `Verification command timed out after ${formatDuration(stepTimeoutMs)}.`
+                    : result.stderr ||
+                      result.stdout ||
+                      "Verification command failed.",
+                }),
+          };
+        }),
+      );
 
       const ranCount = results.filter((result) => !result.skipped).length;
       const failed = results.filter((result) => !result.ok);
       return {
         ok: failed.length === 0,
         packageManager: plan.packageManager,
+        parallel: true,
         ranCount,
         skippedCount: results.length - ranCount,
         results,
@@ -175,6 +182,21 @@ export function createVerifyTool(
       };
     },
   });
+}
+
+function timeoutForTarget(
+  target: VerificationTarget,
+  defaultTimeoutMs: number,
+  requestedTimeoutMs: number | undefined,
+): number {
+  if (requestedTimeoutMs !== undefined) return requestedTimeoutMs;
+  if (target === "build") return Math.max(defaultTimeoutMs, DEFAULT_BUILD_TIMEOUT_MS);
+  return defaultTimeoutMs;
+}
+
+function formatDuration(timeoutMs: number): string {
+  if (timeoutMs % 1_000 !== 0) return `${timeoutMs}ms`;
+  return `${timeoutMs / 1_000}s`;
 }
 
 function defaultTargetsForProfile(


### PR DESCRIPTION
## Summary
- Keep `verify` as the native harness tool, but run independent targets concurrently instead of serially.
- Give `build` the full 300s verifier timeout by default when callers do not pass `timeoutMs`, while leaving typecheck/lint at the profile timeout.
- Surface `parallel`, per-result `timeoutMs`, and timeout details in compact verify output so the model sees timeout vs real diagnostics.
- Update ROADMAP for #134.

## Why
The reported run was not a real build failure. In `single-file-edit`, `verify` used a 60s default timeout for every target, so `bun run build` timed out while still compiling. The model then tried `bash`, but that profile intentionally exposes only `read_file`, `edit_text`, and `verify` for cache/toolset stability.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passes; existing Turbopack NFT warning and missing `OPENROUTER_API_KEY` warnings only)
- `git diff --check`
- Temporary Bun workspace probe: `verify({ targets: ["lint", "build"] })` completed in ~2.1s with `parallel: true`, lint timeout `60000`, build timeout `300000`, and preserved result order.

Closes #134
