### PR TITLE
Fix GitHub clone certificate verification in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 FROM node:22-slim AS runner
-RUN apt-get update && apt-get install -y --no-install-recommends git bash sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git bash sqlite3 && rm -rf /var/lib/apt/lists/*
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable && corepack prepare pnpm@10.13.1 --activate


### PR DESCRIPTION
## Summary
- Install ca-certificates in the Docker runner stage alongside git.
- Keep clone/fetch command behavior and GitHub token header handling unchanged.

## Verification
- pnpm typecheck
- pnpm lint
- git diff --check

## Deployment note
After merge, rebuild and redeploy the container image so the runtime has the updated CA trust store.

Fixes #155