### PR TITLE
feat: add Docker + ONCE deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+.git
+.gitignore
+.env*
+workspace
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+docker
+.github
+scripts
+ROADMAP.md
+AGENTS.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+*.sh text eol=lf
+docker/hooks/* text eol=lf
+Dockerfile text eol=lf
+.github/workflows/*.yml text eol=lf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint-and-typecheck
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM node:22-slim AS deps
+RUN apt-get update && apt-get install -y --no-install-recommends python3 make g++ git && rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:22-slim AS builder
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+FROM node:22-slim AS runner
+RUN apt-get update && apt-get install -y --no-install-recommends git bash sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN npm install -g tsx
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV HOSTNAME=0.0.0.0
+ENV PORT=80
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+RUN ln -s $(find /app/node_modules/.pnpm -maxdepth 1 -type d -name 'drizzle-orm@*' | head -1)/node_modules/drizzle-orm /app/node_modules/drizzle-orm
+
+COPY --from=builder /app/src/db/migrations ./src/db/migrations
+COPY --from=builder /app/src/db/schema.ts ./src/db/schema.ts
+COPY --from=builder /app/src/db/migrate.ts ./src/db/migrate.ts
+COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY docker/hooks/pre-backup /hooks/pre-backup
+RUN chmod +x /hooks/pre-backup
+
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/app/up/route.ts
+++ b/app/up/route.ts
@@ -1,0 +1,5 @@
+export const runtime = "nodejs";
+
+export function GET() {
+  return new Response("OK", { status: 200 });
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+export DATABASE_URL="${DATABASE_URL:-/storage/anton.db}"
+export WORKSPACE_ROOT="${WORKSPACE_ROOT:-/storage/workspace}"
+export ANTON_LOCAL_WORKSPACES_ROOT="${ANTON_LOCAL_WORKSPACES_ROOT:-/storage/workspaces}"
+
+mkdir -p "$(dirname "$DATABASE_URL")"
+mkdir -p "$WORKSPACE_ROOT"
+mkdir -p "$ANTON_LOCAL_WORKSPACES_ROOT"
+
+echo "[entrypoint] running migrations against $DATABASE_URL"
+tsx src/db/migrate.ts
+
+echo "[entrypoint] starting server on $HOSTNAME:$PORT"
+exec node server.js

--- a/docker/hooks/pre-backup
+++ b/docker/hooks/pre-backup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+DB_PATH="${DATABASE_URL:-/storage/anton.db}"
+if [ -f "$DB_PATH" ]; then
+  sqlite3 "$DB_PATH" ".backup '/storage/anton-backup.db'"
+fi

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
+  serverExternalPackages: ["better-sqlite3", "drizzle-orm"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds Docker containerization and ONCE platform compatibility for self-hosted deployment on OCI VM.

## Changes

- **Dockerfile**: Multi-stage build (deps, builder, standalone runner) with node:22-slim, better-sqlite3 native compilation, bash, git, sqlite3
- **/up health check**: ONCE-required health endpoint returning HTTP 200
- **docker/entrypoint.sh**: Runs Drizzle migrations then starts server.js; defaults DATABASE_URL, WORKSPACE_ROOT, ANTON_LOCAL_WORKSPACES_ROOT to /storage (ONCE persistent volume)
- **docker/hooks/pre-backup**: SQLite online backup hook for ONCE backup system
- **next.config.ts**: output standalone for slim Docker image + serverExternalPackages for better-sqlite3 and drizzle-orm
- **.github/workflows/docker.yml**: CI pipeline (lint + typecheck, then build + push to GHCR)
- **.gitattributes**: Enforces LF line endings for shell scripts and Docker files
- **.dockerignore**: Excludes dev artifacts from Docker build context

## Deployment Target

OCI VM (Oracle Linux) with Docker + ONCE, accessible via code.mrgb.com (Cloudflare DNS).

## Verification

- pnpm typecheck passes
- pnpm lint passes
- pnpm build produces standalone output at .next/standalone/server.js
- Build includes better-sqlite3 native binary and drizzle-orm in traced node_modules
