### PR TITLE
fix: add .npmrc with ignore-scripts=false for pnpm v10+ build approval

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 ignoredBuiltDependencies:
+  - msw
   - sharp
   - unrs-resolver


### PR DESCRIPTION
## Summary

Fixes CI failure where `pnpm install --frozen-lockfile` fails with `ERR_PNPM_IGNORED_BUILDS` error.

## Problem

pnpm v10+ blocks all package build scripts by default unless explicitly approved. The CI workflow was failing with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: better-sqlite3@12.9.0, esbuild@0.18.20, esbuild@0.25.12, esbuild@0.27.7, msw@2.13.6, sharp@0.34.5, unrs-resolver@1.11.1
```

Even with `onlyBuiltDependencies` configured in `package.json`, pnpm v10 still blocks build scripts by default and requires an explicit `.npmrc` override.

## Fix

- **Add `.npmrc`** with `ignore-scripts=false` to explicitly allow all build scripts to run. This overrides pnpm v10's default blocking behavior.
- **Add `msw` to `ignoredBuiltDependencies`** in `pnpm-workspace.yaml` since its postinstall script (service worker download) is not needed for production builds.

## Verification

- `pnpm typecheck` passes
- `pnpm lint` passes
- Local `pnpm install` succeeds (warning about msw is expected and harmless)
- CI workflow should now pass the `pnpm install --frozen-lockfile` step
