### PR TITLE
Improve agent resume context and trace reliability

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,9 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Kept chat, Worklog, and Status reasoning traces aligned across live and persisted run views.
 - [✔️] Made verification run independent targets in parallel with build-safe timeout reporting (#134).
 - [✔️] Hardened verification classification and post-edit rollback for cache-safe agent recovery.
+- [✔️] Enriched prior-run context summaries with todos, verification, blockers, touched files, and failed tool details (#136).
+- [✔️] Reduced live trace rendering pressure with lazy-mounted disclosures and bounded running Worklog rows (#139).
+- [✔️] Hardened native grep fallback search and rendered grep results as structured Worklog output (#140).
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -667,7 +667,10 @@ export async function POST(req: Request) {
             contextCollector.addTool(event);
             trace.finishTool(event);
           },
-          onLoopGuard: (event) => trace.noteLoopGuard(event),
+          onLoopGuard: (event) => {
+            contextCollector.addLoopGuard(event);
+            trace.noteLoopGuard(event);
+          },
           onProfilePromotion: (event) => trace.noteProfilePromotion(event),
           onStreamPart: (part) => trace.handleStreamPart(part),
           onAbort: () => {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -645,6 +645,7 @@ function ChatSession({
             streamingResponseMode={streaming ? streamingResponseMode : null}
             onApproval={approveTool}
             onAcceptPlan={() => {
+              setMode("agent");
               void sendWithMcp("Implement plan", "agent");
             }}
             acceptPlanDisabled={streaming || !effectiveProjectId}
@@ -713,6 +714,7 @@ function ChatSession({
             ) : null}
             <Worklog
               messages={displayMessages}
+              streaming={streaming}
               onApproval={approveTool}
               project={project}
               visible={worklogOpen}
@@ -739,6 +741,7 @@ function ChatSession({
           >
             <Worklog
               messages={displayMessages}
+              streaming={streaming}
               onApproval={approveTool}
               project={project}
               visible

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -64,14 +64,32 @@ export function MessageList({
   onExtendTokenBudget,
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollFrameRef = useRef<number | null>(null);
   const todoDisplay = useMemo(() => getTodoTraceDisplay(messages), [messages]);
 
   useEffect(() => {
-    scrollRef.current?.scrollTo({
-      top: scrollRef.current.scrollHeight,
-      behavior: "smooth",
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    if (scrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(scrollFrameRef.current);
+    }
+    scrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollFrameRef.current = null;
+      scrollElement.scrollTo({
+        top: scrollElement.scrollHeight,
+        behavior:
+          status === "submitted" || status === "streaming" ? "auto" : "smooth",
+      });
     });
-  }, [messages, status]);
+
+    return () => {
+      if (scrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+  }, [messages.length, status]);
 
   if (messages.length === 0) {
     return (

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -25,7 +25,6 @@ import { Disclosure } from "@/components/shared/disclosure";
 import {
   formatDuration,
   getModelTurnSummary,
-  getTraceDurationMs,
   getTraceRows,
   groupTraceRowsByStep,
   type TodoTraceDisplay,
@@ -86,21 +85,16 @@ export function RunTraceAccordion({
   );
 
   const forceOpen = pendingApproval;
+  const inlineTraceDefaultOpen = !isRunning && !hasFinalResponseText;
 
   const now = useTick(isRunning);
-  const rows = useMemo(
-    () => getTraceRows(message, todoDisplay),
-    [message, todoDisplay],
-  );
-  const stepGroups = useMemo(() => groupTraceRowsByStep(message, rows), [message, rows]);
   const modelTurnSummary = useMemo(() => getModelTurnSummary(message), [message]);
 
-  if (!run && rows.length === 0) return null;
+  if (!run && !messageHasTracePayload(message)) return null;
 
   const startedAt = run?.startedAt ?? metadata?.startedAt;
   const durationMs =
     getMessageRunDurationMs(message, now) ??
-    getTraceDurationMs(rows) ??
     (startedAt === undefined ? 0 : Math.max(0, now - startedAt));
   const header =
     pendingApproval
@@ -114,8 +108,9 @@ export function RunTraceAccordion({
   return (
     <Disclosure
       className="mb-2 w-full text-xs text-muted-foreground"
-      defaultOpen={!hasFinalResponseText}
+      defaultOpen={inlineTraceDefaultOpen}
       forceOpen={forceOpen}
+      lazyMount
       trigger={({ open }) => (
         <span className="inline-flex max-w-full items-center gap-1.5 rounded px-1 py-0.5 text-[11px]">
           {pendingApproval ? (
@@ -138,39 +133,99 @@ export function RunTraceAccordion({
         </span>
       )}
     >
-      <div className="min-h-0 overflow-hidden">
-        <div className="ml-2 mt-1 space-y-0 border-l border-border/70 pl-3">
-          {buildInterleaved(rows, stepGroups).map((item) =>
-            item.kind === "group" ? (
-              <StepGroupView
-                key={`step-${item.group.stepNumber}`}
-                group={item.group}
-                runStatus={runStatus}
-                budgetLimited={budgetLimited}
-                onApproval={onApproval}
-              />
-            ) : (
-              <div key={item.row.id}>
-                <TraceRowView
-                  row={item.row}
-                  runStatus={runStatus}
-                  budgetLimited={budgetLimited}
-                  budgetGateDisabled={
-                    isRunning ||
-                    pendingApproval ||
-                    (item.row.kind === "budget-gate" &&
-                      item.row.gate.status !== "open")
-                  }
-                  onExtendTokenBudget={onExtendTokenBudget}
-                  onApproval={onApproval}
-                />
-              </div>
-            ),
-          )}
-        </div>
-      </div>
+      {() => (
+        <RunTraceAccordionBody
+          message={message}
+          todoDisplay={todoDisplay}
+          runStatus={runStatus}
+          budgetLimited={budgetLimited}
+          budgetGateDisabled={isRunning || pendingApproval}
+          onApproval={onApproval}
+          onExtendTokenBudget={onExtendTokenBudget}
+        />
+      )}
     </Disclosure>
   );
+}
+
+function RunTraceAccordionBody({
+  message,
+  todoDisplay,
+  runStatus,
+  budgetLimited,
+  budgetGateDisabled,
+  onApproval,
+  onExtendTokenBudget,
+}: {
+  message: AntonUIMessage;
+  todoDisplay?: TodoTraceDisplay;
+  runStatus: AntonRunStatus;
+  budgetLimited: boolean;
+  budgetGateDisabled: boolean;
+  onApproval: ChatAddToolApproveResponseFunction;
+  onExtendTokenBudget?: (
+    runId: string,
+    multiplier: TokenBudgetMultiplierOption,
+  ) => void;
+}) {
+  const rows = useMemo(
+    () => getTraceRows(message, todoDisplay),
+    [message, todoDisplay],
+  );
+  const stepGroups = useMemo(
+    () => groupTraceRowsByStep(message, rows),
+    [message, rows],
+  );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="min-h-0 overflow-hidden">
+      <div className="ml-2 mt-1 space-y-0 border-l border-border/70 pl-3">
+        {buildInterleaved(rows, stepGroups).map((item) =>
+          item.kind === "group" ? (
+            <StepGroupView
+              key={`step-${item.group.stepNumber}`}
+              group={item.group}
+              runStatus={runStatus}
+              budgetLimited={budgetLimited}
+              onApproval={onApproval}
+            />
+          ) : (
+            <div key={item.row.id}>
+              <TraceRowView
+                row={item.row}
+                runStatus={runStatus}
+                budgetLimited={budgetLimited}
+                budgetGateDisabled={
+                  budgetGateDisabled ||
+                  (item.row.kind === "budget-gate" &&
+                    item.row.gate.status !== "open")
+                }
+                onExtendTokenBudget={onExtendTokenBudget}
+                onApproval={onApproval}
+              />
+            </div>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+function messageHasTracePayload(message: AntonUIMessage): boolean {
+  return message.parts.some((part) => {
+    if (
+      part.type === "reasoning" ||
+      part.type === "data-run" ||
+      part.type === "data-activity" ||
+      part.type === "data-todos" ||
+      part.type === "data-budget-gate"
+    ) {
+      return true;
+    }
+    return "toolCallId" in part && typeof part.toolCallId === "string";
+  });
 }
 
 function effectiveRunStatus(

--- a/components/features/run-trace/trace-rows.tsx
+++ b/components/features/run-trace/trace-rows.tsx
@@ -154,6 +154,7 @@ function ReasoningRow({
   return (
     <Disclosure
       className="py-0.5"
+      lazyMount
       trigger={({ open }) => (
         <span className="inline-grid max-w-full grid-cols-[0.875rem_auto_0.75rem] items-start gap-2 rounded px-0 py-0">
           {running ? (
@@ -216,6 +217,7 @@ export function StepGroupView({
     <Disclosure
       className="py-0.5"
       forceOpen={hasPendingApproval}
+      lazyMount
       trigger={({ open }) => (
         <span className="inline-flex max-w-full items-center gap-1.5 rounded px-0 py-0 text-[11px] text-muted-foreground/80 hover:text-foreground/80">
           <span className="truncate">{group.summary}</span>

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -61,16 +61,39 @@ import {
   stepUsageFromCostMetadata,
 } from "@/components/features/run-trace/trace-usage-ui";
 
+const LIVE_WORKLOG_STEP_LIMIT = 4;
+const LIVE_WORKLOG_ITEM_LIMIT = 8;
+
 export function WorklogTimeline({
   messages,
+  streaming = false,
   onApproval,
 }: {
   messages: AntonUIMessage[];
+  streaming?: boolean;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
+  const latestMessage = messages.at(-1);
+  const liveMessage =
+    streaming && latestMessage?.role === "assistant" ? latestMessage : undefined;
+  const stableTimelineMessages =
+    liveMessage === undefined ? messages : messages.slice(0, -1);
+  const stableTimelineKey = stableTimelineMessages
+    .map((message) => message.id)
+    .join("|");
+  const stableGroups = useMemo(
+    () => getSessionTimelineRunGroups(stableTimelineMessages),
+    // Stable persisted messages do not change while the active assistant streams.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stableTimelineKey],
+  );
+  const liveGroups = useMemo(
+    () => (liveMessage ? getSessionTimelineRunGroups([liveMessage]) : []),
+    [liveMessage],
+  );
   const groups = useMemo(
-    () => getSessionTimelineRunGroups(messages),
-    [messages],
+    () => (liveMessage ? [...stableGroups, ...liveGroups] : stableGroups),
+    [liveGroups, liveMessage, stableGroups],
   );
   const [expandedItemId, setExpandedItemId] = useState<string | null>(null);
 
@@ -102,6 +125,7 @@ export function WorklogTimeline({
           const stepUsageMap = stepUsageByNumber(
             stepUsageFromCostMetadata(group.run.costMetadata),
           );
+          const visibleSteps = visibleStepsForGroup(group);
 
           return (
             <TraceThreadNode key={group.runId}>
@@ -114,7 +138,7 @@ export function WorklogTimeline({
                 status={group.run.status}
               />
               <TraceThreadChildren>
-                {group.steps.map((step) => {
+                {visibleSteps.map((step) => {
                   const stepMeta = timelineEventMeta("step", "completed");
                   const harnessStepNumber = parseHarnessStepNumber(step.id);
                   const stepMetrics =
@@ -167,6 +191,19 @@ export function WorklogTimeline({
       </TraceThreadRoot>
     </div>
   );
+}
+
+function visibleStepsForGroup(
+  group: SessionTimelineRunGroup,
+): SessionTimelineRunGroup["steps"] {
+  if (group.run.status !== "running") {
+    return group.steps;
+  }
+
+  return group.steps.slice(-LIVE_WORKLOG_STEP_LIMIT).map((step) => ({
+    ...step,
+    items: step.items.slice(-LIVE_WORKLOG_ITEM_LIMIT),
+  }));
 }
 
 function renderTimelineItem({
@@ -452,6 +489,10 @@ function ToolEntryExpandPanel({
 }
 
 function ToolIoBlocks({ entry }: { entry: ToolTraceEntry }) {
+  if (entry.name === "grep" && isGrepOutput(entry.output)) {
+    return <GrepOutputPanel output={entry.output} />;
+  }
+
   const inputText = safeStringify(entry.input);
   const durableOutput =
     entry.name === "read_file" &&
@@ -493,6 +534,65 @@ function ToolIoBlocks({ entry }: { entry: ToolTraceEntry }) {
           {entry.errorText}
         </TraceLogBlock>
       ) : null}
+    </div>
+  );
+}
+
+type GrepOutput = {
+  ok: true;
+  pattern: string;
+  target?: string;
+  matchCount: number;
+  truncated?: boolean;
+  matches: { file: string; line: number; text: string }[];
+};
+
+function isGrepOutput(value: unknown): value is GrepOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.ok === true &&
+    typeof record.pattern === "string" &&
+    typeof record.matchCount === "number" &&
+    Array.isArray(record.matches)
+  );
+}
+
+function GrepOutputPanel({ output }: { output: GrepOutput }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="rounded border border-border/50 bg-background/40 px-2 py-1.5 font-mono text-[10px] text-muted-foreground">
+        <span className="text-foreground/80">{output.matchCount}</span>{" "}
+        match{output.matchCount === 1 ? "" : "es"} for{" "}
+        <span className="text-foreground/80">{output.pattern}</span>
+        {output.target ? (
+          <>
+            {" "}in <span className="text-foreground/80">{output.target}</span>
+          </>
+        ) : null}
+        {output.truncated ? " (truncated)" : null}
+      </div>
+      {output.matches.length > 0 ? (
+        <div className="max-h-56 overflow-y-auto rounded border border-border/50 bg-card/30">
+          {output.matches.map((match) => (
+            <div
+              key={`${match.file}:${match.line}:${match.text}`}
+              className="border-b border-border/30 px-2 py-1 last:border-b-0"
+            >
+              <div className="font-mono text-[10px] text-muted-foreground">
+                {match.file}:{match.line}
+              </div>
+              <pre className="whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-foreground/85">
+                {match.text}
+              </pre>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded border border-border/50 bg-card/30 px-2 py-1.5 font-mono text-[10px] text-muted-foreground">
+          No matching lines.
+        </div>
+      )}
     </div>
   );
 }

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -59,6 +59,7 @@ type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "diff" | "sta
 
 interface WorklogProps {
   messages: AntonUIMessage[];
+  streaming?: boolean;
   onApproval: ChatAddToolApproveResponseFunction;
   project: ProjectSummary | null;
   className?: string;
@@ -71,6 +72,7 @@ interface WorklogProps {
 
 export function Worklog({
   messages,
+  streaming = false,
   onApproval,
   project,
   className,
@@ -134,6 +136,19 @@ export function Worklog({
       !tabs.includes(tab.id) &&
       (tab.id !== "pr" || hasGithubProject),
   );
+
+  if (!visible) {
+    return (
+      <aside
+        className={cn(
+          "flex min-h-0 flex-col border-l border-layout-border bg-panel/80",
+          className,
+        )}
+        aria-label="Trace workspace"
+        aria-hidden="true"
+      />
+    );
+  }
 
   return (
     <aside
@@ -247,7 +262,11 @@ export function Worklog({
         </header>
 
         {activeTab === "worklog" ? (
-          <WorklogPanel messages={messages} onApproval={onApproval} />
+          <WorklogPanel
+            messages={messages}
+            streaming={streaming}
+            onApproval={onApproval}
+          />
         ) : activeTab === "plans" ? (
           <PlansPanel messages={messages} />
         ) : activeTab === "todos" ? (
@@ -326,12 +345,20 @@ function EmptyTabsPanel() {
 
 function WorklogPanel({
   messages,
+  streaming,
   onApproval,
 }: {
   messages: AntonUIMessage[];
+  streaming: boolean;
   onApproval: ChatAddToolApproveResponseFunction;
 }) {
-  return <WorklogTimeline messages={messages} onApproval={onApproval} />;
+  return (
+    <WorklogTimeline
+      messages={messages}
+      streaming={streaming}
+      onApproval={onApproval}
+    />
+  );
 }
 export function getWorklogEntries(messages: AntonUIMessage[]): WorklogEntry[] {
   return getToolTraceEntries(messages);

--- a/components/shared/disclosure.tsx
+++ b/components/shared/disclosure.tsx
@@ -7,11 +7,14 @@ import { cn } from "@/lib/utils";
 const DISCLOSURE_ANIMATION =
   "overflow-hidden transition-[max-height,opacity] ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
 
+type DisclosureChildren = ReactNode | ((state: { open: boolean }) => ReactNode);
+
 export function Disclosure({
   className,
   defaultOpen = false,
   forceOpen = false,
   disabled = false,
+  lazyMount = false,
   trigger,
   children,
 }: {
@@ -19,15 +22,24 @@ export function Disclosure({
   defaultOpen?: boolean;
   forceOpen?: boolean;
   disabled?: boolean;
+  lazyMount?: boolean;
   trigger: (state: { open: boolean }) => ReactNode;
-  children: ReactNode;
+  children: DisclosureChildren;
 }) {
   const id = useId();
   const contentRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(defaultOpen);
   const effectiveOpen = forceOpen || open;
+  const renderContent = !lazyMount || effectiveOpen;
+  const renderedChildren = renderContent
+    ? typeof children === "function"
+      ? children({ open: effectiveOpen })
+      : children
+    : null;
 
   useEffect(() => {
+    if (!renderContent) return;
+
     const content = contentRef.current;
     const panel = content?.parentElement;
     if (!content || !panel) return;
@@ -47,7 +59,7 @@ export function Disclosure({
       observer.disconnect();
       window.removeEventListener("resize", updateHeight);
     };
-  }, [children]);
+  }, [children, renderContent]);
 
   if (disabled) {
     return <div className={className}>{trigger({ open: false })}</div>;
@@ -74,7 +86,7 @@ export function Disclosure({
           maxHeight: effectiveOpen ? "var(--disclosure-height, 0px)" : "0px",
         }}
       >
-        <div ref={contentRef}>{children}</div>
+        <div ref={contentRef}>{renderedChildren}</div>
       </div>
     </div>
   );

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -23,6 +23,39 @@ type RunContextFile = {
   action: string;
 };
 
+type RunContextTodoItem = {
+  text: string;
+  status: "pending" | "in_progress" | "completed";
+};
+
+type RunContextTodo = {
+  summary: string;
+  itemCount: number;
+  completedCount: number;
+  current?: string;
+  items: RunContextTodoItem[];
+};
+
+type RunContextVerification = {
+  status: string;
+  summary?: string;
+  failureScope?: string;
+  failureSummary?: string;
+  recommendedNext?: string;
+  editedPaths: string[];
+  failedTargets: string[];
+};
+
+type RunContextBlocker = {
+  reason: string;
+  blockedTools: string[];
+  forceFinal: boolean;
+  affectedPath?: string;
+  phase?: string;
+  failureCode?: string;
+  recommendedNext?: string;
+};
+
 type RunContextCommand = {
   command: string;
   exitCode: number | null;
@@ -40,6 +73,10 @@ type RunContextTool = {
   output?: string;
   exitCode?: number | null;
   error?: string;
+  todo?: RunContextTodo;
+  verification?: RunContextVerification;
+  blocker?: RunContextBlocker;
+  touchedFiles?: RunContextFile[];
 };
 
 export class RunContextCollector {
@@ -72,6 +109,17 @@ export class RunContextCollector {
       compactLine,
     );
     const exitCode = outputExitCode(event.output);
+    const todo = todoFromToolOutput(event.toolName, event.output);
+    const verification = verificationFromToolOutput(
+      event.toolName,
+      event.output,
+    );
+    const touchedFiles = touchedFilesFromTool(
+      event.toolName,
+      event.input,
+      event.output,
+      !error,
+    );
 
     this.tools.push({
       name: event.toolName,
@@ -80,11 +128,42 @@ export class RunContextCollector {
       ...(outputSummary ? { output: outputSummary } : {}),
       ...(exitCode !== undefined ? { exitCode } : {}),
       ...(error ? { error } : {}),
+      ...(todo ? { todo } : {}),
+      ...(verification ? { verification } : {}),
+      ...(touchedFiles.length > 0 ? { touchedFiles } : {}),
     });
 
     this.collectFacts(event.toolName, event.input, event.output);
-    this.collectFiles(event.toolName, event.input);
+    for (const file of touchedFiles) {
+      this.files.set(`${file.action}:${file.path}`, file);
+    }
     this.collectCommand(event.toolName, event.input, event.output, error);
+  }
+
+  addLoopGuard(event: RunContextBlocker): void {
+    const blocker = {
+      ...event,
+      reason: compactLine(event.reason, 500),
+      blockedTools: event.blockedTools
+        .map((tool) => compactLine(tool, 100))
+        .filter(Boolean),
+      ...(event.affectedPath
+        ? { affectedPath: compactLine(event.affectedPath, 500) }
+        : {}),
+      ...(event.phase ? { phase: compactLine(event.phase, 100) } : {}),
+      ...(event.failureCode
+        ? { failureCode: compactLine(event.failureCode, 100) }
+        : {}),
+      ...(event.recommendedNext
+        ? { recommendedNext: compactLine(event.recommendedNext, 300) }
+        : {}),
+    };
+    this.tools.push({
+      name: "loop_guard",
+      status: blocker.forceFinal ? "error" : "completed",
+      output: blocker.reason,
+      blocker,
+    });
   }
 
   persist(input: {
@@ -135,6 +214,16 @@ export class RunContextCollector {
       }
     }
 
+    if (toolName === "update_todos") {
+      const todo = todoFromToolOutput(toolName, output);
+      if (todo) this.addFact(`Todos: ${todo.summary}`);
+    }
+
+    if (toolName === "verify") {
+      const verification = verificationFromToolOutput(toolName, output);
+      if (verification) this.addFact(`Verification: ${verificationLine(verification)}`);
+    }
+
     if (toolName === "read_file" && readPath(input) === "package.json") {
       const packageFacts = packageFactsFromContent(stringValue(output.content));
       for (const fact of packageFacts) this.addFact(fact);
@@ -142,18 +231,6 @@ export class RunContextCollector {
 
     const summary = stringValue(output.summary);
     if (summary && toolName !== "inspect_project") this.addFact(summary);
-  }
-
-  private collectFiles(toolName: string, input: unknown): void {
-    if (!isRecord(input)) return;
-    for (const key of ["path", "sourcePath", "targetPath", "destinationPath"]) {
-      const path = stringValue(input[key]);
-      if (!path) continue;
-      this.files.set(`${toolName}:${path}`, {
-        path,
-        action: toolName,
-      });
-    }
   }
 
   private collectCommand(
@@ -252,12 +329,35 @@ function selectSummaries(
 }
 
 function contextBlock(summary: RunContextSummary): string {
-  const parts = [
-    `Run ${summary.createdAt.toISOString()}:`,
-    compactBlock(summary.summary, MAX_DIGEST_BLOCK_CHARS),
-  ];
-  const facts = stringArray(summary.facts).slice(0, 8);
-  if (facts.length > 0) parts.push(`Facts: ${facts.join("; ")}`);
+  const parts = [`Run ${summary.createdAt.toISOString()}:`];
+  const tools = toolArray(summary.tools);
+  const blockers = tools.flatMap((tool) => (tool.blocker ? [tool.blocker] : []));
+  if (blockers.length > 0) {
+    parts.push(`Blockers: ${blockers.slice(-3).map(blockerLine).join("; ")}`);
+  }
+
+  const verification = latestVerification(tools);
+  if (verification) parts.push(`Verification: ${verificationLine(verification)}`);
+
+  const todo = latestTodo(tools);
+  if (todo) parts.push(`Todos: ${todoLine(todo)}`);
+
+  const failedTools = tools
+    .filter((tool) => tool.status === "error" && !tool.blocker)
+    .slice(-5);
+  if (failedTools.length > 0) {
+    parts.push(`Failed tools: ${failedTools.map(failedToolLine).join("; ")}`);
+  }
+
+  const files = touchedFileArray(summary.files).slice(0, 10);
+  if (files.length > 0) {
+    parts.push(
+      `Touched files: ${files
+        .map((file) => `${file.action} ${file.path}`)
+        .join("; ")}`,
+    );
+  }
+
   const commands = commandArray(summary.commands).slice(0, 5);
   if (commands.length > 0) {
     parts.push(
@@ -270,12 +370,11 @@ function contextBlock(summary: RunContextSummary): string {
         .join("; ")}`,
     );
   }
-  const files = fileArray(summary.files).slice(0, 10);
-  if (files.length > 0) {
-    parts.push(
-      `Files: ${files.map((file) => `${file.action} ${file.path}`).join("; ")}`,
-    );
-  }
+
+  const facts = stringArray(summary.facts).slice(0, 8);
+  if (facts.length > 0) parts.push(`Facts: ${facts.join("; ")}`);
+
+  parts.push(compactBlock(summary.summary, MAX_DIGEST_BLOCK_CHARS));
   return compactBlock(parts.join("\n"), MAX_DIGEST_BLOCK_CHARS);
 }
 
@@ -332,6 +431,162 @@ function packageSectionNames(value: unknown): string[] {
   return Object.keys(value).sort((left, right) => left.localeCompare(right));
 }
 
+function todoFromToolOutput(
+  toolName: string,
+  output: unknown,
+): RunContextTodo | undefined {
+  if (toolName !== "update_todos" || !isRecord(output) || output.ok !== true) {
+    return undefined;
+  }
+  const items = todoItemArray(output.items);
+  if (items.length === 0) return undefined;
+  const completedCount =
+    numberValue(output.completedCount) ??
+    items.filter((item) => item.status === "completed").length;
+  const current = items.find((item) => item.status === "in_progress")?.text;
+  const summary =
+    stringValue(output.summary) ||
+    (current
+      ? `${completedCount}/${items.length} complete; current: ${current}`
+      : `${completedCount}/${items.length} complete`);
+  return {
+    summary: compactLine(summary, 500),
+    itemCount: numberValue(output.itemCount) ?? items.length,
+    completedCount,
+    ...(current ? { current: compactLine(current, 240) } : {}),
+    items: items.slice(0, 40),
+  };
+}
+
+function todoItemArray(value: unknown): RunContextTodoItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): RunContextTodoItem[] => {
+    if (!isRecord(item)) return [];
+    const text = compactLine(stringValue(item.text), 240);
+    const status = item.status;
+    if (
+      !text ||
+      (status !== "pending" &&
+        status !== "in_progress" &&
+        status !== "completed")
+    ) {
+      return [];
+    }
+    return [{ text, status }];
+  });
+}
+
+function verificationFromToolOutput(
+  toolName: string,
+  output: unknown,
+): RunContextVerification | undefined {
+  if (toolName !== "verify" || !isRecord(output)) return undefined;
+  const status = compactLine(stringValue(output.status), 100);
+  if (!status) return undefined;
+  return {
+    status,
+    ...optionalCompactString("summary", output.summary, 500),
+    ...optionalCompactString("failureScope", output.failureScope, 100),
+    ...optionalCompactString("failureSummary", output.failureSummary, 500),
+    ...optionalCompactString("recommendedNext", output.recommendedNext, 200),
+    editedPaths: stringArray(output.editedPaths).slice(0, 10),
+    failedTargets: failedTargetsFromVerifyResults(output.results).slice(0, 5),
+  };
+}
+
+function failedTargetsFromVerifyResults(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): string[] => {
+    if (!isRecord(item) || item.ok !== false) return [];
+    const target = compactLine(stringValue(item.target), 100);
+    if (!target) return [];
+    const exitCode = outputExitCode(item);
+    return [exitCode === undefined ? target : `${target} exit ${exitCode}`];
+  });
+}
+
+function touchedFilesFromTool(
+  toolName: string,
+  input: unknown,
+  output: unknown,
+  success: boolean,
+): RunContextFile[] {
+  if (!success || (isRecord(output) && output.ok === false)) return [];
+  const action = touchedFileAction(toolName);
+  if (!action) return [];
+  const record = isRecord(output) ? output : isRecord(input) ? input : {};
+  const files: RunContextFile[] = [];
+  addTouchedPath(files, action, stringValue(record.path));
+  if (toolName === "rename") {
+    addTouchedPath(files, "renamed from", stringValue(record.sourcePath));
+    addTouchedPath(files, "renamed to", stringValue(record.destinationPath));
+  } else if (toolName === "copy") {
+    addTouchedPath(files, "copied from", stringValue(record.sourcePath));
+    addTouchedPath(files, "copied to", stringValue(record.destinationPath));
+  } else {
+    addTouchedPath(files, action, stringValue(record.targetPath));
+    addTouchedPath(files, action, stringValue(record.destinationPath));
+  }
+  addTouchedPathList(files, action, record.paths);
+  addTouchedPathList(files, action, record.restoredPaths);
+  return uniqueFiles(files);
+}
+
+function touchedFileAction(toolName: string): string | undefined {
+  switch (toolName) {
+    case "edit_file":
+    case "replace_text":
+    case "replace_lines":
+    case "edit_text":
+    case "multi_replace_text":
+      return "edited";
+    case "write_file":
+      return "wrote";
+    case "format":
+      return "formatted";
+    case "mkdir":
+      return "created";
+    case "delete":
+      return "deleted";
+    case "rename":
+      return "renamed";
+    case "copy":
+      return "copied";
+    case "git_restore":
+    case "revert_changes":
+      return "restored";
+    default:
+      return undefined;
+  }
+}
+
+function addTouchedPath(
+  files: RunContextFile[],
+  action: string,
+  rawPath: string,
+): void {
+  const path = compactLine(rawPath, 500);
+  if (path) files.push({ path, action });
+}
+
+function addTouchedPathList(
+  files: RunContextFile[],
+  action: string,
+  value: unknown,
+): void {
+  for (const path of stringArray(value)) addTouchedPath(files, action, path);
+}
+
+function uniqueFiles(files: RunContextFile[]): RunContextFile[] {
+  const seen = new Set<string>();
+  return files.filter((file) => {
+    const key = `${file.action}:${file.path}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 function readPath(input: unknown): string | undefined {
   if (!isRecord(input)) return undefined;
   const path = stringValue(input.path).replace(/\\/g, "/");
@@ -386,6 +641,191 @@ function fileArray(value: unknown): RunContextFile[] {
   });
 }
 
+function touchedFileArray(value: unknown): RunContextFile[] {
+  return fileArray(value).flatMap((file): RunContextFile[] => {
+    const action = digestFileAction(file.action);
+    return action ? [{ ...file, action }] : [];
+  });
+}
+
+function digestFileAction(action: string): string | undefined {
+  switch (action) {
+    case "edited":
+    case "wrote":
+    case "formatted":
+    case "created":
+    case "deleted":
+    case "renamed":
+    case "renamed from":
+    case "renamed to":
+    case "copied":
+    case "copied from":
+    case "copied to":
+    case "restored":
+      return action;
+    case "edit_file":
+    case "replace_text":
+    case "replace_lines":
+    case "edit_text":
+    case "multi_replace_text":
+      return "edited";
+    case "write_file":
+      return "wrote";
+    case "format":
+      return "formatted";
+    case "mkdir":
+      return "created";
+    case "delete":
+      return "deleted";
+    case "rename":
+      return "renamed";
+    case "copy":
+      return "copied";
+    case "git_restore":
+    case "revert_changes":
+      return "restored";
+    default:
+      return undefined;
+  }
+}
+
+function toolArray(value: unknown): RunContextTool[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): RunContextTool[] => {
+    if (!isRecord(item)) return [];
+    const name = stringValue(item.name);
+    const status = item.status;
+    if (!name || (status !== "completed" && status !== "error")) return [];
+    const exitCode = outputExitCode(item);
+    const tool: RunContextTool = {
+      name,
+      status,
+      ...optionalString("input", item.input),
+      ...optionalString("output", item.output),
+      ...(exitCode !== undefined ? { exitCode } : {}),
+      ...optionalString("error", item.error),
+    };
+    const todo = todoValue(item.todo);
+    if (todo) tool.todo = todo;
+    const verification = verificationValue(item.verification);
+    if (verification) tool.verification = verification;
+    const blocker = blockerValue(item.blocker);
+    if (blocker) tool.blocker = blocker;
+    const touchedFiles = fileArray(item.touchedFiles);
+    if (touchedFiles.length > 0) tool.touchedFiles = touchedFiles;
+    return [tool];
+  });
+}
+
+function todoValue(value: unknown): RunContextTodo | undefined {
+  if (!isRecord(value)) return undefined;
+  const summary = compactLine(stringValue(value.summary), 500);
+  const items = todoItemArray(value.items);
+  const itemCount = numberValue(value.itemCount) ?? items.length;
+  const completedCount =
+    numberValue(value.completedCount) ??
+    items.filter((item) => item.status === "completed").length;
+  if (!summary || itemCount <= 0) return undefined;
+  const current = compactLine(stringValue(value.current), 240);
+  return {
+    summary,
+    itemCount,
+    completedCount,
+    ...(current ? { current } : {}),
+    items,
+  };
+}
+
+function verificationValue(
+  value: unknown,
+): RunContextVerification | undefined {
+  if (!isRecord(value)) return undefined;
+  const status = compactLine(stringValue(value.status), 100);
+  if (!status) return undefined;
+  return {
+    status,
+    ...optionalCompactString("summary", value.summary, 500),
+    ...optionalCompactString("failureScope", value.failureScope, 100),
+    ...optionalCompactString("failureSummary", value.failureSummary, 500),
+    ...optionalCompactString("recommendedNext", value.recommendedNext, 200),
+    editedPaths: stringArray(value.editedPaths).slice(0, 10),
+    failedTargets: stringArray(value.failedTargets).slice(0, 5),
+  };
+}
+
+function blockerValue(value: unknown): RunContextBlocker | undefined {
+  if (!isRecord(value)) return undefined;
+  const reason = compactLine(stringValue(value.reason), 500);
+  if (!reason) return undefined;
+  return {
+    reason,
+    blockedTools: stringArray(value.blockedTools).slice(0, 20),
+    forceFinal: booleanValue(value.forceFinal),
+    ...optionalCompactString("affectedPath", value.affectedPath, 500),
+    ...optionalCompactString("phase", value.phase, 100),
+    ...optionalCompactString("failureCode", value.failureCode, 100),
+    ...optionalCompactString("recommendedNext", value.recommendedNext, 300),
+  };
+}
+
+function latestTodo(tools: RunContextTool[]): RunContextTodo | undefined {
+  return tools.findLast((tool) => tool.todo)?.todo;
+}
+
+function latestVerification(
+  tools: RunContextTool[],
+): RunContextVerification | undefined {
+  return tools.findLast((tool) => tool.verification)?.verification;
+}
+
+function todoLine(todo: RunContextTodo): string {
+  if (todo.current && !todo.summary.includes("current:")) {
+    return `${todo.summary}; current: ${todo.current}`;
+  }
+  return todo.summary;
+}
+
+function verificationLine(verification: RunContextVerification): string {
+  return [
+    verification.status,
+    verification.failureScope ? `scope ${verification.failureScope}` : "",
+    verification.summary ?? "",
+    verification.failureSummary
+      ? `failure ${verification.failureSummary}`
+      : "",
+    verification.failedTargets.length > 0
+      ? `failed targets ${verification.failedTargets.join(", ")}`
+      : "",
+    verification.editedPaths.length > 0
+      ? `edited ${verification.editedPaths.join(", ")}`
+      : "",
+    verification.recommendedNext ? `next ${verification.recommendedNext}` : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+function blockerLine(blocker: RunContextBlocker): string {
+  return [
+    blocker.reason,
+    blocker.blockedTools.length > 0
+      ? `blocked ${blocker.blockedTools.join(", ")}`
+      : "",
+    blocker.affectedPath ? `path ${blocker.affectedPath}` : "",
+    blocker.phase ? `phase ${blocker.phase}` : "",
+    blocker.failureCode ? `code ${blocker.failureCode}` : "",
+    blocker.recommendedNext ? `next ${blocker.recommendedNext}` : "",
+    blocker.forceFinal ? "final required" : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+function failedToolLine(tool: RunContextTool): string {
+  const reason = tool.error ?? tool.output ?? "failed";
+  return `${tool.name}: ${compactLine(reason, 300)}`;
+}
+
 function textTailField<K extends "stdoutTail" | "stderrTail">(
   key: K,
   value: string,
@@ -401,6 +841,15 @@ function optionalString<K extends string>(
   value: unknown,
 ): Partial<Record<K, string>> {
   const text = stringValue(value);
+  return text ? ({ [key]: text } as Partial<Record<K, string>>) : {};
+}
+
+function optionalCompactString<K extends string>(
+  key: K,
+  value: unknown,
+  maxLength: number,
+): Partial<Record<K, string>> {
+  const text = compactLine(stringValue(value), maxLength);
   return text ? ({ [key]: text } as Partial<Record<K, string>>) : {};
 }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -188,9 +188,11 @@ const PLAN_MODE_TOOLS = [
 
 const ACCEPTED_PLAN_SIMPLE_TOOLS = [
   "read_file",
+  "edit_text",
+  "replace_text",
+  "replace_lines",
+  "multi_replace_text",
   "edit_file",
-  "write_file",
-  "bash",
   "verify",
   "git_status",
 ] as const satisfies readonly NativeAntonToolName[];
@@ -349,7 +351,9 @@ function runProfilePromptLines(
       ...header,
       "- The user accepted an existing plan. Use the immediately preceding plan response as the source of truth.",
       "- Do not rediscover files already named in the plan; read only the target files needed to get fresh hashes before editing.",
-      "- Keep progress brief and use the narrow edit and verification tools supplied to this run.",
+      "- Use `edit_text` for surgical edits. Use `replace_lines`, `replace_text`, or `multi_replace_text` only when text anchors are not enough.",
+      "- Do not call `edit_file` unless an `edit_text` attempt failed on the same path.",
+      "- Keep progress brief and verify after editing.",
     ];
   }
   if (profile === "accepted-plan-general") {

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { execa } from "execa";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { tool, type JSONValue } from "ai";
+import { globToRegex } from "./glob";
 import { compactGrepForModel } from "./model-output";
 import {
   resolveInWorkspace,
@@ -13,6 +16,7 @@ import {
 
 const MAX_RESULTS = 80;
 const MAX_OUTPUT_BYTES = 64 * 1024;
+const MAX_FALLBACK_FILES = 5_000;
 
 export function createGrepTool(workspaceRoot?: string) {
   return tool({
@@ -80,7 +84,17 @@ export function createGrepTool(workspaceRoot?: string) {
         .filter((line) => line.length > 0)
         .slice(0, MAX_RESULTS);
 
-      const matches = rawLines.map((line) => parseRgLine(line, root));
+      const rgMatches = rawLines.map((line) => parseRgLine(line, root));
+      const matches =
+        rgMatches.length > 0
+          ? rgMatches
+          : await fallbackSearch({
+              root,
+              target,
+              pattern,
+              glob,
+              caseInsensitive: caseInsensitive === true,
+            });
 
       return {
         ok: true as const,
@@ -122,4 +136,123 @@ function errorMessage(err: unknown): string {
   if (err instanceof SandboxError) return err.message;
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+async function fallbackSearch({
+  root,
+  target,
+  pattern,
+  glob,
+  caseInsensitive,
+}: {
+  root: string;
+  target: string;
+  pattern: string;
+  glob?: string;
+  caseInsensitive: boolean;
+}): Promise<{ file: string; line: number; text: string }[]> {
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, caseInsensitive ? "i" : "");
+  } catch {
+    return [];
+  }
+
+  const globRegexes = glob
+    ?.split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map(globToRegex);
+  const files = await collectSearchFiles(root, target, globRegexes);
+  const matches: { file: string; line: number; text: string }[] = [];
+
+  for (const file of files) {
+    if (matches.length >= MAX_RESULTS) break;
+    let stat;
+    try {
+      stat = await fs.stat(file);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile() || stat.size > 1024 * 1024) continue;
+
+    let content: string;
+    try {
+      content = await fs.readFile(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    const lines = content.split(/\r?\n/);
+    for (const [index, line] of lines.entries()) {
+      regex.lastIndex = 0;
+      if (!regex.test(line)) continue;
+      matches.push({
+        file: workspaceRelativeTo(root, file),
+        line: index + 1,
+        text: line,
+      });
+      if (matches.length >= MAX_RESULTS) break;
+    }
+  }
+
+  return matches;
+}
+
+async function collectSearchFiles(
+  root: string,
+  target: string,
+  globRegexes: RegExp[] | undefined,
+): Promise<string[]> {
+  const stat = await fs.stat(target);
+  if (stat.isFile()) {
+    return fileMatchesGlob(root, target, globRegexes) ? [target] : [];
+  }
+  if (!stat.isDirectory()) return [];
+
+  const files: string[] = [];
+  await walkSearchDirectory(root, target, globRegexes, files);
+  return files;
+}
+
+async function walkSearchDirectory(
+  root: string,
+  directory: string,
+  globRegexes: RegExp[] | undefined,
+  files: string[],
+): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (files.length >= MAX_FALLBACK_FILES) return;
+    if (shouldSkipSearchEntry(entry.name)) continue;
+
+    const nextPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await walkSearchDirectory(root, nextPath, globRegexes, files);
+      continue;
+    }
+    if (entry.isFile() && fileMatchesGlob(root, nextPath, globRegexes)) {
+      files.push(nextPath);
+    }
+  }
+}
+
+function fileMatchesGlob(
+  root: string,
+  file: string,
+  globRegexes: RegExp[] | undefined,
+): boolean {
+  if (!globRegexes || globRegexes.length === 0) return true;
+  const relative = workspaceRelativeTo(root, file).replaceAll(path.sep, "/");
+  return globRegexes.some((regex) => regex.test(relative));
+}
+
+function shouldSkipSearchEntry(name: string): boolean {
+  return [".git", "node_modules", ".next", "dist", "build"].includes(name);
 }

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -299,6 +299,9 @@ const LEAKED_MARKUP_BLOCK =
 const LEAKED_MARKUP_TAG =
   /<\|(?:DSML|tool_call|tool_calls|function_call|invoke)[^|]*\|[^>]*>/gi;
 
+const PLAN_REASONING_MARKER =
+  /^\s*(?:#{1,6}\s*)?(?:\*\*)?(?:implementation\s+)?plan\s*:?\s*(?:\*\*)?\s*$/i;
+
 export function stripLeakedProviderMarkup(text: string): string {
   let next = text.replace(LEAKED_MARKUP_BLOCK, "");
   next = next.replace(LEAKED_MARKUP_TAG, "");
@@ -313,22 +316,50 @@ export function getAssistantTextDisplay(
   const lastToolIndex = message.parts.findLastIndex(isToolUIPart);
   const progressText: string[] = [];
   const finalText: string[] = [];
+  const trailingPlanReasoningText: string[] = [];
+  const usePlanReasoningFallback = message.metadata?.responseKind === "plan";
 
   for (const [index, part] of message.parts.entries()) {
-    if (part.type !== "text") continue;
-    const text = stripLeakedProviderMarkup(part.text);
-    if (!text) continue;
-    if (options.progressOnly || (lastToolIndex !== -1 && index < lastToolIndex)) {
-      progressText.push(text);
-    } else {
-      finalText.push(text);
+    if (part.type === "reasoning") {
+      const text = stripLeakedProviderMarkup(part.text);
+      if (text && usePlanReasoningFallback && index > lastToolIndex) {
+        trailingPlanReasoningText.push(text);
+      }
+      continue;
     }
+
+    if (part.type === "text") {
+      const text = stripLeakedProviderMarkup(part.text);
+      if (!text) continue;
+      if (options.progressOnly || (lastToolIndex !== -1 && index < lastToolIndex)) {
+        progressText.push(text);
+      } else {
+        finalText.push(text);
+      }
+    }
+  }
+
+  if (finalText.length === 0 && trailingPlanReasoningText.length > 0) {
+    const planFallback = extractPlanReasoningFallback(
+      trailingPlanReasoningText.join("\n\n"),
+    );
+    if (planFallback) finalText.push(planFallback);
   }
 
   return {
     progressText: progressText.join("\n\n"),
     finalText: finalText.join("\n\n"),
   };
+}
+
+function extractPlanReasoningFallback(text: string): string | undefined {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const markerIndex = lines.findIndex((line) =>
+    PLAN_REASONING_MARKER.test(line),
+  );
+  if (markerIndex === -1) return undefined;
+  const planText = lines.slice(markerIndex + 1).join("\n").trim();
+  return planText || undefined;
 }
 
 export function hasPendingToolApproval(message: AntonUIMessage): boolean {


### PR DESCRIPTION
## Summary
- Enriches persisted run context summaries with todos, verification, blockers, touched files, and failed tool details.
- Fixes plan-mode rendering/acceptance regressions and narrows accepted-plan tool behavior.
- Reduces live trace UI pressure with lazy-mounted disclosures, lighter Worklog rendering, and coalesced streaming autoscroll.
- Hardens native grep with a bounded fallback search and renders grep results as structured Worklog output.

## Issues
Closes #136
Closes #137
Closes #138
Closes #139
Closes #140

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

## Manual checks
- Verified affected trace sessions load and expand after the rendering changes.
- Verified plan rendering/acceptance behavior in the local app browser.
- Confirmed no migration files were generated.
