### PR TITLE
fix: approve all packages with build scripts for pnpm v10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,11 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3"
+      "better-sqlite3",
+      "esbuild",
+      "msw",
+      "sharp",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes CI failure in the Docker build workflow where `pnpm install --frozen-lockfile` fails with `ERR_PNPM_IGNORED_BUILDS`.

## Problem

pnpm v10+ blocks all package install scripts by default unless explicitly approved via `onlyBuiltDependencies`. The CI workflow was failing because `esbuild`, `msw`, `sharp`, and `unrs-resolver` all have build scripts that weren't approved.

## Fix

Added the following packages to `pnpm.onlyBuiltDependencies` in `package.json`:
- `esbuild` (used by multiple dependencies)
- `msw` (Mock Service Worker)
- `sharp` (image processing)
- `unrs-resolver` (Rust-based resolver)

These are now approved alongside the existing `better-sqlite3` entry.

## Verification

- `pnpm typecheck` passes
- `pnpm lint` passes
- Local `pnpm install` succeeds without errors
