### PR TITLE
[codex] Add OpenRouter routing settings

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Enriched prior-run context summaries with todos, verification, blockers, touched files, and failed tool details (#136).
 - [✔️] Reduced live trace rendering pressure with lazy-mounted disclosures and bounded running Worklog rows (#139).
 - [✔️] Hardened native grep fallback search and rendered grep results as structured Worklog output (#140).
+- [✔️] Added OpenRouter model catalog, provider routing settings, and routing cache metadata (#142).
 
 ## Phase 1: Trust Boundaries And Safety
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -88,7 +88,12 @@ import {
 } from "@/src/db/queries";
 import { registerActiveChatStream } from "@/src/lib/chat-stream-registry";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
-import { isSupportedModelId, getProviderId, resolveModelId } from "@/src/lib/models";
+import { getProviderId, resolveModelId } from "@/src/lib/models";
+import { isSupportedAgentModelId } from "@/src/lib/openrouter-catalog";
+import {
+  resolveOpenRouterRouting,
+  type OpenRouterRoutingResolution,
+} from "@/src/lib/openrouter-routing";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
 import { redactText, redactValue } from "@/src/lib/redaction";
 import {
@@ -220,12 +225,16 @@ export async function POST(req: Request) {
     continuationModel && continuationModel !== requestedModel
       ? `UI selected ${requestedModel}, but this continuation reused ${continuationModel} from the originating run.`
       : undefined;
-  if (!isSupportedModelId(continuationModel ?? requestedModel)) {
+  if (!(await isSupportedAgentModelId(continuationModel ?? requestedModel))) {
     return Response.json(
       { error: "unsupported model", model },
       { status: 400 },
     );
   }
+  const openRouterRouting = resolveOpenRouterRouting(
+    model,
+    workspaceSettings.openRouterRoutingPreferences,
+  );
 
   const existing = getSession(sessionId);
   const requestedProjectId = parsed.data.projectId ?? null;
@@ -546,6 +555,7 @@ export async function POST(req: Request) {
         tokenBudgetMultiplier,
         permissionMode,
         thinkingEnabled,
+        ...(openRouterRouting ? { openRouterRouting } : {}),
         ...(profileHandoffRun
           ? {
               profileHandoffContinuationOfRunId: profileHandoffRun.id,
@@ -615,6 +625,7 @@ export async function POST(req: Request) {
         tokenBudgetMultiplier,
         permissionMode,
         thinkingEnabled,
+        openRouterRouting,
         profileHandoffContinuationOfRunId: profileHandoffRun?.id,
         tokenBudgetContext: {
           baseMaxTotalTokens: baseBudget.maxTotalTokens,
@@ -659,6 +670,7 @@ export async function POST(req: Request) {
             singleFileTargetResolution?.targetResolutionReason,
           permissionMode,
           enabledMcpServerIds: parsed.data.enabledMcpServerIds,
+          openRouterRouting,
           onStepStart: ({ stepNumber }) => trace.startStep(stepNumber),
           onStepFinish: ({ stepNumber }) => trace.finishStep(stepNumber),
           onStepUsageUpdate: (steps) => trace.updateStepUsage(steps),
@@ -1168,6 +1180,7 @@ function createTraceWriter({
   tokenBudgetMultiplier,
   permissionMode,
   thinkingEnabled,
+  openRouterRouting,
   profileHandoffContinuationOfRunId,
   tokenBudgetContext,
 }: {
@@ -1182,6 +1195,7 @@ function createTraceWriter({
   tokenBudgetMultiplier: number;
   permissionMode: PermissionMode;
   thinkingEnabled: boolean;
+  openRouterRouting?: OpenRouterRoutingResolution;
   profileHandoffContinuationOfRunId?: string;
   tokenBudgetContext: {
     baseMaxTotalTokens: number;
@@ -1467,6 +1481,7 @@ function createTraceWriter({
         tokenBudgetMultiplier,
         permissionMode,
         thinkingEnabled,
+        ...(openRouterRouting ? { openRouterRouting } : {}),
         profileHandoffContinuationOfRunId,
         loopGuardCount:
           limits.tokenAudit?.loopGuardCount ?? loopGuardCount,
@@ -2148,6 +2163,7 @@ function runCostMetadata(
     targetPath?: string;
     targetResolution?: "exact" | "unique_search" | "unresolved" | "ambiguous";
     targetResolutionReason?: string;
+    openRouterRouting?: OpenRouterRoutingResolution;
   },
 ): Record<string, unknown> | null {
   const providerCostMetadata = openRouterCostMetadata(
@@ -2172,6 +2188,9 @@ function runCostMetadata(
         tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
         permissionMode: execution.permissionMode,
         thinkingEnabled: execution.thinkingEnabled,
+        ...(execution.openRouterRouting
+          ? { openRouterRouting: execution.openRouterRouting }
+          : {}),
         ...(execution.profileHandoffContinuationOfRunId
           ? {
               profileHandoffContinuationOfRunId:
@@ -2228,6 +2247,9 @@ function runCostMetadata(
       tokenBudgetMultiplier: execution.tokenBudgetMultiplier,
       permissionMode: execution.permissionMode,
       thinkingEnabled: execution.thinkingEnabled,
+      ...(execution.openRouterRouting
+        ? { openRouterRouting: execution.openRouterRouting }
+        : {}),
       ...(execution.profileHandoffContinuationOfRunId
         ? {
             profileHandoffContinuationOfRunId:

--- a/app/api/openrouter/catalog/route.ts
+++ b/app/api/openrouter/catalog/route.ts
@@ -1,0 +1,9 @@
+import { getOpenRouterCatalog } from "@/src/lib/openrouter-catalog";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json({
+    catalog: await getOpenRouterCatalog(),
+  });
+}

--- a/app/api/openrouter/model-endpoints/route.ts
+++ b/app/api/openrouter/model-endpoints/route.ts
@@ -1,0 +1,15 @@
+import { getOpenRouterModelEndpoints } from "@/src/lib/openrouter-catalog";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const model = url.searchParams.get("model")?.trim();
+  if (!model) {
+    return Response.json({ error: "model is required" }, { status: 400 });
+  }
+
+  return Response.json({
+    endpoints: await getOpenRouterModelEndpoints(model),
+  });
+}

--- a/app/api/workspace-settings/route.ts
+++ b/app/api/workspace-settings/route.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 import { getWorkspaceSettings, updateWorkspaceSettings } from "@/src/db/queries";
-import { isSupportedModelId, resolveModelId } from "@/src/lib/models";
+import { isSupportedAgentModelId } from "@/src/lib/openrouter-catalog";
+import { resolveModelId } from "@/src/lib/models";
+import { sanitizeOpenRouterRoutingPreferences } from "@/src/lib/openrouter-routing";
 import {
   getLocalWorkspacesRoot,
   setLocalWorkspacesRoot,
@@ -11,12 +13,20 @@ import {
 export const runtime = "nodejs";
 
 const permissionModeSchema = z.enum(["default", "auto-review", "full-access"]);
+const routingPreferenceSchema = z.object({
+  order: z.array(z.string().trim().min(1).max(100)).max(24),
+  allowFallbacks: z.boolean(),
+});
 
 const patchSchema = z.object({
   localWorkspacesRoot: z.string().trim().min(1).nullable().optional(),
   defaultModel: z.string().trim().min(1).nullable().optional(),
   defaultMaxSteps: z.number().int().min(1).max(64).nullable().optional(),
   defaultPermissionMode: permissionModeSchema.nullable().optional(),
+  openRouterRoutingPreferences: z
+    .record(z.string().trim().min(1), routingPreferenceSchema)
+    .nullable()
+    .optional(),
 });
 
 export async function GET() {
@@ -38,7 +48,7 @@ export async function PATCH(req: Request) {
   if (
     parsed.data.defaultModel !== undefined &&
     parsed.data.defaultModel !== null &&
-    !isSupportedModelId(parsed.data.defaultModel)
+    !(await isSupportedAgentModelId(parsed.data.defaultModel))
   ) {
     return Response.json(
       { error: "unsupported model", model: parsed.data.defaultModel },
@@ -65,6 +75,13 @@ export async function PATCH(req: Request) {
       ...(parsed.data.defaultPermissionMode !== undefined
         ? { defaultPermissionMode: parsed.data.defaultPermissionMode }
         : {}),
+      ...(parsed.data.openRouterRoutingPreferences !== undefined
+        ? {
+            openRouterRoutingPreferences: sanitizeOpenRouterRoutingPreferences(
+              parsed.data.openRouterRoutingPreferences,
+            ),
+          }
+        : {}),
     };
     if (Object.keys(agentPatch).length > 0) {
       updateWorkspaceSettings(agentPatch);
@@ -87,6 +104,9 @@ function serializeSettings() {
     defaultModel: settings.defaultModel,
     defaultMaxSteps: settings.defaultMaxSteps,
     defaultPermissionMode: settings.defaultPermissionMode,
+    openRouterRoutingPreferences: sanitizeOpenRouterRoutingPreferences(
+      settings.openRouterRoutingPreferences,
+    ),
   };
 }
 

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -198,7 +198,10 @@ export function Composer({
                 thinkingEnabled={thinkingEnabled}
                 onThinkingEnabledChange={onThinkingEnabledChange}
                 disabled={streaming}
-                triggerClassName={cn(COMPOSER_TOOLBAR_CONTROL, "w-36 justify-between")}
+                triggerClassName={cn(
+                  COMPOSER_TOOLBAR_CONTROL,
+                  "w-40 justify-between sm:w-48",
+                )}
               />
               {streaming ? (
                 <Button

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Check, ChevronDown, Loader2, RefreshCw, Search } from "lucide-react";
 
 import {
   getModelLabel,
   getModelsForProvider,
   getProviderId,
+  getProviderModelId,
   PROVIDERS,
   type ModelId,
   type ProviderId,
 } from "@/src/lib/models";
+import type { OpenRouterCatalogSummary } from "@/src/lib/api-types";
+import { getJson } from "@/src/lib/client-fetch";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -19,7 +22,64 @@ import {
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PopupSectionHeader } from "@/components/shared/popup-section-header";
+import {
+  PopupSortSelect,
+  type PopupSortOption,
+} from "@/components/shared/popup-sort-select";
 import { cn } from "@/lib/utils";
+
+type PickerModel = {
+  id: string;
+  label: string;
+  providerSlug?: string;
+  contextLength?: number | null;
+  promptPrice?: string | null;
+  completionPrice?: string | null;
+};
+
+type ModelFilter =
+  | "recommended"
+  | "free"
+  | "long-context"
+  | "low-price"
+  | "name-asc"
+  | "context-desc"
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "deepseek"
+  | "qwen"
+  | "meta"
+  | "mistral"
+  | "other";
+
+const MODEL_FILTER_OPTIONS = [
+  { value: "recommended", label: "Recommended" },
+  { value: "free", label: "Free" },
+  { value: "long-context", label: "Long context" },
+  { value: "low-price", label: "Low price" },
+  { value: "name-asc", label: "Name A-Z" },
+  { value: "context-desc", label: "Context high" },
+  { value: "anthropic", label: "Anthropic" },
+  { value: "openai", label: "OpenAI" },
+  { value: "google", label: "Google" },
+  { value: "deepseek", label: "DeepSeek" },
+  { value: "qwen", label: "Qwen" },
+  { value: "meta", label: "Meta" },
+  { value: "mistral", label: "Mistral" },
+  { value: "other", label: "Other families" },
+] as const satisfies readonly PopupSortOption<ModelFilter>[];
+
+const MODEL_FAMILY_FILTERS = [
+  "anthropic",
+  "openai",
+  "google",
+  "deepseek",
+  "qwen",
+  "meta",
+  "mistral",
+] as const satisfies readonly ModelFilter[];
 
 interface ModelPickerProps {
   value: ModelId;
@@ -44,13 +104,84 @@ export function ModelPicker({
   const [activeProvider, setActiveProvider] = useState<ProviderId>(() =>
     getProviderId(value),
   );
+  const [query, setQuery] = useState("");
+  const [modelFilter, setModelFilter] = useState<ModelFilter>("recommended");
+  const [catalog, setCatalog] = useState<OpenRouterCatalogSummary | null>(null);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [catalogLoading, setCatalogLoading] = useState(false);
+
+  const loadCatalog = useCallback(async ({ refresh = false } = {}) => {
+    if (!refresh && (catalog || catalogError)) return;
+    setCatalogLoading(true);
+    try {
+      const data = await getJson<{ catalog: OpenRouterCatalogSummary }>(
+        "/api/openrouter/catalog",
+      );
+      setCatalog(data.catalog);
+      setCatalogError(null);
+    } catch (err) {
+      setCatalogError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCatalogLoading(false);
+    }
+  }, [catalog, catalogError]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
-      setActiveProvider(getProviderId(value));
+      const nextProvider = getProviderId(value);
+      setActiveProvider(nextProvider);
+      if (nextProvider === "openrouter") void loadCatalog();
     }
     setOpen(nextOpen);
   };
+
+  const openRouterModels = useMemo(() => {
+    const apiModels: PickerModel[] =
+      catalog?.models.map((model) => ({
+        id: `openrouter/${model.id}`,
+        label: model.name,
+        providerSlug: model.id.split("/")[0],
+        contextLength: model.contextLength,
+        promptPrice: model.promptPrice,
+        completionPrice: model.completionPrice,
+      })) ??
+      getModelsForProvider("openrouter").map((model) => ({
+        id: model.id,
+        label: model.label,
+        providerSlug: model.providerModelId.split("/")[0],
+        contextLength: null,
+        promptPrice: null,
+        completionPrice: null,
+      }));
+    const selectedProviderModelId =
+      getProviderId(value) === "openrouter" ? getProviderModelId(value) : null;
+    const withSelected =
+      selectedProviderModelId &&
+      !apiModels.some((model) => model.id === value)
+        ? [
+            {
+              id: value,
+              label: getModelLabel(value),
+              providerSlug: selectedProviderModelId.split("/")[0],
+            },
+            ...apiModels,
+          ]
+        : apiModels;
+    const needle = query.trim().toLowerCase();
+    const filtered = withSelected.filter(
+      (model) =>
+        matchesQuery(model.label, model.id, needle) &&
+        matchesModelFilter(model, modelFilter),
+    );
+    return sortModelResults(filtered, modelFilter).slice(0, 80);
+  }, [catalog, modelFilter, query, value]);
+
+  const triggerLabel =
+    catalog?.models.find(
+      (model) =>
+        getProviderId(value) === "openrouter" &&
+        model.id === getProviderModelId(value),
+    )?.name ?? getModelLabel(value);
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -62,14 +193,21 @@ export function ModelPicker({
           disabled={disabled}
           className={cn("min-w-0 justify-between", triggerClassName)}
         >
-          <span className="truncate">{getModelLabel(value)}</span>
+          <span className="truncate">{triggerLabel}</span>
           <ChevronDown className="size-3 shrink-0 opacity-70" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" side="top" className="w-56 p-0">
+      <PopoverContent
+        align="end"
+        side="top"
+        className="w-[min(22rem,calc(100vw-1rem))] overflow-hidden p-0"
+      >
         <Tabs
           value={activeProvider}
-          onValueChange={(next) => setActiveProvider(next as ProviderId)}
+          onValueChange={(next) => {
+            setActiveProvider(next as ProviderId);
+            if (next === "openrouter") void loadCatalog();
+          }}
           className="min-w-0 gap-0"
         >
           <TabsList
@@ -82,34 +220,113 @@ export function ModelPicker({
               </TabsTrigger>
             ))}
           </TabsList>
-          {PROVIDERS.map((provider) => (
-            <TabsContent
-              key={provider.id}
-              value={provider.id}
-              className="m-0 max-h-48 overflow-y-auto p-0.5"
-            >
-              {getModelsForProvider(provider.id).map((model) => {
-                const selected = model.id === value;
-                return (
-                  <button
-                    key={model.id}
-                    type="button"
-                    className={cn(
-                      "flex w-full items-center justify-between rounded px-1.5 py-1 text-left text-xs leading-4 hover:bg-accent",
-                      selected && "bg-accent text-foreground",
-                    )}
-                    onClick={() => {
-                      onChange(model.id);
-                      setOpen(false);
-                    }}
-                  >
-                    <span>{model.label}</span>
-                    {selected ? <Check className="size-3.5 shrink-0" /> : null}
-                  </button>
-                );
-              })}
-            </TabsContent>
-          ))}
+          <div className="border-b border-border p-1.5">
+            <div className="grid grid-cols-[0.75rem_1fr_auto] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
+              <Search className="size-3 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search models"
+                className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
+                aria-label="Search models"
+              />
+              {activeProvider === "openrouter" ? (
+                <button
+                  type="button"
+                  onClick={() => void loadCatalog({ refresh: true })}
+                  disabled={catalogLoading}
+                  className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+                  aria-label="Refresh OpenRouter models"
+                  title="Refresh OpenRouter models"
+                >
+                  {catalogLoading ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <RefreshCw className="size-3" />
+                  )}
+                </button>
+              ) : (
+                <span className="size-5" aria-hidden="true" />
+              )}
+            </div>
+            {activeProvider === "openrouter" && catalogError ? (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Static fallback models shown.
+              </p>
+            ) : null}
+          </div>
+          {PROVIDERS.map((provider) => {
+            const visibleModels: PickerModel[] =
+              provider.id === "openrouter"
+                ? openRouterModels
+                : getModelsForProvider(provider.id).filter((model) =>
+                    matchesQuery(model.label, model.id, query),
+                  ).map((model) => ({
+                    id: model.id,
+                    label: model.label,
+                  }));
+            return (
+              <TabsContent key={provider.id} value={provider.id} className="m-0">
+                <div className="max-h-96 overflow-y-auto p-0.5">
+                  <PopupSectionHeader
+                    title="Models"
+                    action={
+                      provider.id === "openrouter" ? (
+                        <PopupSortSelect
+                          value={modelFilter}
+                          options={MODEL_FILTER_OPTIONS}
+                          onChange={setModelFilter}
+                          aria-label="Filter models"
+                        />
+                      ) : undefined
+                    }
+                  />
+                  {visibleModels.length === 0 ? (
+                    <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+                      {provider.id === "openrouter" && catalogLoading
+                        ? "Loading models..."
+                        : "No models found."}
+                    </div>
+                  ) : (
+                    <ul className="grid gap-0.5">
+                      {visibleModels.map((model) => {
+                        const selected = model.id === value;
+                        return (
+                          <li key={model.id}>
+                            <button
+                              type="button"
+                              className={cn(
+                                "grid w-full grid-cols-[minmax(0,1fr)_0.75rem] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent",
+                                selected && "bg-accent text-foreground",
+                              )}
+                              onClick={() => {
+                                onChange(model.id as ModelId);
+                                setOpen(false);
+                              }}
+                            >
+                              <span className="min-w-0">
+                                <span className="block truncate font-medium">
+                                  {model.label}
+                                </span>
+                                <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                                  {provider.id === "openrouter"
+                                    ? openRouterModelMeta(model)
+                                    : getProviderModelId(model.id as ModelId)}
+                                </span>
+                              </span>
+                              {selected ? (
+                                <Check className="size-3 text-primary" />
+                              ) : null}
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              </TabsContent>
+            );
+          })}
         </Tabs>
         {showThinking && onThinkingEnabledChange ? (
           <div
@@ -130,4 +347,141 @@ export function ModelPicker({
       </PopoverContent>
     </Popover>
   );
+}
+
+function isFreeModel(model: PickerModel): boolean {
+  return priceValue(model.promptPrice) === 0 && priceValue(model.completionPrice) === 0;
+}
+
+function matchesQuery(label: string, id: string, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return (
+    label.toLowerCase().includes(needle) ||
+    id.toLowerCase().includes(needle)
+  );
+}
+
+function matchesModelFilter(model: PickerModel, filter: ModelFilter): boolean {
+  switch (filter) {
+    case "recommended":
+    case "name-asc":
+    case "context-desc":
+      return true;
+    case "free":
+      return isFreeModel(model);
+    case "long-context":
+      return (model.contextLength ?? 0) >= 128000;
+    case "low-price":
+      return isLowPriceModel(model);
+    case "other":
+      return !MODEL_FAMILY_FILTERS.some((family) =>
+        modelFamilyMatches(model, family),
+      );
+    default:
+      return modelFamilyMatches(model, filter);
+  }
+}
+
+function sortModelResults(
+  models: PickerModel[],
+  filter: ModelFilter,
+): PickerModel[] {
+  const sorted = [...models];
+  switch (filter) {
+    case "name-asc":
+      sorted.sort((a, b) => a.label.localeCompare(b.label));
+      break;
+    case "context-desc":
+    case "long-context":
+      sorted.sort(
+        (a, b) =>
+          (b.contextLength ?? 0) - (a.contextLength ?? 0) ||
+          a.label.localeCompare(b.label),
+      );
+      break;
+    case "free":
+      sorted.sort(
+        (a, b) =>
+          (b.contextLength ?? 0) - (a.contextLength ?? 0) ||
+          a.label.localeCompare(b.label),
+      );
+      break;
+    case "low-price":
+      sorted.sort(
+        (a, b) =>
+          modelPriceScore(a) - modelPriceScore(b) ||
+          (b.contextLength ?? 0) - (a.contextLength ?? 0) ||
+          a.label.localeCompare(b.label),
+      );
+      break;
+    default:
+      break;
+  }
+  return sorted;
+}
+
+function modelFamilyMatches(model: PickerModel, family: ModelFilter): boolean {
+  const slug = (model.providerSlug ?? providerSlugFromModelId(model.id)).toLowerCase();
+  const id = model.id.toLowerCase();
+  switch (family) {
+    case "openai":
+      return slug === "openai" || id.includes("/gpt-");
+    case "google":
+      return slug.startsWith("google") || id.includes("/gemini");
+    case "meta":
+      return slug === "meta-llama" || slug === "meta" || id.includes("/llama");
+    default:
+      return slug === family || slug.startsWith(`${family}-`);
+  }
+}
+
+function isLowPriceModel(model: PickerModel): boolean {
+  const prompt = priceValue(model.promptPrice);
+  const completion = priceValue(model.completionPrice);
+  if (prompt === undefined || completion === undefined) return false;
+  return prompt <= 0.000001 && completion <= 0.000003;
+}
+
+function modelPriceScore(model: PickerModel): number {
+  const prompt = priceValue(model.promptPrice);
+  const completion = priceValue(model.completionPrice);
+  if (prompt === undefined || completion === undefined) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return prompt + completion;
+}
+
+function openRouterModelMeta(model: PickerModel): string {
+  const context =
+    model.contextLength && model.contextLength > 0
+      ? `${formatContextLength(model.contextLength)} ctx`
+      : "ctx ?";
+  const price = isFreeModel(model)
+    ? "free"
+    : `${formatPricePerMillion(model.promptPrice)}/${formatPricePerMillion(model.completionPrice)}`;
+  return `${providerSlugFromModelId(model.id)} / ${context} / ${price}`;
+}
+
+function providerSlugFromModelId(modelId: string): string {
+  return modelId.replace(/^openrouter\//, "").split("/")[0] ?? "unknown";
+}
+
+function formatContextLength(value: number): string {
+  if (value >= 1000000) return `${Math.round(value / 1000000)}M`;
+  if (value >= 1000) return `${Math.round(value / 1000)}k`;
+  return String(value);
+}
+
+function formatPricePerMillion(value: string | null | undefined): string {
+  const numeric = priceValue(value);
+  if (numeric === undefined) return "$?";
+  if (numeric === 0) return "$0";
+  return `$${(numeric * 1000000).toFixed(numeric * 1000000 >= 1 ? 2 : 3)}`;
+}
+
+function priceValue(value: string | null | undefined): number | undefined {
+  if (!value) return undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
 }

--- a/components/features/settings/agent-settings-panel.tsx
+++ b/components/features/settings/agent-settings-panel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
+  Plus,
   ShieldCheck,
   ShieldOff,
   ShieldQuestion,
   SlidersHorizontal,
+  X,
 } from "lucide-react";
 
 import { ErrorBanner, LoadingState } from "@/components/shared/feedback-states";
@@ -19,14 +21,22 @@ import {
   SelectValue,
   SelectViewport,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import type { PermissionMode } from "@/src/agent/permissions";
 import type { WorkspaceSettingsSummary } from "@/src/lib/api-types";
 import {
   DEFAULT_MODEL_ID,
+  getProviderId,
+  getProviderModelId,
   isSupportedModelId,
   resolveModelId,
   type ModelId,
 } from "@/src/lib/models";
+import type {
+  OpenRouterModelEndpointsSummary,
+  OpenRouterRoutingPreferences,
+  OpenRouterRoutingPreference,
+} from "@/src/lib/api-types";
 import {
   errorMessage,
   getJson,
@@ -43,6 +53,10 @@ const COMPACT_SELECT_TRIGGER_CLASS =
 const COMPACT_SELECT_CONTENT_CLASS = "min-w-36";
 const COMPACT_SELECT_VIEWPORT_CLASS = "p-0.5";
 const COMPACT_SELECT_ITEM_CLASS = "py-1 pr-7 pl-1.5";
+const DEFAULT_ROUTING: OpenRouterRoutingPreference = {
+  order: [],
+  allowFallbacks: true,
+};
 
 const PERMISSION_MODE_ITEMS = [
   { value: "default", label: "Ask every time", Icon: ShieldQuestion },
@@ -59,6 +73,12 @@ export function AgentSettingsPanel() {
   const [model, setModel] = useState<ModelId>(DEFAULT_MODEL_ID);
   const [maxSteps, setMaxSteps] = useState("");
   const [permissionMode, setPermissionMode] = useState<PermissionMode>("auto-review");
+  const [routingPreferences, setRoutingPreferences] =
+    useState<OpenRouterRoutingPreferences>({});
+  const [endpointData, setEndpointData] =
+    useState<OpenRouterModelEndpointsSummary | null>(null);
+  const [endpointLoading, setEndpointLoading] = useState(false);
+  const [customProviderTag, setCustomProviderTag] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,6 +105,7 @@ export function AgentSettingsPanel() {
             : "",
         );
         setPermissionMode(data.settings.defaultPermissionMode ?? "auto-review");
+        setRoutingPreferences(data.settings.openRouterRoutingPreferences);
         setError(null);
       } catch (err) {
         if (!cancelled) {
@@ -99,6 +120,77 @@ export function AgentSettingsPanel() {
       cancelled = true;
     };
   }, []);
+
+  const openRouterModelId =
+    getProviderId(model) === "openrouter" ? getProviderModelId(model) : null;
+  const routingForSelectedModel = openRouterModelId
+    ? routingPreferences[openRouterModelId] ?? DEFAULT_ROUTING
+    : DEFAULT_ROUTING;
+
+  const selectedEndpointTags = useMemo(
+    () => new Set(routingForSelectedModel.order),
+    [routingForSelectedModel.order],
+  );
+
+  useEffect(() => {
+    if (!openRouterModelId) return;
+    let cancelled = false;
+    // Endpoint fetch is external state hydration for the selected model.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setEndpointLoading(true);
+    getJson<{ endpoints: OpenRouterModelEndpointsSummary }>(
+      `/api/openrouter/model-endpoints?model=${encodeURIComponent(openRouterModelId)}`,
+    )
+      .then((data) => {
+        if (!cancelled) setEndpointData(data.endpoints);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setEndpointData({
+            model: openRouterModelId,
+            endpoints: [],
+            source: "fallback",
+            fetchedAt: Date.now(),
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setEndpointLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [openRouterModelId]);
+
+  const updateSelectedRouting = (
+    updater: (current: OpenRouterRoutingPreference) => OpenRouterRoutingPreference,
+  ) => {
+    if (!openRouterModelId) return;
+    setRoutingPreferences((current) => ({
+      ...current,
+      [openRouterModelId]: updater(current[openRouterModelId] ?? DEFAULT_ROUTING),
+    }));
+  };
+
+  const addProviderTag = (tag: string) => {
+    const normalized = tag.trim();
+    if (!normalized) return;
+    updateSelectedRouting((current) => ({
+      ...current,
+      order: current.order.includes(normalized)
+        ? current.order
+        : [...current.order, normalized],
+    }));
+    setCustomProviderTag("");
+  };
+
+  const removeProviderTag = (tag: string) => {
+    updateSelectedRouting((current) => ({
+      ...current,
+      order: current.order.filter((item) => item !== tag),
+    }));
+  };
 
   const save = async () => {
     setSaving(true);
@@ -122,10 +214,12 @@ export function AgentSettingsPanel() {
             defaultModel: model,
             defaultMaxSteps: parsedMaxSteps,
             defaultPermissionMode: permissionMode,
+            openRouterRoutingPreferences: routingPreferences,
           }),
         },
       );
       setSettings(data.settings);
+      setRoutingPreferences(data.settings.openRouterRoutingPreferences);
       notifyWorkspaceAgentDefaultsChanged(data.settings);
       setError(null);
     } catch (err) {
@@ -162,6 +256,115 @@ export function AgentSettingsPanel() {
               Used when a session has no saved composer override.
             </p>
           </SettingsCard>
+
+          {openRouterModelId ? (
+            <SettingsCard title="OpenRouter routing">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {routingForSelectedModel.order.length > 0 ? (
+                    routingForSelectedModel.order.map((tag) => (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => removeProviderTag(tag)}
+                        className="inline-flex h-6 max-w-full items-center gap-1 rounded border border-primary/40 bg-primary/10 px-2 text-[11px] font-medium text-foreground"
+                        aria-label={`Remove ${tag} from provider order`}
+                      >
+                        <span className="truncate">{tag}</span>
+                        <X className="size-3 shrink-0" />
+                      </button>
+                    ))
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      No pinned provider order.
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex max-w-sm items-center gap-1.5">
+                  <Input
+                    value={customProviderTag}
+                    onChange={(event) => setCustomProviderTag(event.target.value)}
+                    placeholder="provider/tag"
+                    className="h-7 px-2 text-[11px]"
+                    aria-label="Custom OpenRouter provider tag"
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        addProviderTag(customProviderTag);
+                      }
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="secondary"
+                    onClick={() => addProviderTag(customProviderTag)}
+                    disabled={!customProviderTag.trim()}
+                    aria-label="Add provider tag"
+                  >
+                    <Plus className="size-3.5" />
+                  </Button>
+                </div>
+
+                <div className="flex items-center justify-between gap-4 rounded border border-border px-2 py-1.5">
+                  <span className="text-xs font-medium">Allow fallbacks</span>
+                  <Switch
+                    checked={routingForSelectedModel.allowFallbacks}
+                    onCheckedChange={(checked) =>
+                      updateSelectedRouting((current) => ({
+                        ...current,
+                        allowFallbacks: checked,
+                      }))
+                    }
+                    className="h-4 w-7 ring-0 data-[state=checked]:ring-0"
+                    thumbClassName="size-3 data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0.5"
+                    aria-label="Allow OpenRouter fallbacks"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Endpoint recommendations
+                    </span>
+                    {endpointLoading ? (
+                      <span className="text-[11px] text-muted-foreground">
+                        Loading...
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {(endpointData?.endpoints ?? []).slice(0, 10).map((endpoint) => {
+                      const selected = selectedEndpointTags.has(endpoint.tag);
+                      return (
+                        <button
+                          key={endpoint.tag}
+                          type="button"
+                          onClick={() => addProviderTag(endpoint.tag)}
+                          disabled={selected}
+                          className="max-w-full rounded border border-border px-2 py-1 text-left text-[11px] leading-4 hover:bg-accent disabled:cursor-default disabled:border-primary/40 disabled:bg-primary/10"
+                          title={endpointSummary(endpoint)}
+                        >
+                          <span className="block truncate font-medium text-foreground">
+                            {endpoint.providerName} / {endpoint.tag}
+                          </span>
+                          <span className="block truncate text-muted-foreground">
+                            {endpointMeta(endpoint)}
+                          </span>
+                        </button>
+                      );
+                    })}
+                    {!endpointLoading && (endpointData?.endpoints.length ?? 0) === 0 ? (
+                      <span className="text-xs text-muted-foreground">
+                        No endpoint details available.
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </SettingsCard>
+          ) : null}
 
           <SettingsCard title="Max steps">
             <div className="max-w-xs space-y-2">
@@ -234,4 +437,45 @@ export function AgentSettingsPanel() {
       )}
     </SettingsPageShell>
   );
+}
+
+function endpointMeta(
+  endpoint: OpenRouterModelEndpointsSummary["endpoints"][number],
+): string {
+  const cache = endpoint.supportsImplicitCaching
+    ? "cache"
+    : endpoint.cacheReadPrice
+      ? "cache price"
+      : "no cache";
+  const status = endpoint.status === 0 ? "healthy" : `status ${endpoint.status ?? "?"}`;
+  const uptime =
+    endpoint.uptimeLast30m === null
+      ? "uptime ?"
+      : `${endpoint.uptimeLast30m.toFixed(0)}% up`;
+  const latency =
+    endpoint.latencyLast30m === null
+      ? "lat ?"
+      : `${Math.round(endpoint.latencyLast30m)}ms`;
+  return `${cache} / ${status} / ${uptime} / ${latency} / ${formatPrice(endpoint.promptPrice)}/${formatPrice(endpoint.cacheReadPrice)}`;
+}
+
+function endpointSummary(
+  endpoint: OpenRouterModelEndpointsSummary["endpoints"][number],
+): string {
+  return [
+    endpoint.providerName,
+    endpoint.tag,
+    endpointMeta(endpoint),
+    `prompt ${formatPrice(endpoint.promptPrice)}`,
+    `cache read ${formatPrice(endpoint.cacheReadPrice)}`,
+    `cache write ${formatPrice(endpoint.cacheWritePrice)}`,
+  ].join(" | ");
+}
+
+function formatPrice(value: string | null): string {
+  if (!value) return "-";
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return value;
+  if (numeric === 0) return "$0";
+  return `$${numeric.toExponential(1)}`;
 }

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -18,6 +18,11 @@ import {
   getLanguageModel,
 } from "@/src/lib/providers";
 import {
+  openRouterProviderOptions as openRouterRoutingProviderOptions,
+  resolveOpenRouterRouting,
+  type OpenRouterRoutingResolution,
+} from "@/src/lib/openrouter-routing";
+import {
   buildTokenUsageMetrics,
   openRouterCostFromMetadata,
 } from "@/src/lib/token-usage";
@@ -95,6 +100,7 @@ export type TokenAudit = {
   budget: RunBudgetAudit;
   contextComposition: ContextCompositionAudit;
   promptCache?: PromptCacheAudit;
+  openRouterRouting?: OpenRouterRoutingResolution;
   loopGuardCount?: number;
   promotionReason?: string;
   effectiveProfile?: AgentRunProfile;
@@ -480,6 +486,7 @@ export async function runAgent({
   priorToolHistory = [],
   previousPromptCacheAudit,
   promptCacheIntentionalSegmentTransition,
+  openRouterRouting,
   singleFileTargetPath,
   singleFileTargetResolution,
   singleFileTargetResolutionReason,
@@ -513,6 +520,7 @@ export async function runAgent({
   priorToolHistory?: readonly PriorToolCallRecord[];
   previousPromptCacheAudit?: PromptCacheAudit | null;
   promptCacheIntentionalSegmentTransition?: string;
+  openRouterRouting?: OpenRouterRoutingResolution;
   singleFileTargetPath?: string;
   singleFileTargetResolution?: "exact" | "unique_search" | "unresolved" | "ambiguous";
   singleFileTargetResolutionReason?: string;
@@ -716,13 +724,15 @@ export async function runAgent({
     return true;
   };
 
+  const resolvedOpenRouterRouting =
+    openRouterRouting ?? resolveOpenRouterRouting(selectedModel);
   const openRouterOptions =
     getProviderId(selectedModel) === "openrouter"
       ? {
           openrouter: openRouterProviderOptions(
             profile,
             thinkingEnabled,
-            getProviderModelId(selectedModel),
+            resolvedOpenRouterRouting,
           ),
         }
       : undefined;
@@ -960,6 +970,7 @@ export async function runAgent({
         tokenUsage,
         previousAudit: previousPromptCacheAudit,
         intentionalSegmentTransition: promptCacheIntentionalSegmentTransition,
+        openRouterRouting: resolvedOpenRouterRouting,
       });
       const segmentTokens = finiteNumber(totalUsage.totalTokens) ?? 0;
       const segmentEffective = tokenUsage?.effectiveTokens ?? segmentTokens;
@@ -980,6 +991,9 @@ export async function runAgent({
             }
           : {}),
         tokenBudgetReached,
+        ...(resolvedOpenRouterRouting
+          ? { openRouterRouting: resolvedOpenRouterRouting }
+          : {}),
         promptCache,
         loopGuardCount: toolPolicy.loopGuardCount,
         usage: usageAudit(totalUsage, providerMetadata),
@@ -1099,69 +1113,26 @@ function reasoningOptionsForProfile(profile: AgentRunProfile): {
 function openRouterProviderOptions(
   profile: AgentRunProfile,
   thinkingEnabled: boolean,
-  modelId: string,
+  routing: OpenRouterRoutingResolution | undefined,
 ): {
   reasoning?: ReturnType<typeof reasoningOptionsForProfile>;
   usage: { include: true };
   provider?: {
     order?: string[];
-    allow_fallbacks?: boolean;
-    require_parameters?: boolean;
+    allow_fallbacks: boolean;
+    require_parameters: true;
   };
 } {
-  const provider = openRouterProviderRouting(modelId);
   return {
     ...(thinkingEnabled ? { reasoning: reasoningOptionsForProfile(profile) } : {}),
     usage: { include: true },
-    ...(provider ? { provider } : {}),
+    ...openRouterRoutingProviderOptions(routing),
   };
-}
-
-function openRouterProviderRouting(
-  modelId: string,
-): {
-  order?: string[];
-  allow_fallbacks?: boolean;
-  require_parameters?: boolean;
-} | undefined {
-  const envOrder = providerOrderFromEnv();
-  if (envOrder.length > 0) {
-    return {
-      order: envOrder,
-      allow_fallbacks: envBoolean("OPENROUTER_ALLOW_FALLBACKS") ?? true,
-      require_parameters: true,
-    };
-  }
-
-  if (modelId === "deepseek/deepseek-v4-pro") {
-    return {
-      order: ["alibaba"],
-      allow_fallbacks: true,
-      require_parameters: true,
-    };
-  }
-
-  return undefined;
 }
 
 function supportsForcedToolChoice(modelId: string): boolean {
   const providerModelId = getProviderModelId(modelId).toLowerCase();
   return !providerModelId.includes("deepseek");
-}
-
-function providerOrderFromEnv(): string[] {
-  return (process.env.OPENROUTER_PROVIDER_ORDER ?? "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-}
-
-function envBoolean(name: string): boolean | undefined {
-  const value = process.env[name]?.trim().toLowerCase();
-  if (!value) return undefined;
-  if (["1", "true", "yes", "on"].includes(value)) return true;
-  if (["0", "false", "no", "off"].includes(value)) return false;
-  return undefined;
 }
 
 function usageAudit(

--- a/src/agent/prompt-cache-audit.ts
+++ b/src/agent/prompt-cache-audit.ts
@@ -3,10 +3,12 @@ import type { ModelMessage, ToolSet } from "ai";
 
 import type { TokenUsageMetrics } from "@/src/lib/token-usage";
 import { getProviderId } from "@/src/lib/models";
+import type { OpenRouterRoutingResolution } from "@/src/lib/openrouter-routing";
 
 export type PromptCacheAudit = {
   modelId: string;
   providerId: string;
+  routingFingerprint?: string;
   systemPromptHash: string;
   toolSchemaHash: string;
   nativeToolNamesHash: string;
@@ -33,6 +35,7 @@ export function buildPromptCacheAudit({
   tokenUsage,
   previousAudit,
   intentionalSegmentTransition,
+  openRouterRouting,
 }: {
   modelId: string;
   system: string;
@@ -45,6 +48,7 @@ export function buildPromptCacheAudit({
   tokenUsage?: TokenUsageMetrics;
   previousAudit?: PromptCacheAudit | null;
   intentionalSegmentTransition?: string;
+  openRouterRouting?: OpenRouterRoutingResolution;
 }): PromptCacheAudit {
   const cachedInputTokens = tokenUsage?.cachedInputTokens;
   const cacheWriteTokens = tokenUsage?.cacheWriteTokens;
@@ -66,6 +70,9 @@ export function buildPromptCacheAudit({
   const auditBase = {
     modelId,
     providerId: getProviderId(modelId),
+    ...(openRouterRouting
+      ? { routingFingerprint: openRouterRouting.fingerprint }
+      : {}),
     systemPromptHash: hashText(system),
     toolSchemaHash: hashText(stableJson(toolSchemas(tools, activeToolNames))),
     nativeToolNamesHash: hashText((activeToolNames ?? nativeToolNames).join("\n")),
@@ -92,6 +99,7 @@ export function comparePromptCacheAudit(
     PromptCacheAudit,
     | "modelId"
     | "providerId"
+    | "routingFingerprint"
     | "systemPromptHash"
     | "toolSchemaHash"
     | "nativeToolNamesHash"
@@ -103,6 +111,7 @@ export function comparePromptCacheAudit(
     PromptCacheAudit,
     | "modelId"
     | "providerId"
+    | "routingFingerprint"
     | "systemPromptHash"
     | "toolSchemaHash"
     | "nativeToolNamesHash"
@@ -118,6 +127,9 @@ export function comparePromptCacheAudit(
   }
   if (previous.providerId !== current.providerId) {
     reasons.push("provider id changed from the previous run in this session");
+  }
+  if (previous.routingFingerprint !== current.routingFingerprint) {
+    reasons.push("OpenRouter routing fingerprint changed");
   }
   if (previous.systemPromptHash !== current.systemPromptHash) {
     reasons.push("system prompt hash changed");
@@ -157,6 +169,9 @@ export function promptCacheAuditFromCostMetadata(
   return {
     modelId,
     providerId,
+    ...(typeof promptCache.routingFingerprint === "string"
+      ? { routingFingerprint: promptCache.routingFingerprint }
+      : {}),
     systemPromptHash: stringValue(promptCache.systemPromptHash) ?? "—",
     toolSchemaHash: stringValue(promptCache.toolSchemaHash) ?? "—",
     nativeToolNamesHash: stringValue(promptCache.nativeToolNamesHash) ?? "—",

--- a/src/agent/tools/delegate.ts
+++ b/src/agent/tools/delegate.ts
@@ -9,6 +9,10 @@ import {
   DEFAULT_MODEL,
   getLanguageModel,
 } from "@/src/lib/providers";
+import {
+  openRouterProviderOptions,
+  resolveOpenRouterRouting,
+} from "@/src/lib/openrouter-routing";
 import { listMemories } from "@/src/db/queries";
 import { listSkills } from "../skills";
 import {
@@ -72,6 +76,9 @@ export function createDelegateTaskTool({
             ? {
                 openrouter: {
                   usage: { include: true },
+                  ...openRouterProviderOptions(
+                    resolveOpenRouterRouting(selectedModel),
+                  ),
                 },
               }
             : undefined;

--- a/src/db/migrations/0013_pale_wong.sql
+++ b/src/db/migrations/0013_pale_wong.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `workspace_settings` ADD `openrouter_routing_preferences` text;

--- a/src/db/migrations/meta/0013_snapshot.json
+++ b/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1488 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "96337ab2-021b-4a37-919b-193bfcfd4cd0",
+  "prevId": "d083b074-c3de-47cc-8a2f-3e9219792c0e",
+  "tables": {
+    "background_command_sessions": {
+      "name": "background_command_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_kind": {
+          "name": "command_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stdout_tail": {
+          "name": "stdout_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stderr_tail": {
+          "name": "stderr_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "detected_urls": {
+          "name": "detected_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "background_command_sessions_project_id_idx": {
+          "name": "background_command_sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_status_idx": {
+          "name": "background_command_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_project_started_idx": {
+          "name": "background_command_sessions_project_started_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "background_command_sessions_project_id_projects_id_fk": {
+          "name": "background_command_sessions_project_id_projects_id_fk",
+          "tableFrom": "background_command_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_budget_multiplier": {
+          "name": "token_budget_multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_max_steps": {
+          "name": "default_max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_permission_mode": {
+          "name": "default_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "openrouter_routing_preferences": {
+          "name": "openrouter_routing_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779694147271,
       "tag": "0012_rich_red_ghost",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1780393492675,
+      "tag": "0013_pale_wong",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,7 @@
 import { and, asc, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import type { UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
+import type { OpenRouterRoutingPreferences } from "@/src/lib/api-types";
 
 import {
   collapseAssistantContinuationMessages,
@@ -171,6 +172,7 @@ export function getWorkspaceSettings(): WorkspaceSettings {
     defaultModel: null,
     defaultMaxSteps: null,
     defaultPermissionMode: null,
+    openRouterRoutingPreferences: null,
     createdAt: now,
     updatedAt: now,
   };
@@ -183,6 +185,7 @@ export function updateWorkspaceSettings(input: {
   defaultModel?: string | null;
   defaultMaxSteps?: number | null;
   defaultPermissionMode?: "default" | "auto-review" | "full-access" | null;
+  openRouterRoutingPreferences?: OpenRouterRoutingPreferences | null;
 }): WorkspaceSettings {
   getWorkspaceSettings();
   const update: Partial<WorkspaceSettings> = { updatedAt: new Date() };
@@ -197,6 +200,10 @@ export function updateWorkspaceSettings(input: {
   }
   if ("defaultPermissionMode" in input) {
     update.defaultPermissionMode = input.defaultPermissionMode ?? null;
+  }
+  if ("openRouterRoutingPreferences" in input) {
+    update.openRouterRoutingPreferences =
+      input.openRouterRoutingPreferences ?? null;
   }
   db
     .update(workspaceSettings)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,6 +7,7 @@ import {
   text,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
+import type { OpenRouterRoutingPreferences } from "@/src/lib/api-types";
 
 export const workspaceSettings = sqliteTable("workspace_settings", {
   id: text("id").primaryKey(),
@@ -16,6 +17,9 @@ export const workspaceSettings = sqliteTable("workspace_settings", {
   defaultPermissionMode: text("default_permission_mode", {
     enum: ["default", "auto-review", "full-access"],
   }),
+  openRouterRoutingPreferences: text("openrouter_routing_preferences", {
+    mode: "json",
+  }).$type<OpenRouterRoutingPreferences | null>(),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .default(sql`(unixepoch('now') * 1000)`),

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -6,6 +6,66 @@ export type WorkspaceSettingsSummary = {
   defaultModel: string | null;
   defaultMaxSteps: number | null;
   defaultPermissionMode: "default" | "auto-review" | "full-access" | null;
+  openRouterRoutingPreferences: OpenRouterRoutingPreferences;
+};
+
+export type OpenRouterRoutingPreference = {
+  order: string[];
+  allowFallbacks: boolean;
+};
+
+export type OpenRouterRoutingPreferences = Record<
+  string,
+  OpenRouterRoutingPreference
+>;
+
+export type OpenRouterProviderSummary = {
+  slug: string;
+  name: string;
+  headquarters: string | null;
+  datacenters: string[];
+  privacyPolicyUrl: string | null;
+  termsOfServiceUrl: string | null;
+  statusPageUrl: string | null;
+};
+
+export type OpenRouterModelSummary = {
+  id: string;
+  name: string;
+  contextLength: number | null;
+  promptPrice: string | null;
+  completionPrice: string | null;
+  detailsPath: string | null;
+};
+
+export type OpenRouterCatalogSummary = {
+  providers: OpenRouterProviderSummary[];
+  models: OpenRouterModelSummary[];
+  source: "api" | "fallback";
+  fetchedAt: number;
+  error: string | null;
+};
+
+export type OpenRouterModelEndpointSummary = {
+  tag: string;
+  providerName: string;
+  name: string;
+  status: number | null;
+  uptimeLast30m: number | null;
+  latencyLast30m: number | null;
+  supportsImplicitCaching: boolean;
+  promptPrice: string | null;
+  completionPrice: string | null;
+  cacheReadPrice: string | null;
+  cacheWritePrice: string | null;
+};
+
+export type OpenRouterModelEndpointsSummary = {
+  model: string;
+  endpoints: OpenRouterModelEndpointSummary[];
+  source: "api" | "fallback";
+  fetchedAt: number;
+  error: string | null;
 };
 
 export type GitHubRepositorySummary = {
@@ -110,6 +170,7 @@ export type ProjectRunDetailsStepUsage = {
 export type ProjectRunDetailsPromptCache = {
   modelId: string;
   providerId: string;
+  routingFingerprint?: string;
   systemPromptHash: string;
   toolSchemaHash: string;
   nativeToolNamesHash: string;
@@ -167,6 +228,14 @@ export type ProjectRunDetailsRun = {
   handoffReason?: string | null;
   rawTotalTokens?: number | null;
   effectiveTokens?: number | null;
+  openRouterRouting?: {
+    source: "settings" | "env" | "builtin" | "default";
+    modelId: string;
+    order: string[];
+    allowFallbacks: boolean;
+    requireParameters: boolean;
+    fingerprint: string;
+  };
 };
 
 export type ProjectRunDetailsEvent = {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -8,7 +8,7 @@ export type ProviderId = (typeof PROVIDERS)[number]["id"];
 export const DEFAULT_PROVIDER_ID: ProviderId = "opencode-go";
 export const DEFAULT_MODEL_ID = "opencode-go/deepseek-v4-flash";
 
-const OPENCODE_GO_MODELS = [
+export const OPENCODE_GO_MODELS = [
   { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
   { slug: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
   { slug: "glm-5.1", label: "GLM 5.1" },
@@ -23,7 +23,7 @@ const OPENCODE_GO_MODELS = [
   { slug: "mimo-v2.5", label: "MiMo V2.5" },
 ] as const;
 
-const OPENROUTER_MODELS = [
+export const FALLBACK_OPENROUTER_MODELS = [
   { slug: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
   { slug: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
   { slug: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
@@ -39,7 +39,7 @@ export const MODEL_CATALOG = [
     providerModelId: model.slug,
     label: model.label,
   })),
-  ...OPENROUTER_MODELS.map((model) => ({
+  ...FALLBACK_OPENROUTER_MODELS.map((model) => ({
     id: `openrouter/${model.slug}`,
     provider: "openrouter" as const,
     providerModelId: model.slug,
@@ -48,16 +48,24 @@ export const MODEL_CATALOG = [
 ] as const;
 
 export type ModelCatalogEntry = (typeof MODEL_CATALOG)[number];
-export type ModelId = ModelCatalogEntry["id"];
+export type ModelId = string;
 
 function normalizeModelId(modelId: string): ModelId | null {
-  if (MODEL_CATALOG.some((model) => model.id === modelId)) {
-    return modelId as ModelId;
+  const catalogEntry = MODEL_CATALOG.find((model) => model.id === modelId);
+  if (catalogEntry) {
+    return catalogEntry.id;
   }
 
   const opencodeId = `opencode-go/${modelId}`;
   if (MODEL_CATALOG.some((model) => model.id === opencodeId)) {
-    return opencodeId as ModelId;
+    return opencodeId;
+  }
+
+  if (modelId.startsWith("openrouter/")) {
+    const providerModelId = modelId.slice("openrouter/".length);
+    if (isOpenRouterModelSlug(providerModelId)) {
+      return modelId;
+    }
   }
 
   if (
@@ -66,8 +74,8 @@ function normalizeModelId(modelId: string): ModelId | null {
     !modelId.startsWith("openrouter/")
   ) {
     const openrouterId = `openrouter/${modelId}`;
-    if (MODEL_CATALOG.some((model) => model.id === openrouterId)) {
-      return openrouterId as ModelId;
+    if (isOpenRouterModelSlug(modelId)) {
+      return openrouterId;
     }
   }
 
@@ -85,13 +93,19 @@ export function resolveModelId(modelId: string): ModelId {
 export function getProviderId(modelId: string): ProviderId {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
-  return entry?.provider ?? DEFAULT_PROVIDER_ID;
+  if (entry) return entry.provider;
+  if (resolved.startsWith("openrouter/")) return "openrouter";
+  return DEFAULT_PROVIDER_ID;
 }
 
 export function getProviderModelId(modelId: string): string {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
-  return entry?.providerModelId ?? resolved;
+  if (entry) return entry.providerModelId;
+  if (resolved.startsWith("openrouter/")) {
+    return resolved.slice("openrouter/".length);
+  }
+  return resolved;
 }
 
 export function getModelsForProvider(provider: ProviderId): ModelCatalogEntry[] {
@@ -108,4 +122,25 @@ export function getModelLabel(modelId: string): string {
 export function getDefaultModelForProvider(provider: ProviderId): ModelId {
   const models = getModelsForProvider(provider);
   return models[0]?.id ?? DEFAULT_MODEL_ID;
+}
+
+export function isStaticOpenCodeGoModelId(modelId: string): boolean {
+  const resolved = normalizeModelId(modelId);
+  return (
+    resolved !== null &&
+    MODEL_CATALOG.some(
+      (model) => model.id === resolved && model.provider === "opencode-go",
+    )
+  );
+}
+
+function isOpenRouterModelSlug(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.includes("/") &&
+    !value.startsWith("/") &&
+    !value.endsWith("/") &&
+    !value.includes("..") &&
+    !/\s/.test(value)
+  );
 }

--- a/src/lib/openrouter-catalog.ts
+++ b/src/lib/openrouter-catalog.ts
@@ -1,0 +1,294 @@
+import type {
+  OpenRouterCatalogSummary,
+  OpenRouterModelEndpointSummary,
+  OpenRouterModelEndpointsSummary,
+  OpenRouterModelSummary,
+  OpenRouterProviderSummary,
+} from "@/src/lib/api-types";
+import {
+  FALLBACK_OPENROUTER_MODELS,
+  isStaticOpenCodeGoModelId,
+} from "@/src/lib/models";
+
+const OPENROUTER_API_BASE = "https://openrouter.ai";
+const CATALOG_TTL_MS = 10 * 60 * 1000;
+
+let catalogCache:
+  | {
+      expiresAt: number;
+      value: OpenRouterCatalogSummary;
+    }
+  | undefined;
+
+const endpointCache = new Map<
+  string,
+  {
+    expiresAt: number;
+    value: OpenRouterModelEndpointsSummary;
+  }
+>();
+
+export async function getOpenRouterCatalog(): Promise<OpenRouterCatalogSummary> {
+  const now = Date.now();
+  if (catalogCache && catalogCache.expiresAt > now) return catalogCache.value;
+
+  try {
+    const [providers, models] = await Promise.all([
+      fetchOpenRouterJson("/api/v1/providers"),
+      fetchOpenRouterJson(
+        "/api/v1/models?supported_parameters=tools&output_modalities=text",
+      ),
+    ]);
+    const value: OpenRouterCatalogSummary = {
+      providers: parseProviders(providers),
+      models: parseModels(models),
+      source: "api",
+      fetchedAt: now,
+      error: null,
+    };
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  } catch (err) {
+    const value = fallbackCatalog(errorMessage(err), now);
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  }
+}
+
+export async function getOpenRouterModelEndpoints(
+  modelId: string,
+): Promise<OpenRouterModelEndpointsSummary> {
+  const normalizedModelId = modelId.trim();
+  const now = Date.now();
+  const cached = endpointCache.get(normalizedModelId);
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  try {
+    const catalog = await getOpenRouterCatalog();
+    const model = catalog.models.find((entry) => entry.id === normalizedModelId);
+    const detailsPath =
+      model?.detailsPath ?? `/api/v1/models/${normalizedModelId}/endpoints`;
+    const payload = await fetchOpenRouterJson(detailsPath);
+    const value: OpenRouterModelEndpointsSummary = {
+      model: normalizedModelId,
+      endpoints: sortEndpointRecommendations(parseEndpoints(payload)),
+      source: "api",
+      fetchedAt: now,
+      error: null,
+    };
+    endpointCache.set(normalizedModelId, {
+      expiresAt: now + CATALOG_TTL_MS,
+      value,
+    });
+    return value;
+  } catch (err) {
+    const value: OpenRouterModelEndpointsSummary = {
+      model: normalizedModelId,
+      endpoints: [],
+      source: "fallback",
+      fetchedAt: now,
+      error: errorMessage(err),
+    };
+    endpointCache.set(normalizedModelId, {
+      expiresAt: now + CATALOG_TTL_MS,
+      value,
+    });
+    return value;
+  }
+}
+
+export async function isSupportedAgentModelId(modelId: string): Promise<boolean> {
+  if (isStaticOpenCodeGoModelId(modelId)) return true;
+  const providerModelId = modelId.startsWith("openrouter/")
+    ? modelId.slice("openrouter/".length)
+    : modelId.includes("/")
+      ? modelId
+      : "";
+  if (!providerModelId) return false;
+  const catalog = await getOpenRouterCatalog();
+  return catalog.models.some((model) => model.id === providerModelId);
+}
+
+function fallbackCatalog(
+  error: string | null,
+  fetchedAt: number,
+): OpenRouterCatalogSummary {
+  return {
+    providers: [],
+    models: FALLBACK_OPENROUTER_MODELS.map((model) => ({
+      id: model.slug,
+      name: model.label,
+      contextLength: null,
+      promptPrice: null,
+      completionPrice: null,
+      detailsPath: `/api/v1/models/${model.slug}/endpoints`,
+    })),
+    source: "fallback",
+    fetchedAt,
+    error,
+  };
+}
+
+async function fetchOpenRouterJson(pathOrUrl: string): Promise<unknown> {
+  const url = pathOrUrl.startsWith("https://")
+    ? pathOrUrl
+    : `${OPENROUTER_API_BASE}${pathOrUrl}`;
+  const headers: Record<string, string> = {};
+  if (process.env.OPENROUTER_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.OPENROUTER_API_KEY}`;
+  }
+  const response = await fetch(url, {
+    headers,
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`OpenRouter request failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function parseProviders(payload: unknown): OpenRouterProviderSummary[] {
+  const data = dataArray(payload);
+  return data.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const slug = stringValue(item.slug);
+    const name = stringValue(item.name);
+    if (!slug || !name) return [];
+    return [
+      {
+        slug,
+        name,
+        headquarters: stringValue(item.headquarters) ?? null,
+        datacenters: stringArray(item.datacenters),
+        privacyPolicyUrl: stringValue(item.privacy_policy_url) ?? null,
+        termsOfServiceUrl: stringValue(item.terms_of_service_url) ?? null,
+        statusPageUrl: stringValue(item.status_page_url) ?? null,
+      },
+    ];
+  });
+}
+
+function parseModels(payload: unknown): OpenRouterModelSummary[] {
+  const data = dataArray(payload);
+  return data.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const id = stringValue(item.id);
+    const name = stringValue(item.name);
+    const supportedParameters = stringArray(item.supported_parameters);
+    const architecture = isRecord(item.architecture) ? item.architecture : {};
+    const outputModalities = stringArray(architecture.output_modalities);
+    if (
+      !id ||
+      !name ||
+      !supportedParameters.includes("tools") ||
+      !outputModalities.includes("text")
+    ) {
+      return [];
+    }
+    const pricing = isRecord(item.pricing) ? item.pricing : {};
+    const links = isRecord(item.links) ? item.links : {};
+    return [
+      {
+        id,
+        name,
+        contextLength: numberValue(item.context_length) ?? null,
+        promptPrice: stringValue(pricing.prompt) ?? null,
+        completionPrice: stringValue(pricing.completion) ?? null,
+        detailsPath: stringValue(links.details) ?? null,
+      },
+    ];
+  });
+}
+
+function parseEndpoints(payload: unknown): OpenRouterModelEndpointSummary[] {
+  const root = isRecord(payload) ? payload.data ?? payload : payload;
+  const endpoints = isRecord(root) && Array.isArray(root.endpoints)
+    ? root.endpoints
+    : Array.isArray(root)
+      ? root
+      : [];
+  return endpoints.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const tag = stringValue(item.tag);
+    const providerName = stringValue(item.provider_name);
+    const name = stringValue(item.name);
+    if (!tag || !providerName || !name) return [];
+    const pricing = isRecord(item.pricing) ? item.pricing : {};
+    return [
+      {
+        tag,
+        providerName,
+        name,
+        status: numberValue(item.status) ?? null,
+        uptimeLast30m: numberValue(item.uptime_last_30m) ?? null,
+        latencyLast30m: numberValue(item.latency_last_30m) ?? null,
+        supportsImplicitCaching: item.supports_implicit_caching === true,
+        promptPrice: stringValue(pricing.prompt) ?? null,
+        completionPrice: stringValue(pricing.completion) ?? null,
+        cacheReadPrice:
+          stringValue(pricing.input_cache_read) ??
+          stringValue(pricing.cache_read) ??
+          null,
+        cacheWritePrice:
+          stringValue(pricing.input_cache_write) ??
+          stringValue(pricing.cache_write) ??
+          null,
+      },
+    ];
+  });
+}
+
+function sortEndpointRecommendations(
+  endpoints: OpenRouterModelEndpointSummary[],
+): OpenRouterModelEndpointSummary[] {
+  return [...endpoints].sort((left, right) => {
+    const leftCache = cacheRank(left);
+    const rightCache = cacheRank(right);
+    if (leftCache !== rightCache) return rightCache - leftCache;
+    const leftHealthy = healthRank(left);
+    const rightHealthy = healthRank(right);
+    if (leftHealthy !== rightHealthy) return rightHealthy - leftHealthy;
+    const leftLatency = left.latencyLast30m ?? Number.POSITIVE_INFINITY;
+    const rightLatency = right.latencyLast30m ?? Number.POSITIVE_INFINITY;
+    return leftLatency - rightLatency;
+  });
+}
+
+function cacheRank(endpoint: OpenRouterModelEndpointSummary): number {
+  if (endpoint.supportsImplicitCaching) return 3;
+  if (endpoint.cacheReadPrice !== null && endpoint.cacheWritePrice !== null) return 2;
+  if (endpoint.cacheReadPrice !== null) return 1;
+  return 0;
+}
+
+function healthRank(endpoint: OpenRouterModelEndpointSummary): number {
+  const status = endpoint.status === 0 ? 1 : 0;
+  return status + (endpoint.uptimeLast30m ?? 0) / 100;
+}
+
+function dataArray(payload: unknown): unknown[] {
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  return Array.isArray(payload) ? payload : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/lib/openrouter-routing.ts
+++ b/src/lib/openrouter-routing.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+
+import { getWorkspaceSettings } from "@/src/db/queries";
+import type {
+  OpenRouterRoutingPreference,
+  OpenRouterRoutingPreferences,
+} from "@/src/lib/api-types";
+import {
+  getProviderId,
+  getProviderModelId,
+} from "@/src/lib/models";
+import { stripOpenRouterRoutingSuffix } from "@/src/lib/providers";
+
+export type OpenRouterRoutingSource = "settings" | "env" | "builtin" | "default";
+
+export type OpenRouterRoutingResolution = {
+  source: OpenRouterRoutingSource;
+  modelId: string;
+  order: string[];
+  allowFallbacks: boolean;
+  requireParameters: true;
+  fingerprint: string;
+};
+
+export function resolveOpenRouterRouting(
+  modelId: string,
+  preferences: OpenRouterRoutingPreferences | null | undefined =
+    getWorkspaceSettings().openRouterRoutingPreferences,
+): OpenRouterRoutingResolution | undefined {
+  if (getProviderId(modelId) !== "openrouter") return undefined;
+
+  const providerModelId = stripOpenRouterRoutingSuffix(
+    getProviderModelId(modelId),
+  );
+  const settingsPreference =
+    preferences?.[providerModelId] ?? preferences?.[`openrouter/${providerModelId}`];
+  if (settingsPreference) {
+    return routingResolution("settings", providerModelId, settingsPreference);
+  }
+
+  const envOrder = providerOrderFromEnv();
+  const envAllowFallbacks = envBoolean("OPENROUTER_ALLOW_FALLBACKS");
+  if (envOrder.length > 0 || envAllowFallbacks !== undefined) {
+    return routingResolution("env", providerModelId, {
+      order: envOrder,
+      allowFallbacks: envAllowFallbacks ?? true,
+    });
+  }
+
+  if (providerModelId === "deepseek/deepseek-v4-pro") {
+    return routingResolution("builtin", providerModelId, {
+      order: ["alibaba"],
+      allowFallbacks: true,
+    });
+  }
+
+  return routingResolution("default", providerModelId, {
+    order: [],
+    allowFallbacks: true,
+  });
+}
+
+export function openRouterProviderOptions(
+  routing: OpenRouterRoutingResolution | undefined,
+): {
+  provider?: {
+    order?: string[];
+    allow_fallbacks: boolean;
+    require_parameters: true;
+  };
+} {
+  if (!routing) return {};
+  return {
+    provider: {
+      ...(routing.order.length > 0 ? { order: routing.order } : {}),
+      allow_fallbacks: routing.allowFallbacks,
+      require_parameters: true,
+    },
+  };
+}
+
+export function sanitizeOpenRouterRoutingPreferences(
+  value: OpenRouterRoutingPreferences | null | undefined,
+): OpenRouterRoutingPreferences {
+  if (!value) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([modelId, preference]) => {
+      const normalizedModelId = modelId.trim();
+      const sanitized = sanitizeOpenRouterRoutingPreference(preference);
+      return normalizedModelId && sanitized ? [[normalizedModelId, sanitized]] : [];
+    }),
+  );
+}
+
+function sanitizeOpenRouterRoutingPreference(
+  preference: OpenRouterRoutingPreference,
+): OpenRouterRoutingPreference | undefined {
+  const order = Array.from(
+    new Set(
+      preference.order
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0)
+        .slice(0, 24),
+    ),
+  );
+  return {
+    order,
+    allowFallbacks: preference.allowFallbacks,
+  };
+}
+
+function routingResolution(
+  source: OpenRouterRoutingSource,
+  modelId: string,
+  preference: OpenRouterRoutingPreference,
+): OpenRouterRoutingResolution {
+  const order = Array.from(new Set(preference.order));
+  const fingerprintInput = {
+    modelId,
+    source,
+    order,
+    allowFallbacks: preference.allowFallbacks,
+    requireParameters: true,
+  };
+  return {
+    source,
+    modelId,
+    order,
+    allowFallbacks: preference.allowFallbacks,
+    requireParameters: true,
+    fingerprint: createHash("sha256")
+      .update(JSON.stringify(fingerprintInput))
+      .digest("hex")
+      .slice(0, 16),
+  };
+}
+
+function providerOrderFromEnv(): string[] {
+  return (process.env.OPENROUTER_PROVIDER_ORDER ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function envBoolean(name: string): boolean | undefined {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return undefined;
+  if (["1", "true", "yes", "on"].includes(value)) return true;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  return undefined;
+}

--- a/src/lib/run-details-serializers.ts
+++ b/src/lib/run-details-serializers.ts
@@ -111,6 +111,7 @@ function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
   const execution = isRecord(costMetadata?.execution)
     ? costMetadata.execution
     : null;
+  const openRouterRouting = openRouterRoutingFromExecution(execution);
 
   return {
     id: run.id,
@@ -163,6 +164,7 @@ function serializeProjectRunDetailsRun(run: Run): ProjectRunDetailsRun {
     ...(contextComposition ? { contextComposition } : {}),
     ...(stepUsage.length > 0 ? { stepUsage } : {}),
     ...(promptCache ? { promptCache } : {}),
+    ...(openRouterRouting ? { openRouterRouting } : {}),
     ...(typeof execution?.profile === "string" ? { profile: execution.profile } : {}),
     ...(typeof execution?.mode === "string" ? { mode: execution.mode } : {}),
     ...(finiteNumber(execution?.tokenBudgetMultiplier) !== undefined
@@ -463,6 +465,9 @@ function promptCacheFromTokenAudit(
   return {
     modelId,
     providerId,
+    ...(typeof cache.routingFingerprint === "string"
+      ? { routingFingerprint: cache.routingFingerprint }
+      : {}),
     systemPromptHash: stringValue(cache.systemPromptHash) ?? "—",
     toolSchemaHash: stringValue(cache.toolSchemaHash) ?? "—",
     nativeToolNamesHash: stringValue(cache.nativeToolNamesHash) ?? "—",
@@ -483,6 +488,33 @@ function promptCacheFromTokenAudit(
       : {}),
     likelyCacheMissReasons,
     cacheBreakReasons: stringArray(cache.cacheBreakReasons),
+  };
+}
+
+function openRouterRoutingFromExecution(
+  execution: Record<string, unknown> | null,
+): ProjectRunDetailsRun["openRouterRouting"] | undefined {
+  if (!execution || !isRecord(execution.openRouterRouting)) return undefined;
+  const routing = execution.openRouterRouting;
+  const source = routing.source;
+  if (
+    source !== "settings" &&
+    source !== "env" &&
+    source !== "builtin" &&
+    source !== "default"
+  ) {
+    return undefined;
+  }
+  const modelId = stringValue(routing.modelId);
+  const fingerprint = stringValue(routing.fingerprint);
+  if (!modelId || !fingerprint) return undefined;
+  return {
+    source,
+    modelId,
+    order: stringArray(routing.order),
+    allowFallbacks: routing.allowFallbacks === true,
+    requireParameters: routing.requireParameters === true,
+    fingerprint,
   };
 }
 


### PR DESCRIPTION
﻿Closes #142

## Summary
- add server-side OpenRouter catalog and model endpoint APIs with static fallback behavior
- persist OpenRouter routing preferences in workspace settings and apply them to chat and delegate runs
- surface routing metadata in run details and prompt-cache audit fingerprints
- update the model/settings UI for dynamic OpenRouter model and endpoint selection

## Verification
- `pnpm db:generate`
- `pnpm db:migrate`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

## UI verification
- Adjusted the model picker based on local browser screenshots and feedback: compact trigger, narrower branch-style popup, search row, filter menu, and dense rows.
