### PR TITLE
Harden bash command policy analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,6 +78,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Scrub shell environment by default and pass only an allowlist of required variables.
 - [✔️] Add command policy checks for absolute paths, shell redirection outside workspace, destructive filesystem operations, network access, and secret-printing commands.
 - [✔️] Replace the current `sudo`/`su` denylist with a parser-backed or policy-backed command classifier.
+- [✔️] Harden parser-backed shell command policy against complex shell syntax, redirection escapes, destructive git/force-push commands, and nested shell bypasses (#160).
 - [✔️] Add secret redaction for tool inputs, tool outputs, logs, and UI rendering.
 - [✔️] Add workspace-root validation that prevents using Anton source, `.git`, dependency folders, build output, system directories, and user home as agent workspaces.
 - [✔️] Harden sandbox traversal, symlink escape, workspace root validation, and command policy behavior.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1587,7 +1587,9 @@ function createTraceWriter({
       }
 
       if (event.toolName === "bash") {
-        const classification = preClassifyBashInput(event.input);
+        const classification = preClassifyBashInput(event.input, {
+          workspaceRoot,
+        });
         const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
         details.commandPolicyMode = commandPolicyMode;
         if (classification) {

--- a/src/agent/command-policy.ts
+++ b/src/agent/command-policy.ts
@@ -19,6 +19,53 @@ export type BashCommandPolicyDecision =
       reason: string;
     };
 
+type ShellOperator = "&&" | "||" | ";" | "|" | "&";
+type ShellRedirectionOperator = ">" | ">>" | "<" | "2>" | "2>>";
+
+type ShellToken = {
+  value: string;
+  raw: string;
+  hadExpansion: boolean;
+};
+
+type ParsedItem =
+  | { kind: "token"; token: ShellToken }
+  | { kind: "operator"; operator: ShellOperator }
+  | { kind: "redirection"; operator: ShellRedirectionOperator };
+
+type ShellRedirection = {
+  operator: ShellRedirectionOperator;
+  target?: ShellToken;
+};
+
+type ShellSegment = {
+  raw: string;
+  tokens: ShellToken[];
+  argv: ShellToken[];
+  executable?: ShellToken;
+  redirections: ShellRedirection[];
+};
+
+type ShellAnalysis = {
+  segments: ShellSegment[];
+  operators: ShellOperator[];
+  redirections: ShellRedirection[];
+  unsupportedReasons: string[];
+  securityRelevantUnsupported: boolean;
+  targetSensitiveUnsupported: boolean;
+};
+
+type ShellTokenizerResult = {
+  items: ParsedItem[];
+  unsupportedReasons: string[];
+  securityRelevantUnsupported: boolean;
+};
+
+type UnsupportedCollector = {
+  reasons: string[];
+  securityRelevant: boolean;
+};
+
 const RISK_CATEGORY_ORDER: readonly ToolRiskCategory[] = [
   "read-only",
   "write",
@@ -58,6 +105,132 @@ const READ_ONLY_COMMANDS = new Set([
   "which",
 ]);
 
+const SECRET_READER_COMMANDS = new Set([
+  "awk",
+  "cat",
+  "grep",
+  "head",
+  "less",
+  "more",
+  "rg",
+  "sed",
+  "tail",
+  "type",
+]);
+
+const WRITE_COMMANDS = new Set([
+  "chmod",
+  "chown",
+  "cp",
+  "install",
+  "mkdir",
+  "mv",
+  "tee",
+  "touch",
+  "truncate",
+]);
+
+const DELETE_COMMANDS = new Set(["rm", "rmdir", "unlink"]);
+
+const NETWORK_COMMANDS = new Set([
+  "curl",
+  "ftp",
+  "nc",
+  "netcat",
+  "rsync",
+  "scp",
+  "sftp",
+  "ssh",
+  "telnet",
+  "wget",
+]);
+
+const EXTERNAL_INTEGRATION_COMMANDS = new Set([
+  "aws",
+  "az",
+  "docker",
+  "docker-compose",
+  "flyctl",
+  "gcloud",
+  "gh",
+  "kubectl",
+  "netlify",
+  "railway",
+  "stripe",
+  "supabase",
+  "vercel",
+]);
+
+const PACKAGE_MANAGERS = new Set(["bun", "npm", "pnpm", "yarn"]);
+const PACKAGE_INSTALL_SUBCOMMANDS = new Set([
+  "add",
+  "create",
+  "dlx",
+  "i",
+  "init",
+  "install",
+  "remove",
+  "rm",
+  "update",
+  "upgrade",
+]);
+const LONG_RUNNING_PACKAGE_COMMANDS = new Set([
+  "dev",
+  "preview",
+  "serve",
+  "start",
+  "watch",
+]);
+const LONG_RUNNING_COMMANDS = new Set([
+  "htop",
+  "less",
+  "more",
+  "top",
+  "watch",
+]);
+const JS_TOOL_COMMANDS = new Set(["next", "turbo", "vite", "webpack"]);
+
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  "diff",
+  "log",
+  "ls-files",
+  "rev-parse",
+  "show",
+  "status",
+]);
+const WRITE_GIT_SUBCOMMANDS = new Set([
+  "add",
+  "am",
+  "apply",
+  "checkout",
+  "cherry-pick",
+  "commit",
+  "merge",
+  "mv",
+  "rebase",
+  "restore",
+  "revert",
+  "switch",
+  "tag",
+]);
+const NETWORK_GIT_SUBCOMMANDS = new Set([
+  "clone",
+  "fetch",
+  "ls-remote",
+  "pull",
+  "push",
+]);
+
+const NESTED_SHELL_COMMANDS = new Set([
+  "bash",
+  "cmd",
+  "fish",
+  "powershell",
+  "pwsh",
+  "sh",
+  "zsh",
+]);
+
 const BASH_ENV_ALLOWLIST = new Set([
   "CI",
   "COLORTERM",
@@ -83,11 +256,6 @@ const BASH_ENV_ALLOWLIST = new Set([
   "windir",
 ]);
 
-const FORBIDDEN_COMMAND_PATTERNS: readonly RegExp[] = [
-  /(^|\s|;|&&|\|\|)\s*sudo(\s|$)/,
-  /(^|\s|;|&&|\|\|)\s*su(\s|$)/,
-];
-
 const SECRET_FILE_RE =
   /(^|[\s/\\])(?:\.env(?:\.[^/\\\s]+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|[^/\\\s]*(?:token|secret|credential|private[-_]?key)[^/\\\s]*)(?:$|\s)/i;
 const SECRET_NAME_RE =
@@ -103,28 +271,37 @@ export function classifyBashCommand(command: string): BashCommandClassification 
     };
   }
 
-  const forbidden = forbiddenPattern(normalized);
-  if (forbidden) {
-    return {
-      categories: ["external-integration"],
-      forbidden: true,
-      reason: `forbidden command pattern: ${forbidden}`,
-    };
+  const analysis = analyzeShellCommand(normalized);
+  const categories = new Set<ToolRiskCategory>();
+  let allSegmentsReadOnly = analysis.segments.length > 0;
+
+  for (const operator of analysis.operators) {
+    if (operator === "&") {
+      categories.add("long-running-process");
+      allSegmentsReadOnly = false;
+    }
   }
 
-  const categories = new Set<ToolRiskCategory>();
-  if (isGitCommand(normalized)) categories.add("git");
-  if (hasNetworkPattern(normalized)) categories.add("network");
-  if (hasPackageInstallPattern(normalized)) categories.add("package-install");
-  if (hasLongRunningPattern(normalized)) categories.add("long-running-process");
-  if (hasDeletePattern(normalized)) categories.add("delete");
-  if (hasWritePattern(normalized)) categories.add("write");
-  if (hasExternalIntegrationPattern(normalized)) categories.add("external-integration");
+  for (const redirection of analysis.redirections) {
+    if (isWriteRedirection(redirection.operator)) {
+      categories.add("write");
+      allSegmentsReadOnly = false;
+    }
+  }
 
-  if (
-    isReadOnlyShellCommand(normalized) &&
-    (categories.size === 0 || (categories.size === 1 && categories.has("git")))
-  ) {
+  for (const segment of analysis.segments) {
+    const segmentReadOnly = classifySegment(segment, categories);
+    if (!segmentReadOnly) {
+      allSegmentsReadOnly = false;
+    }
+  }
+
+  if (analysis.unsupportedReasons.length > 0) {
+    categories.add("write");
+    allSegmentsReadOnly = false;
+  }
+
+  if (allSegmentsReadOnly) {
     categories.add("read-only");
   } else if (categories.size === 0) {
     categories.add("write");
@@ -134,7 +311,10 @@ export function classifyBashCommand(command: string): BashCommandClassification 
   return {
     categories: orderedCategories,
     forbidden: false,
-    reason: reasonForCategories(orderedCategories),
+    reason:
+      analysis.unsupportedReasons.length > 0
+        ? unsupportedReason(analysis.unsupportedReasons)
+        : reasonForCategories(orderedCategories),
   };
 }
 
@@ -143,11 +323,8 @@ export function evaluateBashCommandPolicy(
   options: { workspaceRoot?: string } = {},
 ): BashCommandPolicyDecision {
   const classification = classifyBashCommand(command);
-  if (classification.forbidden) {
-    return { allowed: false, classification, reason: classification.reason };
-  }
-
-  const violation = firstPolicyViolation(command, options.workspaceRoot);
+  const analysis = analyzeShellCommand(command.trim());
+  const violation = firstPolicyViolation(analysis, options.workspaceRoot);
   if (violation) {
     return {
       allowed: false,
@@ -171,72 +348,593 @@ export function buildBashEnvironment(
   return env;
 }
 
+function analyzeShellCommand(command: string): ShellAnalysis {
+  const tokenized = tokenizeShell(command);
+  const collector: UnsupportedCollector = {
+    reasons: [...tokenized.unsupportedReasons],
+    securityRelevant: tokenized.securityRelevantUnsupported,
+  };
+  const segments: ShellSegment[] = [];
+  const operators: ShellOperator[] = [];
+  const redirections: ShellRedirection[] = [];
+  let currentItems: ParsedItem[] = [];
+
+  const pushCurrentSegment = () => {
+    const segment = buildSegment(currentItems);
+    if (segment) {
+      segments.push(segment);
+      redirections.push(...segment.redirections);
+    }
+    currentItems = [];
+  };
+
+  for (let i = 0; i < tokenized.items.length; i += 1) {
+    const item = tokenized.items[i];
+    if (!item) continue;
+
+    if (item.kind === "operator") {
+      pushCurrentSegment();
+      operators.push(item.operator);
+      continue;
+    }
+
+    if (item.kind === "redirection") {
+      const next = tokenized.items[i + 1];
+      currentItems.push(item);
+      if (next?.kind === "token") {
+        currentItems.push(next);
+        i += 1;
+      } else {
+        collectUnsupported(
+          collector,
+          "missing redirection target",
+          true,
+        );
+      }
+      continue;
+    }
+
+    currentItems.push(item);
+  }
+
+  pushCurrentSegment();
+
+  let targetSensitiveUnsupported = false;
+  for (const segment of segments) {
+    if (segment.executable?.hadExpansion) {
+      collectUnsupported(
+        collector,
+        "variable expansion in executable",
+        true,
+      );
+    }
+    if (isNestedShellExecution(segment)) {
+      collectUnsupported(collector, "nested shell execution", true);
+    }
+
+    for (const redirection of segment.redirections) {
+      if (redirection.target?.hadExpansion) {
+        targetSensitiveUnsupported = true;
+        collectUnsupported(
+          collector,
+          "variable expansion in redirection target",
+          false,
+        );
+      }
+    }
+
+    if (hasVariableExpandedPathTarget(segment)) {
+      targetSensitiveUnsupported = true;
+      collectUnsupported(
+        collector,
+        "variable expansion in path-sensitive target",
+        false,
+      );
+    }
+  }
+
+  return {
+    segments,
+    operators,
+    redirections,
+    unsupportedReasons: collector.reasons,
+    securityRelevantUnsupported: collector.securityRelevant,
+    targetSensitiveUnsupported,
+  };
+}
+
+function tokenizeShell(command: string): ShellTokenizerResult {
+  const items: ParsedItem[] = [];
+  const collector: UnsupportedCollector = {
+    reasons: [],
+    securityRelevant: false,
+  };
+  let value = "";
+  let raw = "";
+  let quote: "single" | "double" | null = null;
+  let hadExpansion = false;
+
+  const flushToken = () => {
+    if (!raw) return;
+    items.push({
+      kind: "token",
+      token: {
+        value,
+        raw,
+        hadExpansion,
+      },
+    });
+    value = "";
+    raw = "";
+    hadExpansion = false;
+  };
+
+  const pushOperator = (operator: ShellOperator) => {
+    flushToken();
+    items.push({ kind: "operator", operator });
+  };
+
+  const pushRedirection = (operator: ShellRedirectionOperator) => {
+    flushToken();
+    items.push({ kind: "redirection", operator });
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i];
+    if (char === undefined) continue;
+    const next = command[i + 1];
+    const afterNext = command[i + 2];
+
+    if (quote === null) {
+      if (/\s/.test(char)) {
+        flushToken();
+        continue;
+      }
+
+      if (char === "'" || char === '"') {
+        quote = char === "'" ? "single" : "double";
+        raw += char;
+        continue;
+      }
+
+      if (char === "$" && next === "(") {
+        collectUnsupported(collector, "command substitution", true);
+        hadExpansion = true;
+        value += "$(";
+        raw += "$(";
+        i += 1;
+        continue;
+      }
+
+      if (char === "`") {
+        collectUnsupported(collector, "command substitution", true);
+        hadExpansion = true;
+        value += char;
+        raw += char;
+        continue;
+      }
+
+      if ((char === "<" || char === ">") && next === "(") {
+        collectUnsupported(collector, "process substitution", true);
+        value += `${char}(`;
+        raw += `${char}(`;
+        i += 1;
+        continue;
+      }
+
+      if (char === "<" && next === "<") {
+        collectUnsupported(
+          collector,
+          afterNext === "<" ? "here-string" : "here-doc",
+          true,
+        );
+        flushToken();
+        i += afterNext === "<" ? 2 : 1;
+        continue;
+      }
+
+      if (char === "2" && next === ">") {
+        pushRedirection(afterNext === ">" ? "2>>" : "2>");
+        i += afterNext === ">" ? 2 : 1;
+        continue;
+      }
+
+      if (char === ">") {
+        pushRedirection(next === ">" ? ">>" : ">");
+        if (next === ">") i += 1;
+        continue;
+      }
+
+      if (char === "<") {
+        pushRedirection("<");
+        continue;
+      }
+
+      if (char === "&" && next === "&") {
+        pushOperator("&&");
+        i += 1;
+        continue;
+      }
+
+      if (char === "|" && next === "|") {
+        pushOperator("||");
+        i += 1;
+        continue;
+      }
+
+      if (char === "|" && next === "&") {
+        collectUnsupported(collector, "stderr pipe operator", true);
+        pushOperator("|");
+        i += 1;
+        continue;
+      }
+
+      if (char === "|" || char === ";" || char === "&") {
+        pushOperator(char);
+        continue;
+      }
+
+      if (char === "(" || char === ")") {
+        collectUnsupported(collector, "subshell or group expression", true);
+        value += char;
+        raw += char;
+        continue;
+      }
+
+      if (char === "$") {
+        hadExpansion = true;
+      }
+    } else {
+      if (quote === "single" && char === "'") {
+        quote = null;
+        raw += char;
+        continue;
+      }
+
+      if (quote === "double" && char === '"') {
+        quote = null;
+        raw += char;
+        continue;
+      }
+
+      if (quote === "double") {
+        if (char === "$" && next === "(") {
+          collectUnsupported(collector, "command substitution", true);
+          hadExpansion = true;
+          value += "$(";
+          raw += "$(";
+          i += 1;
+          continue;
+        }
+        if (char === "`") {
+          collectUnsupported(collector, "command substitution", true);
+          hadExpansion = true;
+        }
+        if (char === "$") {
+          hadExpansion = true;
+        }
+      }
+    }
+
+    if (char === "\\" && quote !== "single") {
+      const escaped = command[i + 1];
+      if (escaped !== undefined) {
+        value += escaped;
+        raw += `${char}${escaped}`;
+        i += 1;
+        continue;
+      }
+    }
+
+    value += char;
+    raw += char;
+  }
+
+  if (quote !== null) {
+    collectUnsupported(collector, "unclosed quote", true);
+  }
+  flushToken();
+
+  return {
+    items,
+    unsupportedReasons: collector.reasons,
+    securityRelevantUnsupported: collector.securityRelevant,
+  };
+}
+
+function buildSegment(items: readonly ParsedItem[]): ShellSegment | null {
+  if (items.length === 0) return null;
+
+  const tokens: ShellToken[] = [];
+  const redirections: ShellRedirection[] = [];
+  const rawParts: string[] = [];
+
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (!item) continue;
+
+    if (item.kind === "token") {
+      tokens.push(item.token);
+      rawParts.push(item.token.raw);
+      continue;
+    }
+
+    if (item.kind === "redirection") {
+      const next = items[i + 1];
+      const target = next?.kind === "token" ? next.token : undefined;
+      redirections.push({ operator: item.operator, target });
+      rawParts.push(item.operator);
+      if (target) {
+        rawParts.push(target.raw);
+        i += 1;
+      }
+    }
+  }
+
+  const executableIndex = tokens.findIndex(
+    (token) => !isShellAssignment(token.value),
+  );
+  const executable =
+    executableIndex >= 0 ? tokens[executableIndex] : undefined;
+  const argv = executableIndex >= 0 ? tokens.slice(executableIndex) : [];
+
+  return {
+    raw: rawParts.join(" "),
+    tokens,
+    argv,
+    executable,
+    redirections,
+  };
+}
+
+function classifySegment(
+  segment: ShellSegment,
+  categories: Set<ToolRiskCategory>,
+): boolean {
+  const executableName = executableNameForSegment(segment);
+  if (!executableName) {
+    if (segment.redirections.some((redirect) => isWriteRedirection(redirect.operator))) {
+      categories.add("write");
+    }
+    return false;
+  }
+
+  if (DELETE_COMMANDS.has(executableName)) {
+    categories.add("delete");
+    return false;
+  }
+
+  if (WRITE_COMMANDS.has(executableName)) {
+    categories.add("write");
+    return false;
+  }
+
+  if (NETWORK_COMMANDS.has(executableName)) {
+    categories.add("network");
+    categories.add("external-integration");
+    return false;
+  }
+
+  if (EXTERNAL_INTEGRATION_COMMANDS.has(executableName)) {
+    categories.add("external-integration");
+    if (executableName === "gh") categories.add("network");
+    return false;
+  }
+
+  if (executableName === "git") {
+    return classifyGitSegment(segment, categories);
+  }
+
+  if (isPackageInstallSegment(executableName, segment)) {
+    categories.add("package-install");
+    categories.add("write");
+    return false;
+  }
+
+  if (isPackageLongRunningSegment(executableName, segment)) {
+    categories.add("long-running-process");
+    return false;
+  }
+
+  if (isLongRunningSegment(executableName, segment)) {
+    categories.add("long-running-process");
+    return false;
+  }
+
+  if (isInlineWriteSegment(executableName, segment)) {
+    categories.add("write");
+    return false;
+  }
+
+  if (executableName === "find" && hasArg(segment, "-delete")) {
+    categories.add("delete");
+    return false;
+  }
+
+  if (executableName === "find" && hasAnyArg(segment, ["-exec", "-execdir"])) {
+    categories.add("write");
+    return false;
+  }
+
+  if (READ_ONLY_COMMANDS.has(executableName)) {
+    return !segment.redirections.some((redirect) =>
+      isWriteRedirection(redirect.operator),
+    );
+  }
+
+  categories.add("write");
+  return false;
+}
+
+function classifyGitSegment(
+  segment: ShellSegment,
+  categories: Set<ToolRiskCategory>,
+): boolean {
+  categories.add("git");
+  const parsed = parseGitSubcommand(segment);
+  if (!parsed.subcommand) {
+    return false;
+  }
+
+  if (READ_ONLY_GIT_SUBCOMMANDS.has(parsed.subcommand)) {
+    return true;
+  }
+
+  if (parsed.subcommand === "branch") {
+    if (isReadOnlyGitBranch(parsed.args)) return true;
+    categories.add("write");
+    return false;
+  }
+
+  if (parsed.subcommand === "submodule" && parsed.args[0] === "update") {
+    categories.add("network");
+    categories.add("external-integration");
+    categories.add("write");
+    return false;
+  }
+
+  if (NETWORK_GIT_SUBCOMMANDS.has(parsed.subcommand)) {
+    categories.add("network");
+    categories.add("external-integration");
+    if (parsed.subcommand !== "ls-remote") {
+      categories.add("write");
+    }
+    return false;
+  }
+
+  if (parsed.subcommand === "clean") {
+    categories.add("delete");
+    return false;
+  }
+
+  if (parsed.subcommand === "reset") {
+    categories.add(hasAnyArgValue(parsed.args, ["--hard"]) ? "delete" : "write");
+    return false;
+  }
+
+  if (WRITE_GIT_SUBCOMMANDS.has(parsed.subcommand)) {
+    categories.add("write");
+    return false;
+  }
+
+  categories.add("write");
+  return false;
+}
+
 function firstPolicyViolation(
-  command: string,
+  analysis: ShellAnalysis,
   workspaceRoot: string | undefined,
 ): string | null {
-  const normalized = command.trim();
-  if (!normalized) return null;
-  if (printsEnvironment(normalized)) {
-    return "refuses commands that print the shell environment";
+  if (analysis.segments.length === 0) return null;
+
+  const unsupported = unsupportedSyntaxViolation(analysis);
+  if (unsupported) return unsupported;
+
+  for (const segment of analysis.segments) {
+    const executableName = executableNameForSegment(segment);
+    if (executableName === "sudo" || executableName === "su") {
+      return "refuses privileged shell commands";
+    }
+    if (executableName === "env" || executableName === "printenv" || executableName === "set") {
+      return "refuses commands that print the shell environment";
+    }
   }
-  if (readsSecretTarget(normalized)) {
-    return "refuses commands that read or search likely secret files or values";
-  }
+
   return (
-    destructiveTargetViolation(normalized) ??
-    absolutePathViolation(normalized) ??
-    redirectionViolation(normalized, workspaceRoot)
+    readsSecretTargetViolation(analysis) ??
+    destructiveTargetViolation(analysis) ??
+    gitPolicyViolation(analysis) ??
+    absolutePathViolation(analysis) ??
+    redirectionViolation(analysis, workspaceRoot)
   );
 }
 
-function forbiddenPattern(command: string): RegExp | null {
-  for (const re of FORBIDDEN_COMMAND_PATTERNS) {
-    if (re.test(command)) return re;
+function unsupportedSyntaxViolation(analysis: ShellAnalysis): string | null {
+  if (
+    !analysis.securityRelevantUnsupported &&
+    !analysis.targetSensitiveUnsupported
+  ) {
+    return null;
+  }
+  return unsupportedReason(analysis.unsupportedReasons);
+}
+
+function readsSecretTargetViolation(analysis: ShellAnalysis): string | null {
+  for (const segment of analysis.segments) {
+    const executableName = executableNameForSegment(segment);
+    if (!executableName || !SECRET_READER_COMMANDS.has(executableName)) {
+      continue;
+    }
+
+    for (const token of segment.argv.slice(1)) {
+      if (SECRET_FILE_RE.test(`${token.value} `) || SECRET_NAME_RE.test(token.value)) {
+        return "refuses commands that read or search likely secret files or values";
+      }
+    }
   }
   return null;
 }
 
-function printsEnvironment(command: string): boolean {
-  return splitCommandSegments(command).some((segment) =>
-    /^(?:env|printenv|set)(?:\s|$)/.test(segment),
-  );
-}
+function destructiveTargetViolation(analysis: ShellAnalysis): string | null {
+  for (const segment of analysis.segments) {
+    const executableName = executableNameForSegment(segment);
+    if (!executableName) continue;
+    if (executableName === "find" && hasArg(segment, "-delete")) {
+      for (const target of findSearchRoots(segment)) {
+        if (
+          isRootHomeCurrentOrParentTarget(target.value) ||
+          isWorkspaceWideGlob(target.value) ||
+          targetsParentDirectory(target.value)
+        ) {
+          return "refuses destructive filesystem commands aimed at root, home, parent, current directory, or workspace-wide wildcards";
+        }
+      }
+      continue;
+    }
+    if (!DELETE_COMMANDS.has(executableName)) continue;
 
-function readsSecretTarget(command: string): boolean {
-  return splitCommandSegments(command).some((segment) => {
-    if (!/^(?:cat|grep|head|tail|less|more|rg|sed|awk|type)\b/.test(segment)) {
-      return false;
-    }
-    return SECRET_FILE_RE.test(`${segment} `) || SECRET_NAME_RE.test(segment);
-  });
-}
+    for (const target of commandTargets(segment)) {
+      if (target.hadExpansion) {
+        return "refuses destructive filesystem commands with variable-expanded targets";
+      }
 
-function destructiveTargetViolation(command: string): string | null {
-  for (const segment of splitCommandSegments(command)) {
-    if (!/^(?:rm|unlink|rmdir)\b/.test(segment)) continue;
-    const targets = shellWords(segment).slice(1).filter((token) => !token.startsWith("-"));
-    if (
-      targets.some((token) =>
-        ["/", "\\", "~", ".", "..", "*", "./*", ".\\*"].includes(token),
-      )
-    ) {
-      return "refuses destructive filesystem commands aimed at root, home, parent, current directory, or workspace-wide wildcards";
+      if (isRootHomeCurrentOrParentTarget(target.value) || isWorkspaceWideGlob(target.value)) {
+        return "refuses destructive filesystem commands aimed at root, home, parent, current directory, or workspace-wide wildcards";
+      }
+
+      if (targetsParentDirectory(target.value)) {
+        return "refuses destructive filesystem commands targeting parent directories";
+      }
     }
-    if (targets.some((token) => token.startsWith("../") || token.startsWith("..\\"))) {
-      return "refuses destructive filesystem commands targeting parent directories";
-    }
-  }
-  if (/\bgit\s+(?:clean|reset\s+--hard)\b/.test(command)) {
-    return "refuses destructive git cleanup/reset commands";
   }
   return null;
 }
 
-function absolutePathViolation(command: string): string | null {
-  for (const token of shellWords(command)) {
-    if (isUrl(token) || token.startsWith("-")) continue;
-    if (isAbsoluteFilesystemPath(token)) {
+function gitPolicyViolation(analysis: ShellAnalysis): string | null {
+  for (const segment of analysis.segments) {
+    if (executableNameForSegment(segment) !== "git") continue;
+    const parsed = parseGitSubcommand(segment);
+    if (!parsed.subcommand) continue;
+
+    if (parsed.subcommand === "clean") {
+      return "refuses destructive git cleanup commands";
+    }
+
+    if (parsed.subcommand === "reset" && hasAnyArgValue(parsed.args, ["--hard"])) {
+      return "refuses destructive git reset commands";
+    }
+
+    if (parsed.subcommand === "push" && hasGitForcePushArg(parsed.args)) {
+      return "refuses force-push commands";
+    }
+  }
+  return null;
+}
+
+function absolutePathViolation(analysis: ShellAnalysis): string | null {
+  for (const token of allTokens(analysis)) {
+    if (isUrl(token.value) || token.value.startsWith("-")) continue;
+    if (isAbsoluteFilesystemPath(token.value)) {
       return "refuses absolute filesystem paths in shell commands";
     }
   }
@@ -244,19 +942,22 @@ function absolutePathViolation(command: string): string | null {
 }
 
 function redirectionViolation(
-  command: string,
+  analysis: ShellAnalysis,
   workspaceRoot: string | undefined,
 ): string | null {
-  const redirections = command.matchAll(/(?:^|[^<>])>{1,2}(?![>&])\s*([^;&|)\s]+)/g);
-  for (const match of redirections) {
-    const target = stripQuotes(match[1] ?? "");
-    if (!target || target === "/dev/null") continue;
-    if (target.startsWith("../") || target.startsWith("..\\")) {
+  for (const redirection of analysis.redirections) {
+    if (!isWriteRedirection(redirection.operator)) continue;
+    const target = redirection.target;
+    if (!target || target.value === "/dev/null") continue;
+    if (target.hadExpansion) {
+      return "refuses shell redirection with variable-expanded targets";
+    }
+    if (target.value === ".." || target.value.startsWith("../") || target.value.startsWith("..\\")) {
       return "refuses shell redirection outside the workspace";
     }
-    if (isAbsoluteFilesystemPath(target)) {
+    if (isAbsoluteFilesystemPath(target.value)) {
       if (!workspaceRoot) return "refuses absolute shell redirection targets";
-      if (!isInside(path.resolve(target), path.resolve(workspaceRoot))) {
+      if (!isInside(path.resolve(target.value), path.resolve(workspaceRoot))) {
         return "refuses shell redirection outside the workspace";
       }
     }
@@ -264,20 +965,316 @@ function redirectionViolation(
   return null;
 }
 
-function shellWords(command: string): string[] {
-  const words = command.match(/"[^"]*"|'[^']*'|[^\s;&|()]+/g) ?? [];
-  return words.map(stripQuotes);
+function executableNameForSegment(segment: ShellSegment): string | undefined {
+  const executable = segment.executable?.value;
+  if (!executable) return undefined;
+  const base = path.basename(executable).toLowerCase();
+  return base.endsWith(".exe") ? base.slice(0, -4) : base;
 }
 
-function splitCommandSegments(command: string): string[] {
-  return command
-    .split(/&&|\|\||[;|]/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+function isPackageInstallSegment(
+  executableName: string,
+  segment: ShellSegment,
+): boolean {
+  if (executableName === "npx") return true;
+  if (executableName === "pip" || executableName === "pip3") {
+    return segment.argv[1]?.value === "install";
+  }
+  if (executableName === "uv") {
+    const subcommand = segment.argv[1]?.value;
+    if (subcommand === "pip") return segment.argv[2]?.value === "install";
+    return subcommand !== undefined && ["add", "remove", "sync"].includes(subcommand);
+  }
+  if (executableName === "poetry") {
+    return hasAnyArgValue(segment.argv.slice(1).map((token) => token.value), [
+      "add",
+      "install",
+      "remove",
+      "update",
+    ]);
+  }
+  if (executableName === "cargo") return segment.argv[1]?.value === "install";
+  if (executableName === "go") {
+    return hasAnyArgValue(segment.argv.slice(1).map((token) => token.value), [
+      "get",
+      "install",
+    ]);
+  }
+  if (executableName === "gem") return segment.argv[1]?.value === "install";
+  if (executableName === "bundle") {
+    return hasAnyArgValue(segment.argv.slice(1).map((token) => token.value), [
+      "add",
+      "install",
+      "update",
+    ]);
+  }
+  if (executableName === "composer") {
+    return hasAnyArgValue(segment.argv.slice(1).map((token) => token.value), [
+      "install",
+      "remove",
+      "require",
+      "update",
+    ]);
+  }
+  if (!PACKAGE_MANAGERS.has(executableName)) return false;
+  const subcommand = packageSubcommand(segment);
+  return (
+    subcommand !== undefined &&
+    PACKAGE_INSTALL_SUBCOMMANDS.has(subcommand)
+  );
 }
 
-function stripQuotes(value: string): string {
-  return value.replace(/^["']|["']$/g, "");
+function isPackageLongRunningSegment(
+  executableName: string,
+  segment: ShellSegment,
+): boolean {
+  if (!PACKAGE_MANAGERS.has(executableName)) return false;
+  const subcommand = packageSubcommand(segment);
+  if (!subcommand) return false;
+  if (LONG_RUNNING_PACKAGE_COMMANDS.has(subcommand)) return true;
+  if (subcommand !== "run") return false;
+  const scriptName = segment.argv[2]?.value;
+  return scriptName !== undefined && LONG_RUNNING_PACKAGE_COMMANDS.has(scriptName);
+}
+
+function isLongRunningSegment(
+  executableName: string,
+  segment: ShellSegment,
+): boolean {
+  if (LONG_RUNNING_COMMANDS.has(executableName)) return true;
+  if (executableName === "tail" && hasShortFlag(segment, "f")) return true;
+  if (JS_TOOL_COMMANDS.has(executableName)) {
+    const subcommand = segment.argv[1]?.value;
+    return subcommand !== undefined && LONG_RUNNING_PACKAGE_COMMANDS.has(subcommand);
+  }
+  if (executableName === "nodemon" || executableName === "ts-node-dev") {
+    return true;
+  }
+  if (executableName === "tsx" && segment.argv[1]?.value === "watch") {
+    return true;
+  }
+  if (
+    (executableName === "python" || executableName === "python3") &&
+    segment.argv[1]?.value === "-m" &&
+    segment.argv[2]?.value === "http.server"
+  ) {
+    return true;
+  }
+  if (executableName === "sleep") {
+    const seconds = Number(segment.argv[1]?.value ?? "0");
+    return Number.isFinite(seconds) && seconds >= 30;
+  }
+  return false;
+}
+
+function isInlineWriteSegment(
+  executableName: string,
+  segment: ShellSegment,
+): boolean {
+  if ((executableName === "sed" || executableName === "perl") && hasShortFlag(segment, "i")) {
+    return true;
+  }
+  return false;
+}
+
+function parseGitSubcommand(segment: ShellSegment): {
+  subcommand?: string;
+  args: string[];
+} {
+  const args = segment.argv.slice(1).map((token) => token.value);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg) continue;
+    if (arg === "--") {
+      const subcommand = args[index + 1];
+      return subcommand
+        ? { subcommand: subcommand.toLowerCase(), args: args.slice(index + 2) }
+        : { args: [] };
+    }
+    if (!arg.startsWith("-")) {
+      return { subcommand: arg.toLowerCase(), args: args.slice(index + 1) };
+    }
+    if (gitGlobalOptionTakesValue(arg)) {
+      index += arg.includes("=") ? 0 : 1;
+    }
+  }
+  return { args: [] };
+}
+
+function gitGlobalOptionTakesValue(arg: string): boolean {
+  return (
+    arg === "-C" ||
+    arg === "-c" ||
+    arg === "--git-dir" ||
+    arg === "--namespace" ||
+    arg === "--work-tree" ||
+    arg.startsWith("--git-dir=") ||
+    arg.startsWith("--namespace=") ||
+    arg.startsWith("--work-tree=")
+  );
+}
+
+function isReadOnlyGitBranch(args: readonly string[]): boolean {
+  const writeFlags = new Set([
+    "-D",
+    "-M",
+    "-c",
+    "-d",
+    "-m",
+    "--copy",
+    "--delete",
+    "--move",
+  ]);
+  for (const arg of args) {
+    if (writeFlags.has(arg)) return false;
+    if (!arg.startsWith("-")) return false;
+  }
+  return true;
+}
+
+function packageSubcommand(segment: ShellSegment): string | undefined {
+  const candidate = segment.argv[1]?.value;
+  return candidate?.toLowerCase();
+}
+
+function hasShortFlag(segment: ShellSegment, flag: string): boolean {
+  return segment.argv
+    .slice(1)
+    .some((token) => token.value === `-${flag}` || /^-[A-Za-z]+$/.test(token.value) && token.value.includes(flag));
+}
+
+function hasArg(segment: ShellSegment, arg: string): boolean {
+  return segment.argv.some((token) => token.value === arg);
+}
+
+function hasAnyArg(segment: ShellSegment, args: readonly string[]): boolean {
+  return segment.argv.some((token) => args.includes(token.value));
+}
+
+function hasAnyArgValue(
+  values: readonly string[],
+  matches: readonly string[],
+): boolean {
+  return values.some((value) => matches.includes(value));
+}
+
+function hasGitForcePushArg(args: readonly string[]): boolean {
+  return args.some(
+    (arg) =>
+      arg === "-f" ||
+      arg === "--force" ||
+      arg === "--force-with-lease" ||
+      arg === "--mirror",
+  );
+}
+
+function commandTargets(segment: ShellSegment): ShellToken[] {
+  const targets: ShellToken[] = [];
+  let afterDoubleDash = false;
+  for (const token of segment.argv.slice(1)) {
+    if (!afterDoubleDash && token.value === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (!afterDoubleDash && token.value.startsWith("-")) continue;
+    targets.push(token);
+  }
+  return targets;
+}
+
+function findSearchRoots(segment: ShellSegment): ShellToken[] {
+  const roots: ShellToken[] = [];
+  for (const token of segment.argv.slice(1)) {
+    if (token.value === "--") continue;
+    if (
+      token.value.startsWith("-") ||
+      token.value === "!" ||
+      token.value === "(" ||
+      token.value === ")"
+    ) {
+      break;
+    }
+    roots.push(token);
+  }
+  return roots.length > 0
+    ? roots
+    : [{ value: ".", raw: ".", hadExpansion: false }];
+}
+
+function hasVariableExpandedPathTarget(segment: ShellSegment): boolean {
+  const executableName = executableNameForSegment(segment);
+  if (!executableName) return false;
+  if (
+    DELETE_COMMANDS.has(executableName) ||
+    WRITE_COMMANDS.has(executableName) ||
+    SECRET_READER_COMMANDS.has(executableName)
+  ) {
+    return commandTargets(segment).some((target) => target.hadExpansion);
+  }
+  return false;
+}
+
+function isNestedShellExecution(segment: ShellSegment): boolean {
+  const executableName = executableNameForSegment(segment);
+  if (!executableName || !NESTED_SHELL_COMMANDS.has(executableName)) {
+    return false;
+  }
+
+  if (executableName === "cmd") {
+    return segment.argv
+      .slice(1)
+      .some((token) => token.value.toLowerCase() === "/c");
+  }
+
+  if (executableName === "powershell" || executableName === "pwsh") {
+    return segment.argv.slice(1).some((token) => {
+      const value = token.value.toLowerCase();
+      return value === "-command" || value === "-c" || value === "/c";
+    });
+  }
+
+  return segment.argv.slice(1).some((token) => {
+    const value = token.value.toLowerCase();
+    return value === "-c" || value === "-lc" || value === "-cl";
+  });
+}
+
+function allTokens(analysis: ShellAnalysis): ShellToken[] {
+  return analysis.segments.flatMap((segment) => [
+    ...segment.tokens,
+    ...segment.redirections
+      .map((redirection) => redirection.target)
+      .filter((target): target is ShellToken => target !== undefined),
+  ]);
+}
+
+function isShellAssignment(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(value);
+}
+
+function isWriteRedirection(operator: ShellRedirectionOperator): boolean {
+  return operator === ">" || operator === ">>" || operator === "2>" || operator === "2>>";
+}
+
+function isRootHomeCurrentOrParentTarget(value: string): boolean {
+  return ["/", "\\", "~", ".", "..", "./", ".\\"].includes(value) ||
+    value.startsWith("~/");
+}
+
+function targetsParentDirectory(value: string): boolean {
+  return (
+    value.startsWith("../") ||
+    value.startsWith("..\\") ||
+    value.includes("/../") ||
+    value.includes("\\..\\")
+  );
+}
+
+function isWorkspaceWideGlob(value: string): boolean {
+  if (["*", "**", "./*", ".\\*", "./**", ".\\**"].includes(value)) {
+    return true;
+  }
+  return !/[\\/]/.test(value) && value.includes("*");
 }
 
 function isAbsoluteFilesystemPath(value: string): boolean {
@@ -310,106 +1307,26 @@ function orderedRiskCategories(
 
 function reasonForCategories(categories: readonly ToolRiskCategory[]): string {
   if (categories.length === 1 && categories[0] === "read-only") {
-    return "matched read-only command patterns";
+    return "matched read-only command structure";
   }
-  return `matched ${categories.join(", ")} command risk patterns`;
+  return `matched ${categories.join(", ")} command risk structure`;
 }
 
-function isGitCommand(command: string): boolean {
-  return /(^|[\s;&|()])git(\s|$)/.test(command);
+function unsupportedReason(reasons: readonly string[]): string {
+  const unique = [...new Set(reasons)];
+  if (unique.length === 0) return "unsupported shell syntax requires approval";
+  return `unsupported shell syntax requires approval: ${unique.join(", ")}`;
 }
 
-function hasNetworkPattern(command: string): boolean {
-  return (
-    /\b(?:curl|wget|ssh|scp|sftp|rsync|nc|netcat|telnet|ftp)\b/.test(command) ||
-    /\b(?:https?|ssh|git):\/\/\S+/.test(command) ||
-    /\bgit@[A-Za-z0-9_.-]+:[^\s]+/.test(command) ||
-    /\bgit\s+(?:clone|fetch|pull|push|ls-remote|submodule\s+update)\b/.test(
-      command,
-    ) ||
-    /\bgh\s+(?:api|auth|browse|codespace|gist|issue|pr|release|repo|run|workflow)\b/.test(
-      command,
-    )
-  );
-}
-
-function hasPackageInstallPattern(command: string): boolean {
-  return (
-    /\b(?:npm|pnpm|yarn|bun)\s+(?:install|i|add|remove|rm|update|upgrade|dlx|create|init)\b/.test(
-      command,
-    ) ||
-    /\bnpx\b/.test(command) ||
-    /\bpip3?\s+install\b/.test(command) ||
-    /\buv\s+(?:add|remove|sync|pip\s+install)\b/.test(command) ||
-    /\bpoetry\s+(?:add|install|remove|update)\b/.test(command) ||
-    /\bcargo\s+install\b/.test(command) ||
-    /\bgo\s+(?:get|install)\b/.test(command) ||
-    /\bgem\s+install\b/.test(command) ||
-    /\bbundle\s+(?:add|install|update)\b/.test(command) ||
-    /\bcomposer\s+(?:install|require|remove|update)\b/.test(command)
-  );
-}
-
-function hasLongRunningPattern(command: string): boolean {
-  return (
-    /(^|[\s;&|()])(?:watch|top|htop|less|more)\b/.test(command) ||
-    /\b(?:tail)\s+[^;&|]*\s-f\b/.test(command) ||
-    /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|preview|watch)\b/.test(
-      command,
-    ) ||
-    /\b(?:next|vite|webpack|turbo)\s+(?:dev|start|serve|preview|watch)\b/.test(
-      command,
-    ) ||
-    /\b(?:nodemon|tsx\s+watch|ts-node-dev)\b/.test(command) ||
-    /\bpython3?\s+-m\s+http\.server\b/.test(command) ||
-    /(^|[\s;&|()])sleep\s+(?:[3-9]\d|\d{3,})\b/.test(command) ||
-    /(^|[^&])&\s*(?:$|[#;])/.test(command)
-  );
-}
-
-function hasDeletePattern(command: string): boolean {
-  return (
-    /(^|[\s;&|()])(?:rm|unlink|rmdir)\b/.test(command) ||
-    /\bfind\b[^;&|]*\s-delete\b/.test(command) ||
-    /\bgit\s+(?:clean|reset\s+--hard)\b/.test(command)
-  );
-}
-
-function hasWritePattern(command: string): boolean {
-  return (
-    /(^|[^<>])>{1,2}(?![>&])/.test(command) ||
-    /(^|[\s;&|()])(?:tee|touch|mkdir|mv|cp|install|chmod|chown|truncate)\b/.test(
-      command,
-    ) ||
-    /\b(?:sed|perl)\s+[^;&|]*\s-i(?:\s|$)/.test(command) ||
-    /\bgit\s+(?:add|am|apply|checkout|cherry-pick|commit|merge|mv|rebase|restore|revert|switch|tag)\b/.test(
-      command,
-    ) ||
-    hasPackageInstallPattern(command)
-  );
-}
-
-function hasExternalIntegrationPattern(command: string): boolean {
-  return (
-    /\b(?:gh|aws|gcloud|az|vercel|netlify|flyctl|railway|supabase|stripe|kubectl|docker|docker-compose)\b/.test(
-      command,
-    ) || hasNetworkPattern(command)
-  );
-}
-
-function isReadOnlyShellCommand(command: string): boolean {
-  const segments = splitCommandSegments(command);
-  if (segments.length === 0) return true;
-
-  return segments.every((segment) => {
-    const executable = segment.match(/^([A-Za-z0-9_.-]+)/)?.[1];
-    if (!executable) return false;
-    if (executable === "git") {
-      return /\bgit\s+(?:status|diff|show|log|branch|rev-parse|ls-files)\b/.test(
-        segment,
-      );
-    }
-    if (executable === "find" && /\s-delete\b/.test(segment)) return false;
-    return READ_ONLY_COMMANDS.has(executable);
-  });
+function collectUnsupported(
+  collector: UnsupportedCollector,
+  reason: string,
+  securityRelevant: boolean,
+): void {
+  if (!collector.reasons.includes(reason)) {
+    collector.reasons.push(reason);
+  }
+  if (securityRelevant) {
+    collector.securityRelevant = true;
+  }
 }

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -14,6 +14,7 @@ import {
 import { planFormatCommand } from "./tools/format";
 import {
   classifyBashCommand as classifyBashCommandByPolicy,
+  evaluateBashCommandPolicy,
   type BashCommandClassification,
 } from "./command-policy";
 import { planVerification } from "./tools/verify";
@@ -314,11 +315,12 @@ export function stripApprovalFlags<TTools extends ToolSet>(
 
 export function preClassifyBashInput(
   input: unknown,
+  options: { workspaceRoot?: string } = {},
 ): BashCommandClassification | undefined {
   if (typeof input !== "object" || input === null) return undefined;
   const command = (input as Record<string, unknown>)["command"];
   if (typeof command !== "string") return undefined;
-  return classifyBashCommand(command);
+  return evaluateBashCommandPolicy(command, options).classification;
 }
 
 export function isMcpTool(name: string): boolean {
@@ -688,7 +690,8 @@ function buildBashApproval(
   const command = stringValue(input.command) ?? "";
   const timeoutMs = numberValue(input.timeoutMs) ?? BASH_DEFAULT_TIMEOUT_MS;
   const cwd = workspaceRootLabel(workspaceRoot);
-  const classification = classifyBashCommand(command);
+  const policy = evaluateBashCommandPolicy(command, { workspaceRoot });
+  const classification = policy.classification;
   const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
 
   return {
@@ -715,8 +718,8 @@ function buildBashApproval(
       `Classification: ${classification.reason}.`,
       commandPolicyMode === "advisory"
         ? "Full-access mode treats command policy classification as advisory; sandbox cwd, timeout, output limits, and redaction still apply."
-        : classification.forbidden
-        ? "This command matches a forbidden pattern and will be refused even if approved."
+        : !policy.allowed
+        ? "This command violates command policy and will be refused even if approved."
         : "Approval lets the command start; it does not bypass sandbox cwd, timeout, or output limits.",
     ],
   };


### PR DESCRIPTION
## Summary
- Replaces regex-only shell segmentation with a conservative command analyzer that tracks segments, operators, redirections, executables, argv, nested shells, and unsupported shell syntax.
- Applies evaluated command-policy metadata to bash approval previews and live trace classification so UI reasons match execution enforcement.
- Records the issue-scoped Phase 1 hardening item in `ROADMAP.md`.

Closes #160

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` / `git diff --cached --check` (passed; Git emitted Windows LF-to-CRLF working-copy warnings only)
- Manual direct policy probes for: `ls`, `pwd`, `rg x src`, read-only pipeline, secret reads/searches, environment printing, workspace and parent redirection, destructive filesystem targets, `find . -delete`, scoped `find src -name *.tmp -delete`, read-only git commands, destructive git reset/clean, force push, curl, package install commands, command substitution, backticks, nested shell execution, process substitution, here-doc, unclosed quote, variable executable, variable path target, and benign non-path variable echo.

## Notes
- No `bash` input schema, tool name, profile tool list, system prompt, or `activeTools` changes.
- Background command paths were source-verified to share `evaluateBashCommandPolicy(...)` for preflight, start, and restart. A direct ad-hoc `tsx` import of `src/workspace/background-commands.ts` was blocked by the existing Node 24/package-export issue before Anton code executed, so no background process was started for runtime probing.
- Visual verification: not applicable; no UI layout changes.