### PR TITLE
Phase 6: Harness Contract Hardening

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Reduced live trace rendering pressure with lazy-mounted disclosures and bounded running Worklog rows (#139).
 - [✔️] Hardened native grep fallback search and rendered grep results as structured Worklog output (#140).
 - [✔️] Added OpenRouter model catalog, provider routing settings, and routing cache metadata (#142).
+- [✔️] Hardened chat message validation, compact model-visible tool outputs, and MCP startup warnings (#144).
 
 ## Phase 1: Trust Boundaries And Safety
 
@@ -178,9 +179,9 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 ## Known Implementation Risks
 
-- [] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
+- [✔️] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
 - [] Shell tool still runs through `bash -lc`; command policy is heuristic rather than a full shell parser.
-- [] MCP stdio server startup can execute configured commands before user approval.
+- [✔️] MCP stdio server startup can execute configured commands before user approval.
 - [] Full-file `write_file` remains the main write primitive.
 - [] Message persistence still deletes and reinserts the full session transcript in some recovery paths.
 - [] GitHub clone/fetch runs synchronously inside request handling and may exceed request duration for large repositories.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -95,6 +95,7 @@ import {
   type OpenRouterRoutingResolution,
 } from "@/src/lib/openrouter-routing";
 import { CHAT_MODES, DEFAULT_CHAT_MODE, type ChatMode } from "@/src/lib/chat-modes";
+import { parseAntonUIMessages } from "@/src/lib/anton-message-validation";
 import { redactText, redactValue } from "@/src/lib/redaction";
 import {
   outputExitCode as sharedOutputExitCode,
@@ -154,7 +155,7 @@ const bodySchema = z.object({
       runId: z.string().min(1),
     })
     .optional(),
-  messages: z.array(z.unknown()).min(1),
+  messages: z.unknown(),
 });
 
 export async function POST(req: Request) {
@@ -167,8 +168,16 @@ export async function POST(req: Request) {
     );
   }
 
+  const messages = parseAntonUIMessages(parsed.data.messages);
+  if (!messages.ok) {
+    return Response.json(
+      { error: "invalid messages", issues: messages.issues },
+      { status: 400 },
+    );
+  }
+
   const { sessionId } = parsed.data;
-  const uiMessages = parsed.data.messages as AntonUIMessage[];
+  const uiMessages = messages.messages;
   const incomingHistory = uiMessages.filter(hasSubstantiveHistoryParts);
   const budgetExtension = parsed.data.extendTokenBudget;
   const profileHandoffContinuation = parsed.data.continueProfileHandoff;
@@ -683,6 +692,7 @@ export async function POST(req: Request) {
             contextCollector.addLoopGuard(event);
             trace.noteLoopGuard(event);
           },
+          onMcpWarnings: (warnings) => trace.noteMcpWarnings(warnings),
           onProfilePromotion: (event) => trace.noteProfilePromotion(event),
           onStreamPart: (part) => trace.handleStreamPart(part),
           onAbort: () => {
@@ -1720,6 +1730,17 @@ function createTraceWriter({
         status: "completed",
         label: "Model selection preserved",
         summary,
+      });
+    },
+    noteMcpWarnings(warnings: readonly string[]) {
+      if (warnings.length === 0) return;
+      startEvent({
+        id: `${runId}:mcp-warnings:${sequence + 1}`,
+        kind: "progress",
+        status: "completed",
+        label: "MCP servers skipped",
+        summary: `${warnings.length} MCP warning${warnings.length === 1 ? "" : "s"} recorded before tool loading completed.`,
+        details: { mcpWarnings: warnings.slice(0, 20) },
       });
     },
     noteTargetResolution(resolution: SingleFileTargetResolution | undefined) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -432,11 +432,6 @@ function mcpToolPromptLines(mcpTools: LoadedMcpTools): string[] {
       ),
     );
   }
-  if (mcpTools.warnings.length > 0) {
-    lines.push(
-      ...mcpTools.warnings.map((warning) => `- MCP warning: ${warning}`),
-    );
-  }
   return lines;
 }
 
@@ -497,6 +492,7 @@ export async function runAgent({
   onToolCallFinish,
   onStreamPart,
   onLoopGuard,
+  onMcpWarnings,
   onProfilePromotion,
   onError,
   onAbort,
@@ -553,6 +549,7 @@ export async function runAgent({
     recommendedNext?: string;
     forceFinal: boolean;
   }) => void;
+  onMcpWarnings?: (warnings: readonly string[]) => void;
   onProfilePromotion?: (event: ProfilePromotionEvent) => void;
   onError?: (error: unknown) => void;
   onAbort?: () => void;
@@ -611,6 +608,9 @@ export async function runAgent({
   const mcpTools = allowMcpTools
     ? await loadMcpTools({ workspaceRoot, enabledMcpServerIds })
     : emptyLoadedMcpTools();
+  if (mcpTools.warnings.length > 0) {
+    onMcpWarnings?.(mcpTools.warnings);
+  }
   let closed = false;
   const closeMcpTools = async () => {
     if (closed) return;

--- a/src/agent/mcp.ts
+++ b/src/agent/mcp.ts
@@ -7,7 +7,7 @@ import {
   type MCPClientConfig,
 } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
-import type { ToolSet } from "ai";
+import type { JSONValue, ToolSet } from "ai";
 
 import {
   isMcpServerTrusted,
@@ -23,6 +23,7 @@ import {
   ensureWorkspaceRootAt,
   resolveInWorkspace,
 } from "./sandbox";
+import { modelVisibleToolOutput } from "./tools/model-output";
 
 const MCP_CONFIG_FILE = ".mcp.json";
 const MAX_MCP_CONFIG_BYTES = 256 * 1024;
@@ -85,7 +86,7 @@ type McpServerSpec = {
 
 type ExecutableTool = ToolSet[string] & {
   description?: string;
-  execute?: (input: unknown, options: never) => unknown;
+  execute?: (input: unknown, options: unknown) => unknown;
 };
 
 export async function loadMcpTools({
@@ -97,11 +98,11 @@ export async function loadMcpTools({
 } = {}): Promise<LoadedMcpTools> {
   const tools: ToolSet = {};
   const toolSummaries: McpToolSummary[] = [];
-  const workspaceConfig = readMcpConfig(workspaceRoot);
+  const workspaceConfig = safeReadMcpConfig(workspaceRoot);
   const warnings: string[] = [...(workspaceConfig?.warnings ?? [])];
   const clients: MCPClient[] = [];
   const specs = [
-    ...globalMcpServerSpecs(enabledMcpServerIds),
+    ...globalMcpServerSpecs(enabledMcpServerIds, warnings),
     ...(workspaceConfig ? workspaceMcpServerSpecs(workspaceConfig.servers) : []),
   ];
 
@@ -218,6 +219,19 @@ export function readMcpConfig(
   return { servers: parsed.data.mcpServers, warnings: [] };
 }
 
+function safeReadMcpConfig(
+  workspaceRoot?: string,
+): ReturnType<typeof readMcpConfig> {
+  try {
+    return readMcpConfig(workspaceRoot);
+  } catch (err) {
+    return {
+      servers: {},
+      warnings: [`failed to inspect ${MCP_CONFIG_FILE}: ${errorMessage(err)}`],
+    };
+  }
+}
+
 function emptyMcpTools(warnings: string[] = []): LoadedMcpTools {
   return {
     tools: {},
@@ -270,7 +284,19 @@ function wrapMcpTool(
     ...mcpTool,
     description: `[MCP:${serverName}] ${mcpTool.description ?? toolName}`,
     needsApproval: true,
-    execute: async (input: unknown, options: never) => {
+    toModelOutput: ({ output }: { output: unknown }) => ({
+      type: "json",
+      value: modelVisibleToolOutput(output, {
+        successCode: "MCP_TOOL_OK",
+        failureCode: "MCP_TOOL_FAILED",
+        successSummary: `MCP tool ${serverName}/${toolName} completed.`,
+        failureSummary: `MCP tool ${serverName}/${toolName} failed.`,
+        successRecommendedNext: "Continue using the returned MCP output.",
+        failureRecommendedNext:
+          "Inspect the MCP error, adjust the input, or use a native Anton tool if possible.",
+      }) as JSONValue,
+    }),
+    execute: async (input: unknown, options: unknown) => {
       try {
         const output = await mcpTool.execute?.(input, options);
         return { ok: true as const, output };
@@ -278,20 +304,39 @@ function wrapMcpTool(
         return { ok: false as const, error: errorMessage(err) };
       }
     },
-  } as ToolSet[string];
+  } as unknown as ToolSet[string];
 }
 
-function globalMcpServerSpecs(enabledMcpServerIds?: string[]): McpServerSpec[] {
+function globalMcpServerSpecs(
+  enabledMcpServerIds: string[] | undefined,
+  warnings: string[],
+): McpServerSpec[] {
   return listEnabledMcpServers(enabledMcpServerIds).flatMap((server) => {
     const parsed = mcpServerConfigSchema.safeParse(server.config);
-    if (!parsed.success) return [];
+    if (!parsed.success) {
+      warnings.push(
+        `skipping malformed MCP server ${server.displayName}: ${parsed.error.issues
+          .map((issue) => issue.message)
+          .join("; ")}`,
+      );
+      return [];
+    }
+    let trusted = false;
+    try {
+      trusted = isMcpServerTrusted(server);
+    } catch (err) {
+      warnings.push(
+        `skipping MCP server ${server.displayName}: trust check failed: ${errorMessage(err)}`,
+      );
+      return [];
+    }
     return [
       {
         id: server.id,
         displayName: server.displayName,
         namespace: server.namespace,
         config: parsed.data,
-        trusted: isMcpServerTrusted(server),
+        trusted,
         source: "global" as const,
       },
     ];

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -12,6 +12,7 @@ import {
   type BashFailedReason,
 } from "@/src/lib/bash-stream";
 import { redactText } from "@/src/lib/redaction";
+import { modelVisibleToolOutput } from "./model-output";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -68,14 +69,22 @@ export const bashTool = createBashTool();
 
 function compactBashModelOutput(output: unknown): JSONValue {
   if (!isRecord(output)) {
-    return { ok: false, error: "unexpected bash output" };
+    return modelVisibleToolOutput(output, {
+      successCode: "BASH_OK",
+      failureCode: "BASH_OUTPUT_MALFORMED",
+      successSummary: "Command completed.",
+      failureSummary: "Bash returned malformed output.",
+      failureRecommendedNext: "Retry with a simpler command or report the tool failure.",
+    }) as JSONValue;
   }
   const exitCode = numberOrNull(output.exitCode);
   const failedReason =
     typeof output.failedReason === "string" ? output.failedReason : undefined;
   const stderr = stringValue(output.stderr);
-  return {
-    ok: output.ok === true && exitCode === 0 && failedReason === undefined,
+  const ok = output.ok === true && exitCode === 0 && failedReason === undefined;
+  const failureCode = bashFailureCode(output, exitCode, failedReason);
+  return modelVisibleToolOutput({
+    ok,
     exitCode,
     timedOut: booleanValue(output.timedOut),
     killed: booleanValue(output.killed),
@@ -88,7 +97,19 @@ function compactBashModelOutput(output: unknown): JSONValue {
         : exitCode !== null && exitCode !== 0
           ? `Command exited with code ${exitCode}.`
           : failedReason ?? null,
-  };
+  }, {
+    successCode: "BASH_OK",
+    failureCode,
+    successSummary: "Command completed successfully.",
+    failureSummary:
+      typeof output.error === "string"
+        ? output.error
+        : exitCode !== null && exitCode !== 0
+          ? `Command exited with code ${exitCode}.`
+          : failedReason ?? "Command failed.",
+    successRecommendedNext: "Continue with the command output.",
+    failureRecommendedNext: recommendedNextForBashFailure(failureCode, ok),
+  }) as JSONValue;
 }
 
 function truncate(output: string): string {
@@ -288,4 +309,41 @@ function numberOrNull(value: unknown): number | null {
 function tail(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return value.slice(value.length - maxLength);
+}
+
+function bashFailureCode(
+  output: Record<string, unknown>,
+  exitCode: number | null,
+  failedReason: string | undefined,
+): string {
+  if (output.ok === true && exitCode === 0 && failedReason === undefined) {
+    return "BASH_OK";
+  }
+  if (output.ok === false && typeof output.error === "string" && exitCode === null) {
+    return "BASH_POLICY_REJECTED";
+  }
+  if (failedReason === "timeout") return "BASH_TIMEOUT";
+  if (failedReason === "max_buffer") return "BASH_OUTPUT_TRUNCATED";
+  if (exitCode !== null && exitCode !== 0) return "BASH_NONZERO_EXIT";
+  return "BASH_FAILED";
+}
+
+function recommendedNextForBashFailure(
+  code: string,
+  ok: boolean,
+): string | undefined {
+  if (ok) return undefined;
+  if (code === "BASH_POLICY_REJECTED") {
+    return "Revise the command to satisfy the workspace command policy.";
+  }
+  if (code === "BASH_TIMEOUT") {
+    return "Run a narrower command or request a longer timeout within the tool cap.";
+  }
+  if (code === "BASH_NONZERO_EXIT") {
+    return "Inspect stderr/stdout, fix the underlying issue, then retry if needed.";
+  }
+  if (code === "BASH_OUTPUT_TRUNCATED") {
+    return "Rerun with narrower output or use a purpose-built read/search tool.";
+  }
+  return "Retry with a simpler command or report the failure.";
 }

--- a/src/agent/tools/edit-text.ts
+++ b/src/agent/tools/edit-text.ts
@@ -12,6 +12,7 @@ import { assertGuardAllowed } from "./file-guardrails";
 import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
 import { applyTextEditsToContent, buildDisplayDiff } from "./text-edits";
 import { lintEditedFile } from "./post-edit-lint";
+import { modelVisibleToolOutput } from "./model-output";
 
 const editSchema = z.object({
   oldText: z.string().describe("Text to find in the current file on disk (LF or CRLF both work)."),
@@ -197,12 +198,19 @@ function structuredError(input: {
 
 function compactEditTextModelOutput(output: unknown): JSONValue {
   if (!isRecord(output)) {
-    return { ok: false, error: "unexpected edit_text output" };
+    return modelVisibleToolOutput(output, {
+      successCode: "EDIT_TEXT_OK",
+      failureCode: "EDIT_TEXT_OUTPUT_MALFORMED",
+      successSummary: "Edit applied.",
+      failureSummary: "edit_text returned malformed output.",
+      failureRecommendedNext: "Retry with a simpler edit or report the tool failure.",
+    }) as JSONValue;
   }
   if (output.ok !== true) {
-    return {
+    const code = stringValue(output.code) || "EDIT_TEXT_FAILED";
+    return modelVisibleToolOutput({
       ok: false,
-      code: stringValue(output.code),
+      code,
       path: stringValue(output.path),
       message: stringValue(output.message) || stringValue(output.error),
       noChangesApplied: true,
@@ -225,9 +233,16 @@ function compactEditTextModelOutput(output: unknown): JSONValue {
       ...(Array.isArray(output.lintIssues)
         ? { lintIssues: output.lintIssues.slice(0, 5) }
         : {}),
-    };
+    }, {
+      successCode: "EDIT_TEXT_OK",
+      failureCode: "EDIT_TEXT_FAILED",
+      successSummary: "Edit applied.",
+      failureSummary:
+        stringValue(output.message) || stringValue(output.error) || "edit_text failed.",
+      failureRecommendedNext: recommendedNextForEditTextFailure(code),
+    }) as JSONValue;
   }
-  return {
+  return modelVisibleToolOutput({
     ok: true,
     path: stringValue(output.path),
     editCount: numberValue(output.editCount),
@@ -244,7 +259,13 @@ function compactEditTextModelOutput(output: unknown): JSONValue {
     ...(Array.isArray(output.postEditLintIssues)
       ? { postEditLintIssues: output.postEditLintIssues.slice(0, 5) }
       : {}),
-  };
+  }, {
+    successCode: "EDIT_TEXT_OK",
+    failureCode: "EDIT_TEXT_FAILED",
+    successSummary: `Edited ${stringValue(output.path) || "file"}.`,
+    failureSummary: "edit_text failed.",
+    successRecommendedNext: "Run verification if this changed project files.",
+  }) as JSONValue;
 }
 
 function errorMessage(err: unknown): string {
@@ -263,4 +284,20 @@ function stringValue(value: unknown): string {
 
 function numberValue(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function recommendedNextForEditTextFailure(code: string): string {
+  if (code === "FIND_NOT_FOUND") {
+    return "Use nearMatches or re-read the relevant range, then retry with current text.";
+  }
+  if (code === "FIND_NOT_UNIQUE") {
+    return "Narrow the oldText snippet or set replaceAll only when every match is intended.";
+  }
+  if (code === "GUARD_REJECTED") {
+    return "Set allowGuarded only if this guarded edit is intentional.";
+  }
+  if (code === "SYNTAX_OR_LINT_FAILED") {
+    return "Use the lint issues and failed patch preview to make a smaller valid edit.";
+  }
+  return "Inspect the error, adjust the edit, and retry if appropriate.";
 }

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -11,6 +11,61 @@ export const GREP_MODEL_MAX_MATCH_CHARS = 220;
 export const GLOB_MODEL_MAX_PATHS = 80;
 export const VERIFY_MODEL_OUTPUT_TAIL_CHARS = 1_200;
 
+export type ModelVisibleToolOutput = {
+  ok: boolean;
+  code: string;
+  summary: string;
+  recommendedNext?: string;
+  pathHints?: unknown;
+  details?: unknown;
+} & Record<string, unknown>;
+
+export function modelVisibleToolOutput(
+  output: unknown,
+  defaults: {
+    successCode: string;
+    failureCode: string;
+    successSummary: string;
+    failureSummary: string;
+    successRecommendedNext?: string;
+    failureRecommendedNext?: string;
+    pathHints?: unknown;
+    details?: unknown;
+  },
+): ModelVisibleToolOutput {
+  const record = isRecord(output) ? output : {};
+  const ok = record.ok === true;
+  const code =
+    typeof record.code === "string" && record.code.length > 0
+      ? record.code
+      : ok
+        ? defaults.successCode
+        : defaults.failureCode;
+  const summary =
+    firstString(record.summary, record.message, record.error) ??
+    (ok ? defaults.successSummary : defaults.failureSummary);
+  const recommendedNext =
+    firstString(record.recommendedNext) ??
+    (ok
+      ? defaults.successRecommendedNext
+      : defaults.failureRecommendedNext);
+  const pathHints =
+    record.pathHints ?? pathHintFromRecord(record) ?? defaults.pathHints;
+  return {
+    ...record,
+    ok,
+    code,
+    summary,
+    ...(recommendedNext ? { recommendedNext } : {}),
+    ...(pathHints !== undefined ? { pathHints } : {}),
+    ...(record.details !== undefined
+      ? { details: record.details }
+      : defaults.details !== undefined
+        ? { details: defaults.details }
+        : {}),
+  };
+}
+
 export function readFileOutputIsFullCoverage(output: Record<string, unknown>): boolean {
   if (output.truncated === true) return false;
   const startLine = finiteNumber(output.startLine) ?? 1;
@@ -40,11 +95,19 @@ export function compactReadFileForModel(
   output: unknown,
   profile: AgentRunProfile = "general-chat",
 ): unknown {
-  if (!isRecord(output) || output.ok !== true) return output;
+  if (!isRecord(output) || output.ok !== true) {
+    return modelVisibleToolOutput(output, {
+      successCode: "READ_FILE_OK",
+      failureCode: "READ_FILE_FAILED",
+      successSummary: "File read successfully.",
+      failureSummary: "File could not be read.",
+      failureRecommendedNext: "Check the path and read a nearby directory if needed.",
+    });
+  }
   const content = typeof output.content === "string" ? output.content : "";
 
   if (readFileOutputIsModestFullFile(output)) {
-    return {
+    return modelVisibleToolOutput({
       ok: true,
       path: output.path,
       startLine: output.startLine,
@@ -53,7 +116,13 @@ export function compactReadFileForModel(
       sizeBytes: output.sizeBytes,
       sha256: output.sha256,
       content,
-    };
+    }, {
+      successCode: "READ_FILE_OK",
+      failureCode: "READ_FILE_FAILED",
+      successSummary: `Read ${stringValue(output.path) || "file"}.`,
+      failureSummary: "File could not be read.",
+      successRecommendedNext: "Continue with the visible file content.",
+    });
   }
 
   const lines = content.split("\n");
@@ -81,7 +150,7 @@ export function compactReadFileForModel(
       finiteNumber(output.totalLines) !== undefined &&
       (finiteNumber(output.endLine) as number) <
         (finiteNumber(output.totalLines) as number));
-  return {
+  return modelVisibleToolOutput({
     ok: true,
     path: output.path,
     startLine: output.startLine,
@@ -104,12 +173,26 @@ export function compactReadFileForModel(
         }
       : {}),
     content: compactContent,
-  };
+  }, {
+    successCode: "READ_FILE_OK",
+    failureCode: "READ_FILE_FAILED",
+    successSummary: `Read ${stringValue(output.path) || "file"}${truncated ? " with truncation" : ""}.`,
+    failureSummary: "File could not be read.",
+    successRecommendedNext: truncated
+      ? "Request a narrower line range before editing unseen content."
+      : "Continue with the visible file content.",
+  });
 }
 
 export function compactGrepForModel(output: unknown): unknown {
   if (!isRecord(output) || output.ok !== true || !Array.isArray(output.matches)) {
-    return output;
+    return modelVisibleToolOutput(output, {
+      successCode: "GREP_OK",
+      failureCode: "GREP_FAILED",
+      successSummary: "Search completed.",
+      failureSummary: "Search could not be completed.",
+      failureRecommendedNext: "Fix the pattern or path, then search again.",
+    });
   }
   const matches = output.matches.slice(0, GREP_MODEL_MAX_MATCHES).map((match) => {
     if (!isRecord(match)) return match;
@@ -122,7 +205,7 @@ export function compactGrepForModel(output: unknown): unknown {
           : text,
     };
   });
-  return {
+  return modelVisibleToolOutput({
     ...output,
     matches,
     matchCount: matches.length,
@@ -130,26 +213,56 @@ export function compactGrepForModel(output: unknown): unknown {
       output.truncated === true ||
       (Array.isArray(output.matches) &&
         output.matches.length > GREP_MODEL_MAX_MATCHES),
-  };
+  }, {
+    successCode: "GREP_OK",
+    failureCode: "GREP_FAILED",
+    successSummary: `Found ${matches.length} matching line${matches.length === 1 ? "" : "s"}.`,
+    failureSummary: "Search could not be completed.",
+    successRecommendedNext: matches.length > 0
+      ? "Inspect the most relevant match with read_file."
+      : "Try a broader pattern if needed.",
+  });
 }
 
 export function compactGlobForModel(output: unknown): unknown {
   if (!isRecord(output) || output.ok !== true || !Array.isArray(output.matches)) {
-    return output;
+    return modelVisibleToolOutput(output, {
+      successCode: "GLOB_OK",
+      failureCode: "GLOB_FAILED",
+      successSummary: "Glob completed.",
+      failureSummary: "Glob could not be completed.",
+      failureRecommendedNext: "Check the base path or simplify the glob pattern.",
+    });
   }
   const matches = output.matches.slice(0, GLOB_MODEL_MAX_PATHS);
-  return {
+  return modelVisibleToolOutput({
     ...output,
     matches,
     matchCount: matches.length,
     truncated:
       output.truncated === true ||
       output.matches.length > GLOB_MODEL_MAX_PATHS,
-  };
+  }, {
+    successCode: "GLOB_OK",
+    failureCode: "GLOB_FAILED",
+    successSummary: `Found ${matches.length} path${matches.length === 1 ? "" : "s"}.`,
+    failureSummary: "Glob could not be completed.",
+    successRecommendedNext: matches.length > 0
+      ? "Read or inspect the relevant paths."
+      : "Try a broader pattern if needed.",
+  });
 }
 
 export function compactVerifyForModel(output: unknown): unknown {
-  if (!isRecord(output)) return output;
+  if (!isRecord(output)) {
+    return modelVisibleToolOutput(output, {
+      successCode: "VERIFY_OK",
+      failureCode: "VERIFY_FAILED",
+      successSummary: "Verification completed.",
+      failureSummary: "Verification failed.",
+      failureRecommendedNext: "Inspect verification output and decide whether to fix or report.",
+    });
+  }
   const results = Array.isArray(output.results)
     ? output.results.map(compactVerifyResultForModel)
     : output.results;
@@ -185,7 +298,7 @@ export function compactVerifyForModel(output: unknown): unknown {
       : [];
 
   if (output.ok === false) {
-    return {
+    return modelVisibleToolOutput({
       ...base,
       ok: false,
       ...(parseIssues.length > 0 ? { parseIssues: parseIssues.slice(0, 5) } : {}),
@@ -198,13 +311,28 @@ export function compactVerifyForModel(output: unknown): unknown {
             exitCode: failed.exitCode,
           }
         : {}),
-    };
+    }, {
+      successCode: "VERIFY_OK",
+      failureCode: "VERIFY_FAILED",
+      successSummary: "Verification completed.",
+      failureSummary: failureSummary ?? "Verification failed.",
+      failureRecommendedNext: "Fix edited-file failures; report unrelated or broken verification.",
+    });
   }
 
-  return {
+  return modelVisibleToolOutput({
     ...base,
     results,
-  };
+  }, {
+    successCode: "VERIFY_OK",
+    failureCode: "VERIFY_FAILED",
+    successSummary: typeof output.summary === "string"
+      ? output.summary
+      : "Verification completed.",
+    failureSummary: "Verification failed.",
+    successRecommendedNext:
+      output.recommendedNext === "final" ? "final" : undefined,
+  });
 }
 
 export function extractVerifyFailureSummary(output: unknown): string | undefined {
@@ -306,6 +434,29 @@ function tailText(value: unknown): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function pathHintFromRecord(record: Record<string, unknown>): unknown {
+  if (typeof record.path === "string" && record.path.length > 0) {
+    return [record.path];
+  }
+  if (typeof record.file === "string" && record.file.length > 0) {
+    return [record.file];
+  }
+  return undefined;
 }
 
 function finiteNumber(value: unknown): number | undefined {

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -13,6 +13,7 @@ import {
   assertGuardAllowed,
   assertPathGuardAllowed,
 } from "./file-guardrails";
+import { modelVisibleToolOutput } from "./model-output";
 
 export function createWriteFileTool(workspaceRoot?: string) {
   return tool({
@@ -93,15 +94,29 @@ export const writeFileTool = createWriteFileTool();
 
 function compactWriteFileModelOutput(output: unknown): JSONValue {
   if (!isRecord(output)) {
-    return { ok: false, error: "unexpected write_file output" };
+    return modelVisibleToolOutput(output, {
+      successCode: "WRITE_FILE_OK",
+      failureCode: "WRITE_FILE_OUTPUT_MALFORMED",
+      successSummary: "File written.",
+      failureSummary: "write_file returned malformed output.",
+      failureRecommendedNext: "Retry with a smaller, explicit write or report the tool failure.",
+    }) as JSONValue;
   }
   if (output.ok !== true) {
-    return {
+    const error = typeof output.error === "string" ? output.error : "write_file failed";
+    return modelVisibleToolOutput({
       ok: false,
-      error: typeof output.error === "string" ? output.error : "write_file failed",
-    };
+      code: writeFileFailureCode(error),
+      error,
+    }, {
+      successCode: "WRITE_FILE_OK",
+      failureCode: "WRITE_FILE_FAILED",
+      successSummary: "File written.",
+      failureSummary: error,
+      failureRecommendedNext: recommendedNextForWriteFileFailure(error),
+    }) as JSONValue;
   }
-  return {
+  return modelVisibleToolOutput({
     ok: true,
     path: stringValue(output.path),
     bytesWritten: numberValue(output.bytesWritten),
@@ -110,7 +125,13 @@ function compactWriteFileModelOutput(output: unknown): JSONValue {
       typeof output.previousHash === "string" ? output.previousHash : null,
     previousTruncated: booleanValue(output.previousTruncated),
     nextHash: stringValue(output.nextHash),
-  };
+  }, {
+    successCode: "WRITE_FILE_OK",
+    failureCode: "WRITE_FILE_FAILED",
+    successSummary: `Wrote ${stringValue(output.path) || "file"}.`,
+    failureSummary: "write_file failed.",
+    successRecommendedNext: "Run verification if this changed project files.",
+  }) as JSONValue;
 }
 
 function errorMessage(err: unknown): string {
@@ -133,4 +154,33 @@ function numberValue(value: unknown): number {
 
 function booleanValue(value: unknown): boolean {
   return typeof value === "boolean" ? value : false;
+}
+
+function writeFileFailureCode(error: string): string {
+  if (error.includes("expectedHash is required")) return "WRITE_FILE_EXPECTED_HASH_REQUIRED";
+  if (error.includes("hash mismatch")) return "WRITE_FILE_HASH_MISMATCH";
+  if (error.includes("target already exists")) return "WRITE_FILE_TARGET_EXISTS";
+  if (error.includes("byte cap")) return "WRITE_FILE_TOO_LARGE";
+  if (error.toLowerCase().includes("guard")) return "WRITE_FILE_GUARD_REJECTED";
+  return "WRITE_FILE_FAILED";
+}
+
+function recommendedNextForWriteFileFailure(error: string): string {
+  const code = writeFileFailureCode(error);
+  if (code === "WRITE_FILE_EXPECTED_HASH_REQUIRED") {
+    return "Read the current file first, then retry with expectedHash or use edit_text.";
+  }
+  if (code === "WRITE_FILE_HASH_MISMATCH") {
+    return "Re-read the file and retry only after reconciling the current content.";
+  }
+  if (code === "WRITE_FILE_TARGET_EXISTS") {
+    return "Use expectedHash for replacement or choose a new path.";
+  }
+  if (code === "WRITE_FILE_TOO_LARGE") {
+    return "Use a smaller targeted edit or split the write.";
+  }
+  if (code === "WRITE_FILE_GUARD_REJECTED") {
+    return "Set allowGuarded only if this guarded write is intentional.";
+  }
+  return "Inspect the error, adjust the write, and retry if appropriate.";
 }

--- a/src/lib/anton-message-validation.ts
+++ b/src/lib/anton-message-validation.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+
+import type { AntonUIMessage } from "@/src/lib/trace";
+
+const MESSAGE_ROLES = ["system", "user", "assistant"] as const;
+const TOOL_PART_RE = /^tool-[A-Za-z0-9_-]+$/;
+const DATA_PART_RE = /^data-[A-Za-z0-9_-]+$/;
+const KNOWN_STRUCTURAL_PARTS = new Set([
+  "step-start",
+  "source-url",
+  "source-document",
+  "file",
+]);
+
+const antonUIPartSchema = z
+  .record(z.string(), z.unknown())
+  .superRefine((part, ctx) => {
+    const type = part.type;
+    if (typeof type !== "string" || type.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["type"],
+        message: "message part type is required",
+      });
+      return;
+    }
+
+    if (type === "text") {
+      if (typeof part.text !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["text"],
+          message: "text part requires string text",
+        });
+      }
+      return;
+    }
+
+    if (type === "reasoning") {
+      if (part.text !== undefined && typeof part.text !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["text"],
+          message: "reasoning text must be a string when present",
+        });
+      }
+      return;
+    }
+
+    if (DATA_PART_RE.test(type)) {
+      if (part.id !== undefined && typeof part.id !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["id"],
+          message: "data part id must be a string when present",
+        });
+      }
+      if (!Object.prototype.hasOwnProperty.call(part, "data")) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["data"],
+          message: "data part requires data",
+        });
+      }
+      return;
+    }
+
+    if (TOOL_PART_RE.test(type) || type === "dynamic-tool") {
+      if (type === "dynamic-tool" && typeof part.toolName !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["toolName"],
+          message: "dynamic tool part requires string toolName",
+        });
+      }
+      if (part.toolCallId !== undefined && typeof part.toolCallId !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["toolCallId"],
+          message: "tool part toolCallId must be a string when present",
+        });
+      }
+      if (part.state !== undefined && typeof part.state !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["state"],
+          message: "tool part state must be a string when present",
+        });
+      }
+      if (part.errorText !== undefined && typeof part.errorText !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["errorText"],
+          message: "tool part errorText must be a string when present",
+        });
+      }
+      return;
+    }
+
+    if (KNOWN_STRUCTURAL_PARTS.has(type)) return;
+
+    ctx.addIssue({
+      code: "custom",
+      path: ["type"],
+      message: `unsupported message part type: ${type}`,
+    });
+  });
+
+export const antonUIMessagesSchema = z
+  .array(
+    z
+      .object({
+        id: z.string().min(1),
+        role: z.enum(MESSAGE_ROLES),
+        parts: z.array(antonUIPartSchema).min(1),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      })
+      .passthrough(),
+  )
+  .min(1);
+
+export function parseAntonUIMessages(value: unknown):
+  | { ok: true; messages: AntonUIMessage[] }
+  | { ok: false; issues: z.core.$ZodIssue[] } {
+  const parsed = antonUIMessagesSchema.safeParse(value);
+  if (!parsed.success) {
+    return { ok: false, issues: parsed.error.issues };
+  }
+  return { ok: true, messages: parsed.data as unknown as AntonUIMessage[] };
+}


### PR DESCRIPTION
## Summary

- Adds an Anton UI message boundary validator for `/api/chat`, returning structured `400` issues for malformed message parts before the agent loop.
- Adds a shared compact model-visible tool output contract with stable `ok`, `code`, `summary`, `recommendedNext`, and path/detail fields where available.
- Applies the compact contract to bash, verify, read_file, grep, glob, edit_text, write_file, and MCP wrapper errors while preserving full tool outputs for UI/audit.
- Makes MCP loading more fail-closed: malformed global configs and workspace config inspection failures are warning-only skips, untrusted workspace `.mcp.json` servers expose no tools, and warning text is persisted to Worklog instead of the system prompt.
- Updates `ROADMAP.md` for #144.

Closes #144

## Verification

- `pnpm typecheck` passed.
- `pnpm lint` passed.
- `git diff --check` passed.
- Manual validator check: valid text message accepted; malformed text part rejected with issue path `[0, "parts", 0, "text"]`.
- Manual compact-output checks confirmed stable `code` and `recommendedNext` for `write_file`, `edit_text`, `read_file`, `grep`, `glob`, and `verify` failures.
- Manual MCP check with a temp workspace `.mcp.json` and isolated global server IDs loaded `0` tools and emitted the expected untrusted-server warning.

Note: a direct `tsx --eval` import of the `bash` tool hit a Node 24/package export issue inside an `execa` dependency, so bash compact output was covered by typecheck and source review rather than that eval snippet.
