### PR TITLE
[codex] Make full-access shell policy advisory

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,7 +180,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 ## Known Implementation Risks
 
 - [✔️] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
-- [] Shell tool still runs through `bash -lc`; command policy is heuristic rather than a full shell parser.
+- [] Normal permission modes still use heuristic shell command classification; `full-access` intentionally treats command policy as advisory only.
 - [✔️] MCP stdio server startup can execute configured commands before user approval.
 - [] Full-file `write_file` remains the main write primitive.
 - [] Message persistence still deletes and reinserts the full session transcript in some recovery paths.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -55,6 +55,7 @@ import { compactReadFileForModel } from "@/src/agent/tools/model-output";
 import type { ProfilePromotionEvent } from "@/src/agent/profile-promotion";
 import {
   buildToolApprovalMetadata,
+  commandPolicyModeForPermission,
   getNativeToolPermissionMetadata,
   isMcpTool,
   preClassifyBashInput,
@@ -1864,6 +1865,7 @@ function createTraceWriter({
             toolName: event.toolName,
             input: event.input,
             workspaceRoot,
+            permissionMode,
           })
         : undefined;
       if (approval) {
@@ -1874,11 +1876,14 @@ function createTraceWriter({
 
       if (event.toolName === "bash") {
         const classification = preClassifyBashInput(event.input);
+        const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
+        details.commandPolicyMode = commandPolicyMode;
         if (classification) {
           details.bashClassification = {
             categories: [...classification.categories],
             forbidden: classification.forbidden,
             reason: classification.reason,
+            commandPolicyMode,
           };
         }
       }

--- a/app/api/projects/[id]/commands/[commandId]/restart/route.ts
+++ b/app/api/projects/[id]/commands/[commandId]/restart/route.ts
@@ -1,4 +1,4 @@
-import { getProject } from "@/src/db/queries";
+import { getProject, getWorkspaceSettings } from "@/src/db/queries";
 import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
 import { redactText } from "@/src/lib/redaction";
 import { restartProjectBackgroundCommand } from "@/src/workspace/background-commands";
@@ -18,10 +18,13 @@ export async function POST(_req: Request, { params }: Ctx) {
   }
 
   try {
+    const permissionMode =
+      getWorkspaceSettings().defaultPermissionMode ?? "auto-review";
     const result = await restartProjectBackgroundCommand(
       project.id,
       commandId,
       project.localPath,
+      permissionMode,
     );
     if (!result.ok) {
       return Response.json(

--- a/app/api/projects/[id]/commands/preflight/route.ts
+++ b/app/api/projects/[id]/commands/preflight/route.ts
@@ -1,4 +1,4 @@
-import { getProject } from "@/src/db/queries";
+import { getProject, getWorkspaceSettings } from "@/src/db/queries";
 import { redactText } from "@/src/lib/redaction";
 import { preflightProjectBackgroundCommand } from "@/src/workspace/background-commands";
 import { z } from "zod";
@@ -34,9 +34,12 @@ export async function POST(req: Request, { params }: Ctx) {
   }
 
   try {
+    const permissionMode =
+      getWorkspaceSettings().defaultPermissionMode ?? "auto-review";
     const result = preflightProjectBackgroundCommand(
       project.localPath,
       parsed.data.command,
+      permissionMode,
     );
     if (!result.ok) {
       return Response.json(
@@ -49,6 +52,7 @@ export async function POST(req: Request, { params }: Ctx) {
       allowed: result.allowed,
       risky: result.risky,
       categories: result.categories,
+      commandPolicyMode: result.commandPolicyMode,
       reason: result.reason,
     });
   } catch (err) {

--- a/app/api/projects/[id]/commands/route.ts
+++ b/app/api/projects/[id]/commands/route.ts
@@ -1,4 +1,4 @@
-import { getProject } from "@/src/db/queries";
+import { getProject, getWorkspaceSettings } from "@/src/db/queries";
 import { serializeBackgroundCommandSession } from "@/src/lib/api-serializers";
 import type { ProjectBackgroundCommandsSummary } from "@/src/lib/api-types";
 import { redactText } from "@/src/lib/redaction";
@@ -66,10 +66,13 @@ export async function POST(req: Request, { params }: Ctx) {
   }
 
   try {
+    const permissionMode =
+      getWorkspaceSettings().defaultPermissionMode ?? "auto-review";
     const result = await startProjectBackgroundCommand(
       project.id,
       project.localPath,
       parsed.data,
+      permissionMode,
     );
     if (!result.ok) {
       return Response.json(

--- a/components/features/run-trace/terminal-output.tsx
+++ b/components/features/run-trace/terminal-output.tsx
@@ -60,18 +60,25 @@ export function TerminalOutput({ command, output, className }: TerminalOutputPro
           (no output)
         </div>
       )}
-      {status && (
-        <div className="border-t border-white/8 px-2 py-1">
-          <span
-            className={cn(
-              "text-[10px] font-medium",
-              status.tone === "error"
-                ? "text-red-400"
-                : "text-muted-foreground/60",
-            )}
-          >
-            {status.label}
-          </span>
+      {(status || parsed.commandPolicyMode) && (
+        <div className="flex items-center gap-2 border-t border-white/8 px-2 py-1">
+          {status ? (
+            <span
+              className={cn(
+                "text-[10px] font-medium",
+                status.tone === "error"
+                  ? "text-red-400"
+                  : "text-muted-foreground/60",
+              )}
+            >
+              {status.label}
+            </span>
+          ) : null}
+          {parsed.commandPolicyMode ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Policy: {parsed.commandPolicyMode}
+            </span>
+          ) : null}
         </div>
       )}
     </div>

--- a/components/features/run-trace/terminal-utils.ts
+++ b/components/features/run-trace/terminal-utils.ts
@@ -8,6 +8,7 @@ export interface BashOutput {
   stdout?: string;
   stderr?: string;
   exitCode?: number | null;
+  commandPolicyMode?: "enforced" | "advisory";
   timedOut?: boolean;
   killed?: boolean;
   failedReason?: BashFailedReason;
@@ -32,6 +33,11 @@ export function parseBashOutput(output: unknown): BashOutput {
     exitCode:
       typeof record.exitCode === "number" || record.exitCode === null
         ? record.exitCode
+        : undefined,
+    commandPolicyMode:
+      record.commandPolicyMode === "enforced" ||
+      record.commandPolicyMode === "advisory"
+        ? record.commandPolicyMode
         : undefined,
     timedOut:
       typeof record.timedOut === "boolean" ? record.timedOut : undefined,

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -619,6 +619,9 @@ function bashOutputFromEntry(entry: ToolTraceEntry): BashOutput {
   return {
     ...(stdout ? { stdout } : {}),
     ...(stderr ? { stderr } : {}),
+    ...(pickCommandPolicyMode(entry.output)
+      ? { commandPolicyMode: pickCommandPolicyMode(entry.output) }
+      : {}),
     exitCode:
       typeof entry.output === "object" &&
       entry.output !== null &&
@@ -630,6 +633,14 @@ function bashOutputFromEntry(entry: ToolTraceEntry): BashOutput {
     ...(failedReason === "timeout" ? { timedOut: true, failedReason } : {}),
     ...(failedReason && failedReason !== "timeout" ? { failedReason } : {}),
   };
+}
+
+function pickCommandPolicyMode(
+  output: unknown,
+): BashOutput["commandPolicyMode"] {
+  if (typeof output !== "object" || output === null) return undefined;
+  const value = (output as Record<string, unknown>).commandPolicyMode;
+  return value === "enforced" || value === "advisory" ? value : undefined;
 }
 
 function parseFailedReason(

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -30,6 +30,7 @@ import { planVerification } from "./tools/verify";
 // and the harness resumes the loop.
 
 export type PermissionMode = "default" | "auto-review" | "full-access";
+export type CommandPolicyMode = "enforced" | "advisory";
 
 export const TOOL_RISK_CATEGORIES = [
   "read-only",
@@ -64,6 +65,7 @@ export type ToolApprovalMetadata = {
   };
   command?: {
     command: string;
+    commandPolicyMode: CommandPolicyMode;
     shell: "bash -lc";
     cwd: string;
     timeoutMs: number;
@@ -237,14 +239,21 @@ export function buildToolApprovalMetadata({
   toolName,
   input,
   workspaceRoot,
+  permissionMode = "auto-review",
 }: {
   toolName: string;
   input: unknown;
   workspaceRoot?: string;
+  permissionMode?: PermissionMode;
 }): ToolApprovalMetadata | undefined {
   const nativeMetadata = getNativeToolPermissionMetadata(toolName);
   if (nativeMetadata) {
-    return buildNativeToolApprovalMetadata(toolName, input, workspaceRoot);
+    return buildNativeToolApprovalMetadata(
+      toolName,
+      input,
+      workspaceRoot,
+      permissionMode,
+    );
   }
 
   if (isMcpTool(toolName)) {
@@ -320,6 +329,7 @@ function buildNativeToolApprovalMetadata(
   toolName: string,
   input: unknown,
   workspaceRoot: string | undefined,
+  permissionMode: PermissionMode,
 ): ToolApprovalMetadata | undefined {
   const metadata = getNativeToolPermissionMetadata(toolName);
   if (!metadata) return undefined;
@@ -327,7 +337,7 @@ function buildNativeToolApprovalMetadata(
 
   switch (toolName) {
     case "bash":
-      return buildBashApproval(record, metadata, workspaceRoot);
+      return buildBashApproval(record, metadata, workspaceRoot, permissionMode);
     case "edit_file":
       return buildEditFileApproval(record, metadata, workspaceRoot);
     case "edit_text":
@@ -673,11 +683,13 @@ function buildBashApproval(
   input: Record<string, unknown>,
   metadata: ToolPermissionMetadata,
   workspaceRoot: string | undefined,
+  permissionMode: PermissionMode,
 ): ToolApprovalMetadata {
   const command = stringValue(input.command) ?? "";
   const timeoutMs = numberValue(input.timeoutMs) ?? BASH_DEFAULT_TIMEOUT_MS;
   const cwd = workspaceRootLabel(workspaceRoot);
   const classification = classifyBashCommand(command);
+  const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
 
   return {
     title: "Run shell command",
@@ -686,6 +698,7 @@ function buildBashApproval(
     target: command,
     command: {
       command,
+      commandPolicyMode,
       shell: "bash -lc",
       cwd,
       timeoutMs,
@@ -698,8 +711,11 @@ function buildBashApproval(
       `Working directory: ${cwd}`,
       `Timeout: ${timeoutMs}ms`,
       `Output cap: ${BASH_OUTPUT_CAP_BYTES} bytes per stream.`,
+      `Command policy mode: ${commandPolicyMode}.`,
       `Classification: ${classification.reason}.`,
-      classification.forbidden
+      commandPolicyMode === "advisory"
+        ? "Full-access mode treats command policy classification as advisory; sandbox cwd, timeout, output limits, and redaction still apply."
+        : classification.forbidden
         ? "This command matches a forbidden pattern and will be refused even if approved."
         : "Approval lets the command start; it does not bypass sandbox cwd, timeout, or output limits.",
     ],
@@ -982,6 +998,12 @@ function buildMcpToolApprovalMetadata(toolName: string): ToolApprovalMetadata {
 
 export function classifyBashCommand(command: string): BashCommandClassification {
   return classifyBashCommandByPolicy(command);
+}
+
+export function commandPolicyModeForPermission(
+  permissionMode: PermissionMode,
+): CommandPolicyMode {
+  return permissionMode === "full-access" ? "advisory" : "enforced";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -13,13 +13,21 @@ import {
 } from "@/src/lib/bash-stream";
 import { redactText } from "@/src/lib/redaction";
 import { modelVisibleToolOutput } from "./model-output";
+import {
+  commandPolicyModeForPermission,
+  type CommandPolicyMode,
+  type PermissionMode,
+} from "../permissions";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_TIMEOUT_MS = 300_000;
 const SEARCH_COMMAND_TIMEOUT_MS = 240_000;
 
-export function createBashTool(workspaceRoot?: string) {
+export function createBashTool(
+  workspaceRoot?: string,
+  permissionMode: PermissionMode = "auto-review",
+) {
   return tool({
     description:
       "Run a shell command inside the workspace directory. The command is classified by risk category before execution, runs with a timeout, and has its output truncated. Prefer the `grep` tool for workspace text search instead of shell `grep`. `sudo` is forbidden. Requires user approval.",
@@ -44,9 +52,11 @@ export function createBashTool(workspaceRoot?: string) {
         ? ensureWorkspaceRootAt(workspaceRoot)
         : ensureWorkspaceRoot();
       const policy = evaluateBashCommandPolicy(command, { workspaceRoot: root });
-      if (!policy.allowed) {
+      const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
+      if (commandPolicyMode === "enforced" && !policy.allowed) {
         return {
           ok: false as const,
+          commandPolicyMode,
           classification: policy.classification,
           riskCategories: policy.classification.categories as string[],
           error: policy.reason,
@@ -60,7 +70,14 @@ export function createBashTool(workspaceRoot?: string) {
           : DEFAULT_TIMEOUT_MS);
       const classification = policy.classification;
 
-      return executeWithStreaming(command, root, timeout, toolCallId, classification);
+      return executeWithStreaming(
+        command,
+        root,
+        timeout,
+        toolCallId,
+        classification,
+        commandPolicyMode,
+      );
     },
   });
 }
@@ -88,6 +105,7 @@ function compactBashModelOutput(output: unknown): JSONValue {
     exitCode,
     timedOut: booleanValue(output.timedOut),
     killed: booleanValue(output.killed),
+    commandPolicyMode: commandPolicyModeValue(output.commandPolicyMode),
     failedReason: failedReason ?? null,
     stdoutTail: tail(stringValue(output.stdout), 4_000),
     stderrTail: tail(stderr, 4_000),
@@ -126,6 +144,7 @@ async function executeWithStreaming(
   timeout: number,
   streamId: string,
   classification: ReturnType<typeof classifyBashCommand>,
+  commandPolicyMode: CommandPolicyMode,
 ): Promise<BashToolOutput | BashToolErrorOutput> {
   bashProgress.startStream(streamId);
 
@@ -180,6 +199,7 @@ async function executeWithStreaming(
       (exitCode !== null && exitCode !== 0);
     return {
       ok: !commandFailed,
+      commandPolicyMode,
       classification,
       riskCategories: classification.categories as string[],
       exitCode,
@@ -212,6 +232,7 @@ async function executeWithStreaming(
 
     return {
       ok: false as const,
+      commandPolicyMode,
       classification,
       riskCategories: classification.categories as string[],
       error,
@@ -239,6 +260,7 @@ async function executeWithStreaming(
 
 type BashToolOutput = {
   ok: boolean;
+  commandPolicyMode: CommandPolicyMode;
   classification: ReturnType<typeof classifyBashCommand>;
   riskCategories: string[];
   exitCode: number | null;
@@ -253,6 +275,7 @@ type BashToolOutput = {
 
 type BashToolErrorOutput = {
   ok: false;
+  commandPolicyMode: CommandPolicyMode;
   classification: ReturnType<typeof classifyBashCommand>;
   riskCategories: string[];
   error: string;
@@ -306,6 +329,10 @@ function numberOrNull(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) ? value : null;
 }
 
+function commandPolicyModeValue(value: unknown): CommandPolicyMode {
+  return value === "advisory" ? "advisory" : "enforced";
+}
+
 function tail(value: string, maxLength: number): string {
   if (value.length <= maxLength) return value;
   return value.slice(value.length - maxLength);
@@ -319,7 +346,12 @@ function bashFailureCode(
   if (output.ok === true && exitCode === 0 && failedReason === undefined) {
     return "BASH_OK";
   }
-  if (output.ok === false && typeof output.error === "string" && exitCode === null) {
+  if (
+    output.ok === false &&
+    typeof output.error === "string" &&
+    exitCode === null &&
+    failedReason === undefined
+  ) {
     return "BASH_POLICY_REJECTED";
   }
   if (failedReason === "timeout") return "BASH_TIMEOUT";

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -163,7 +163,7 @@ export function createAntonTools({
     git_commit: createGitCommitTool(workspaceRoot),
     git_restore: createGitRestoreTool(workspaceRoot),
     revert_changes: createRevertChangesTool(workspaceRoot),
-    bash: createBashTool(workspaceRoot),
+    bash: createBashTool(workspaceRoot, permissionMode),
     inspect_project: createInspectProjectTool(workspaceRoot),
     verify: createVerifyTool(workspaceRoot, profile, {
       getEditedPaths: () => toolPolicy?.getEditedPathsSnapshot() ?? [],

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -517,6 +517,7 @@ export type BackgroundCommandPreflightResult = {
   allowed: boolean;
   risky: boolean;
   categories: string[];
+  commandPolicyMode: "enforced" | "advisory";
   reason: string;
 };
 

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -219,6 +219,7 @@ export type ApprovalMetadata = {
   };
   command?: {
     command: string;
+    commandPolicyMode?: "enforced" | "advisory";
     shell: string;
     cwd: string;
     timeoutMs: number;
@@ -238,6 +239,7 @@ export type ApprovalMetadata = {
     categories: string[];
     forbidden: boolean;
     reason: string;
+    commandPolicyMode?: "enforced" | "advisory";
   };
 };
 
@@ -271,6 +273,9 @@ export function getApprovalMetadata(
       categories,
       forbidden: Boolean((bashDetails as Record<string, unknown>).forbidden),
       reason: (bashDetails as Record<string, unknown>).reason as string,
+      commandPolicyMode: commandPolicyModeValue(
+        (bashDetails as Record<string, unknown>).commandPolicyMode,
+      ),
     };
   }
   return {
@@ -488,7 +493,12 @@ function structuredApprovalMetadata(value: unknown): ApprovalMetadata | undefine
     diffPreview: structuredDiffPreview(record.diffPreview),
     command,
     external: structuredExternalMetadata(record.external),
-    bashClassification: command?.classification,
+    bashClassification: command
+      ? {
+          ...command.classification,
+          commandPolicyMode: command.commandPolicyMode,
+        }
+      : undefined,
   };
 }
 
@@ -600,6 +610,7 @@ function structuredCommandMetadata(
   }
   return {
     command: record.command,
+    commandPolicyMode: commandPolicyModeValue(record.commandPolicyMode),
     shell: record.shell,
     cwd: record.cwd,
     timeoutMs: record.timeoutMs,
@@ -619,6 +630,12 @@ function structuredClassification(
     forbidden: Boolean(record.forbidden),
     reason: record.reason,
   };
+}
+
+function commandPolicyModeValue(
+  value: unknown,
+): "enforced" | "advisory" | undefined {
+  return value === "enforced" || value === "advisory" ? value : undefined;
 }
 
 function structuredExternalMetadata(

--- a/src/workspace/background-commands.ts
+++ b/src/workspace/background-commands.ts
@@ -8,7 +8,12 @@ import {
   buildBashEnvironment,
   evaluateBashCommandPolicy,
 } from "@/src/agent/command-policy";
-import type { ToolRiskCategory } from "@/src/agent/permissions";
+import {
+  commandPolicyModeForPermission,
+  type CommandPolicyMode,
+  type PermissionMode,
+  type ToolRiskCategory,
+} from "@/src/agent/permissions";
 import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
 import {
   detectPackageManager,
@@ -71,6 +76,7 @@ export type PreflightBackgroundCommandResult =
       allowed: boolean;
       risky: boolean;
       categories: ToolRiskCategory[];
+      commandPolicyMode: CommandPolicyMode;
       reason: string;
     }
   | { ok: false; error: string; status?: number };
@@ -78,6 +84,7 @@ export type PreflightBackgroundCommandResult =
 export function preflightProjectBackgroundCommand(
   projectRoot: string,
   command: string,
+  permissionMode: PermissionMode = "auto-review",
 ): PreflightBackgroundCommandResult {
   ensureBootstrapped();
   const trimmed = command.trim();
@@ -87,23 +94,28 @@ export function preflightProjectBackgroundCommand(
 
   const root = ensureWorkspaceRootAt(projectRoot);
   const policy = evaluateBashCommandPolicy(trimmed, { workspaceRoot: root });
+  const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
   const categories = [...policy.classification.categories];
-  if (!policy.allowed) {
+  if (commandPolicyMode === "enforced" && !policy.allowed) {
     return {
       ok: true,
       allowed: false,
       risky: false,
       categories,
+      commandPolicyMode,
       reason: policy.reason,
     };
   }
 
-  const risky = categories.some((category) => category !== "read-only");
+  const risky =
+    commandPolicyMode === "enforced" &&
+    categories.some((category) => category !== "read-only");
   return {
     ok: true,
     allowed: true,
     risky,
     categories,
+    commandPolicyMode,
     reason: policy.classification.reason,
   };
 }
@@ -145,6 +157,7 @@ export async function startProjectBackgroundCommand(
   projectId: string,
   projectRoot: string,
   input: StartBackgroundCommandInput,
+  permissionMode: PermissionMode = "auto-review",
 ): Promise<StartBackgroundCommandResult> {
   ensureBootstrapped();
   const root = ensureWorkspaceRootAt(projectRoot);
@@ -176,7 +189,8 @@ export async function startProjectBackgroundCommand(
       return { ok: false, error: "Command is required.", status: 400 };
     }
     const policy = evaluateBashCommandPolicy(command, { workspaceRoot: root });
-    if (!policy.allowed) {
+    const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
+    if (commandPolicyMode === "enforced" && !policy.allowed) {
       return { ok: false, error: policy.reason, status: 403 };
     }
     spawnArgs = { file: "bash", args: ["-lc", command], shell: false };
@@ -265,6 +279,7 @@ export async function restartProjectBackgroundCommand(
   projectId: string,
   commandId: string,
   projectRoot: string,
+  permissionMode: PermissionMode = "auto-review",
 ): Promise<StartBackgroundCommandResult> {
   ensureBootstrapped();
   const session = getProjectBackgroundCommand(projectId, commandId);
@@ -292,7 +307,7 @@ export async function restartProjectBackgroundCommand(
   userStopRequestedSessions.delete(commandId);
 
   const root = ensureWorkspaceRootAt(projectRoot);
-  const spawnArgs = spawnArgsForSession(session, root);
+  const spawnArgs = spawnArgsForSession(session, root, permissionMode);
   if (!spawnArgs.ok) {
     return { ok: false, error: spawnArgs.error, status: 400 };
   }
@@ -691,12 +706,14 @@ function finalizeProcess(
 function spawnArgsForSession(
   session: BackgroundCommandSession,
   root: string,
+  permissionMode: PermissionMode,
 ):
   | { ok: true; value: { file: string; args: string[]; shell?: false } }
   | { ok: false; error: string } {
   if (session.commandKind === "custom") {
     const policy = evaluateBashCommandPolicy(session.command, { workspaceRoot: root });
-    if (!policy.allowed) {
+    const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
+    if (commandPolicyMode === "enforced" && !policy.allowed) {
       return { ok: false, error: policy.reason };
     }
     return {


### PR DESCRIPTION
## Summary
- Makes native `bash` execution receive the active permission mode and treats command policy as advisory in `full-access` while preserving enforcement in `default` and `auto-review`.
- Carries `commandPolicyMode: "enforced" | "advisory"` through bash output, approval/audit metadata, trace parsing, and Worklog terminal display.
- Applies the same mode-aware policy behavior to custom background command preflight/start/restart using the workspace default permission mode.
- Narrows the roadmap shell-policy risk note to reflect that `full-access` intentionally bypasses command policy while normal modes still use heuristic classification.

Closes #148.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- Manual policy check with `printenv PATH`: `auto-review` => `policyMode=enforced`, `executionBlocked=true`; `full-access` => `policyMode=advisory`, `executionBlocked=false`.
- Terminal parser check preserved `commandPolicyMode: "advisory"` from bash output.

## Notes
- No active tool names, bash input schema, or system prompt were changed. The bash constructor and runtime metadata changed only.
- Direct ad-hoc execution of the full `bash` tool/background helper through `tsx` was blocked by a local package export resolution error in the runner before Anton code executed (`unicorn-magic` via `npm-run-path`). Typecheck/lint and the shared policy-mode logic verified cleanly.
