### PR TITLE
Centralize workspace process execution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,6 +182,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 
 - [✔️] Chat message input is still validated as `z.array(z.unknown())` before casting to `AntonUIMessage[]`.
 - [] Normal permission modes still use heuristic shell command classification; `full-access` intentionally treats command policy as advisory only.
+- [] Workspace process execution is centralized around cwd, environment allowlist, timeouts, output caps, and redaction, but does not provide OS-level confinement yet.
 - [✔️] MCP stdio server startup can execute configured commands before user approval.
 - [✔️] Full-file `write_file` replacement risk is resolved by patch-first editing.
 - [] Message persistence still deletes and reinserts the full session transcript in some recovery paths.

--- a/components/features/run-trace/approval-details.tsx
+++ b/components/features/run-trace/approval-details.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { cn } from "@/lib/utils";
 import type { ApprovalMetadata } from "@/src/lib/trace";
 
@@ -25,6 +27,24 @@ export function ApprovalDetails({
         <span className="font-medium text-foreground/80">{approval.title}</span>
         <span> - {approval.summary}</span>
       </div>
+      {approval.command ? (
+        <div className="flex min-w-0 flex-wrap gap-1 font-mono text-[9px] text-muted-foreground">
+          {approval.command.commandPolicyMode ? (
+            <MetaChip>policy {approval.command.commandPolicyMode}</MetaChip>
+          ) : null}
+          <MetaChip className="max-w-full truncate">
+            cwd {approval.command.cwd}
+          </MetaChip>
+          <MetaChip>{approval.command.timeoutMs}ms</MetaChip>
+          <MetaChip>{approval.command.outputCapBytes}B/stream</MetaChip>
+          {approval.command.boundary ? (
+            <>
+              <MetaChip>{approval.command.boundary.label}</MetaChip>
+              <MetaChip>Unconfined</MetaChip>
+            </>
+          ) : null}
+        </div>
+      ) : null}
       <ul className="space-y-0.5">
         {visibleDetails.map((detail) => (
           <li key={detail} className="break-words">
@@ -36,5 +56,24 @@ export function ApprovalDetails({
         <div>{approval.details.length - visibleDetails.length} more detail(s) in Worklog</div>
       )}
     </div>
+  );
+}
+
+function MetaChip({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "rounded bg-secondary/50 px-1 py-px ring-1 ring-border/40",
+        className,
+      )}
+    >
+      {children}
+    </span>
   );
 }

--- a/components/features/run-trace/live-terminal.tsx
+++ b/components/features/run-trace/live-terminal.tsx
@@ -35,6 +35,8 @@ export function LiveTerminalOutput({
   const timedOut = streamState.timedOut ?? initialOutput?.timedOut;
   const killed = streamState.killed ?? initialOutput?.killed;
   const failedReason = streamState.failedReason ?? initialOutput?.failedReason;
+  const commandPolicyMode = initialOutput?.commandPolicyMode;
+  const boundary = initialOutput?.boundary;
   const isRunning = Boolean(streamToken) && !streamState.finished;
   const status = terminalStatus({
     exitCode,
@@ -96,24 +98,39 @@ export function LiveTerminalOutput({
           (no output)
         </div>
       )}
-      {status ? (
-        <div className="border-t border-white/8 px-2 py-1">
-          <span
-            className={cn(
-              "text-[10px] font-medium",
-              status.tone === "error"
-                ? "text-red-400"
-                : "text-muted-foreground/60",
-            )}
-          >
-            {status.label}
-          </span>
-        </div>
-      ) : isRunning ? (
-        <div className="border-t border-white/8 px-2 py-1">
-          <span className="text-[10px] font-medium text-sky-400 animate-pulse">
-            Running...
-          </span>
+      {status || isRunning || commandPolicyMode || boundary ? (
+        <div className="flex flex-wrap items-center gap-2 border-t border-white/8 px-2 py-1">
+          {status ? (
+            <span
+              className={cn(
+                "text-[10px] font-medium",
+                status.tone === "error"
+                  ? "text-red-400"
+                  : "text-muted-foreground/60",
+              )}
+            >
+              {status.label}
+            </span>
+          ) : isRunning ? (
+            <span className="animate-pulse text-[10px] font-medium text-sky-400">
+              Running...
+            </span>
+          ) : null}
+          {commandPolicyMode ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Policy: {commandPolicyMode}
+            </span>
+          ) : null}
+          {boundary ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Boundary: {boundary.label}
+            </span>
+          ) : null}
+          {boundary ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Confinement: Unconfined
+            </span>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/components/features/run-trace/terminal-output.tsx
+++ b/components/features/run-trace/terminal-output.tsx
@@ -60,8 +60,8 @@ export function TerminalOutput({ command, output, className }: TerminalOutputPro
           (no output)
         </div>
       )}
-      {(status || parsed.commandPolicyMode) && (
-        <div className="flex items-center gap-2 border-t border-white/8 px-2 py-1">
+      {(status || parsed.commandPolicyMode || parsed.boundary) && (
+        <div className="flex flex-wrap items-center gap-2 border-t border-white/8 px-2 py-1">
           {status ? (
             <span
               className={cn(
@@ -77,6 +77,16 @@ export function TerminalOutput({ command, output, className }: TerminalOutputPro
           {parsed.commandPolicyMode ? (
             <span className="text-[10px] text-muted-foreground/60">
               Policy: {parsed.commandPolicyMode}
+            </span>
+          ) : null}
+          {parsed.boundary ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Boundary: {parsed.boundary.label}
+            </span>
+          ) : null}
+          {parsed.boundary ? (
+            <span className="text-[10px] text-muted-foreground/60">
+              Confinement: Unconfined
             </span>
           ) : null}
         </div>

--- a/components/features/run-trace/terminal-utils.ts
+++ b/components/features/run-trace/terminal-utils.ts
@@ -9,6 +9,11 @@ export interface BashOutput {
   stderr?: string;
   exitCode?: number | null;
   commandPolicyMode?: "enforced" | "advisory";
+  boundary?: {
+    kind: "workspace-cwd";
+    confinement: "unconfined";
+    label: "Workspace cwd only";
+  };
   timedOut?: boolean;
   killed?: boolean;
   failedReason?: BashFailedReason;
@@ -39,12 +44,32 @@ export function parseBashOutput(output: unknown): BashOutput {
       record.commandPolicyMode === "advisory"
         ? record.commandPolicyMode
         : undefined,
+    boundary: parseExecutionBoundary(record.boundary),
     timedOut:
       typeof record.timedOut === "boolean" ? record.timedOut : undefined,
     killed: typeof record.killed === "boolean" ? record.killed : undefined,
     failedReason: isFailedReason(record.failedReason)
       ? record.failedReason
       : undefined,
+  };
+}
+
+function parseExecutionBoundary(
+  value: unknown,
+): BashOutput["boundary"] | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    record.kind !== "workspace-cwd" ||
+    record.confinement !== "unconfined" ||
+    record.label !== "Workspace cwd only"
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "workspace-cwd",
+    confinement: "unconfined",
+    label: "Workspace cwd only",
   };
 }
 

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -589,6 +589,8 @@ function bashOutputFromEntry(entry: ToolTraceEntry): BashOutput {
   const failedReason = parseFailedReason(
     entry.errorText ?? pickString(entry.output as Record<string, unknown>, "failedReason"),
   );
+  const commandPolicyMode = pickCommandPolicyMode(entry.output);
+  const boundary = pickExecutionBoundary(entry.output);
   const stdout =
     typeof entry.output === "object" &&
     entry.output !== null &&
@@ -607,9 +609,8 @@ function bashOutputFromEntry(entry: ToolTraceEntry): BashOutput {
   return {
     ...(stdout ? { stdout } : {}),
     ...(stderr ? { stderr } : {}),
-    ...(pickCommandPolicyMode(entry.output)
-      ? { commandPolicyMode: pickCommandPolicyMode(entry.output) }
-      : {}),
+    ...(commandPolicyMode ? { commandPolicyMode } : {}),
+    ...(boundary ? { boundary } : {}),
     exitCode:
       typeof entry.output === "object" &&
       entry.output !== null &&
@@ -629,6 +630,25 @@ function pickCommandPolicyMode(
   if (typeof output !== "object" || output === null) return undefined;
   const value = (output as Record<string, unknown>).commandPolicyMode;
   return value === "enforced" || value === "advisory" ? value : undefined;
+}
+
+function pickExecutionBoundary(output: unknown): BashOutput["boundary"] {
+  if (typeof output !== "object" || output === null) return undefined;
+  const value = (output as Record<string, unknown>).boundary;
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    record.kind !== "workspace-cwd" ||
+    record.confinement !== "unconfined" ||
+    record.label !== "Workspace cwd only"
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "workspace-cwd",
+    confinement: "unconfined",
+    label: "Workspace cwd only",
+  };
 }
 
 function parseFailedReason(

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -18,6 +18,10 @@ import {
   type BashCommandClassification,
 } from "./command-policy";
 import { planVerification } from "./tools/verify";
+import {
+  getWorkspaceExecutionBoundary,
+  type WorkspaceExecutionBoundary,
+} from "@/src/workspace/process-runner";
 
 // Permission gate helpers for tool execution.
 //
@@ -71,6 +75,7 @@ export type ToolApprovalMetadata = {
     cwd: string;
     timeoutMs: number;
     outputCapBytes: number;
+    boundary: WorkspaceExecutionBoundary;
     classification: BashCommandClassification;
   };
   external?: {
@@ -80,7 +85,8 @@ export type ToolApprovalMetadata = {
   };
 };
 
-const BASH_DEFAULT_TIMEOUT_MS = 30_000;
+const BASH_DEFAULT_TIMEOUT_MS = 180_000;
+const BASH_SEARCH_COMMAND_TIMEOUT_MS = 240_000;
 const BASH_OUTPUT_CAP_BYTES = 64 * 1024;
 const WRITE_FILE_MAX_BYTES = 1024 * 1024;
 const READ_FILE_MAX_BYTES = 256 * 1024;
@@ -688,11 +694,16 @@ function buildBashApproval(
   permissionMode: PermissionMode,
 ): ToolApprovalMetadata {
   const command = stringValue(input.command) ?? "";
-  const timeoutMs = numberValue(input.timeoutMs) ?? BASH_DEFAULT_TIMEOUT_MS;
+  const timeoutMs =
+    numberValue(input.timeoutMs) ??
+    (looksLikeSearchCommand(command)
+      ? BASH_SEARCH_COMMAND_TIMEOUT_MS
+      : BASH_DEFAULT_TIMEOUT_MS);
   const cwd = workspaceRootLabel(workspaceRoot);
   const policy = evaluateBashCommandPolicy(command, { workspaceRoot });
   const classification = policy.classification;
   const commandPolicyMode = commandPolicyModeForPermission(permissionMode);
+  const boundary = getWorkspaceExecutionBoundary();
 
   return {
     title: "Run shell command",
@@ -706,21 +717,24 @@ function buildBashApproval(
       cwd,
       timeoutMs,
       outputCapBytes: BASH_OUTPUT_CAP_BYTES,
+      boundary,
       classification,
     },
     details: [
       `Command: ${command || "(empty)"}`,
       `Shell: bash -lc`,
+      `Command policy mode: ${commandPolicyMode}.`,
       `Working directory: ${cwd}`,
       `Timeout: ${timeoutMs}ms`,
       `Output cap: ${BASH_OUTPUT_CAP_BYTES} bytes per stream.`,
-      `Command policy mode: ${commandPolicyMode}.`,
+      `Execution boundary: ${boundary.label}.`,
+      "Confinement: Unconfined.",
       `Classification: ${classification.reason}.`,
       commandPolicyMode === "advisory"
-        ? "Full-access mode treats command policy classification as advisory; sandbox cwd, timeout, output limits, and redaction still apply."
+        ? "Full-access mode treats command policy classification as advisory; cwd, environment allowlist, timeout, output limits, and redaction still apply. OS confinement is not provided."
         : !policy.allowed
         ? "This command violates command policy and will be refused even if approved."
-        : "Approval lets the command start; it does not bypass sandbox cwd, timeout, or output limits.",
+        : "Approval lets the command start; cwd, environment allowlist, timeout, output limits, and redaction still apply. OS confinement is not provided.",
     ],
   };
 }
@@ -1006,6 +1020,11 @@ export function commandPolicyModeForPermission(
   permissionMode: PermissionMode,
 ): CommandPolicyMode {
   return permissionMode === "full-access" ? "advisory" : "enforced";
+}
+
+function looksLikeSearchCommand(command: string): boolean {
+  const trimmed = command.trim();
+  return /^(grep|rg|find)\b/.test(trimmed);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/agent/tools/bash.ts
+++ b/src/agent/tools/bash.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
-import { execa } from "execa";
 import { tool, type JSONValue } from "ai";
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt } from "../sandbox";
 import {
-  buildBashEnvironment,
   classifyBashCommand,
   evaluateBashCommandPolicy,
 } from "../command-policy";
@@ -11,13 +9,18 @@ import {
   bashProgress,
   type BashFailedReason,
 } from "@/src/lib/bash-stream";
-import { redactText } from "@/src/lib/redaction";
 import { modelVisibleToolOutput } from "./model-output";
 import {
   commandPolicyModeForPermission,
   type CommandPolicyMode,
   type PermissionMode,
 } from "../permissions";
+import {
+  getWorkspaceExecutionBoundary,
+  startWorkspaceProcess,
+  truncateWorkspaceProcessOutput,
+  type WorkspaceExecutionBoundary,
+} from "@/src/workspace/process-runner";
 
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const DEFAULT_TIMEOUT_MS = 180_000;
@@ -130,14 +133,6 @@ function compactBashModelOutput(output: unknown): JSONValue {
   }) as JSONValue;
 }
 
-function truncate(output: string): string {
-  const redacted = redactText(output);
-  const buf = Buffer.from(redacted, "utf8");
-  if (buf.byteLength <= MAX_OUTPUT_BYTES) return redacted;
-  const head = buf.subarray(0, MAX_OUTPUT_BYTES).toString("utf8");
-  return `${head}\n...[truncated ${buf.byteLength - MAX_OUTPUT_BYTES} bytes]`;
-}
-
 async function executeWithStreaming(
   command: string,
   root: string,
@@ -153,37 +148,29 @@ async function executeWithStreaming(
   let sentExit = false;
 
   try {
-    const subprocess = execa("bash", ["-lc", command], {
-      cwd: root,
-      env: buildBashEnvironment(),
-      extendEnv: false,
-      timeout,
-      reject: false,
-      stripFinalNewline: false,
-      maxBuffer: MAX_OUTPUT_BYTES * 4,
+    const processHandle = startWorkspaceProcess("bash", ["-lc", command], root, {
+      timeoutMs: timeout,
+      outputCapBytes: MAX_OUTPUT_BYTES,
+      maxBufferBytes: MAX_OUTPUT_BYTES * 4,
+      onStdout: (text) => {
+        stdoutChunks.push(text);
+        bashProgress.emitChunk(streamId, { type: "stdout", chunk: text });
+      },
+      onStderr: (text) => {
+        stderrChunks.push(text);
+        bashProgress.emitChunk(streamId, { type: "stderr", chunk: text });
+      },
     });
 
-    subprocess.stdout?.on("data", (chunk: Buffer) => {
-      const text = redactText(chunk.toString("utf8"));
-      stdoutChunks.push(text);
-      bashProgress.emitChunk(streamId, { type: "stdout", chunk: text });
-    });
+    const result = await processHandle.result;
+    const exitCode = result.exitCode;
+    const timedOut = result.timedOut;
+    const killed = result.killed;
+    const failedReason = result.failedReason;
 
-    subprocess.stderr?.on("data", (chunk: Buffer) => {
-      const text = redactText(chunk.toString("utf8"));
-      stderrChunks.push(text);
-      bashProgress.emitChunk(streamId, { type: "stderr", chunk: text });
-    });
-
-    const result = await subprocess;
-    const exitCode = result.exitCode ?? null;
-    const timedOut = result.timedOut ?? false;
-    const killed = result.isCanceled ?? false;
-    const failedReason = failedReasonForResult({
-      timedOut,
-      killed,
-      isMaxBuffer: result.isMaxBuffer ?? false,
-    });
+    if (result.failedToStart && result.stderr && stderrChunks.length === 0) {
+      bashProgress.emitChunk(streamId, { type: "stderr", chunk: `${result.stderr}\n` });
+    }
 
     bashProgress.emitChunk(streamId, {
       type: "exit",
@@ -206,9 +193,10 @@ async function executeWithStreaming(
       timedOut,
       killed,
       failedReason,
-      stdout: truncate(stdoutChunks.join("")),
-      stderr: truncate(stderrChunks.join("")),
+      stdout: result.stdout,
+      stderr: result.stderr,
       streamId,
+      boundary: result.boundary,
       ...(commandFailed
         ? {
             error:
@@ -218,8 +206,11 @@ async function executeWithStreaming(
         : {}),
     };
   } catch (err) {
-    const error = redactText(errorMessage(err));
-    const stderr = truncate([...stderrChunks, error].filter(Boolean).join("\n"));
+    const error = truncateWorkspaceProcessOutput(errorMessage(err), MAX_OUTPUT_BYTES);
+    const stderr = truncateWorkspaceProcessOutput(
+      [...stderrChunks, error].filter(Boolean).join("\n"),
+      MAX_OUTPUT_BYTES,
+    );
     bashProgress.emitChunk(streamId, { type: "stderr", chunk: `${error}\n` });
     bashProgress.emitChunk(streamId, {
       type: "exit",
@@ -240,9 +231,10 @@ async function executeWithStreaming(
       timedOut: false,
       killed: false,
       failedReason: "error",
-      stdout: truncate(stdoutChunks.join("")),
+      stdout: truncateWorkspaceProcessOutput(stdoutChunks.join(""), MAX_OUTPUT_BYTES),
       stderr,
       streamId,
+      boundary: getWorkspaceExecutionBoundary(),
     };
   } finally {
     if (!sentExit) {
@@ -271,6 +263,7 @@ type BashToolOutput = {
   stderr: string;
   streamId: string;
   error?: string;
+  boundary: WorkspaceExecutionBoundary;
 };
 
 type BashToolErrorOutput = {
@@ -286,22 +279,8 @@ type BashToolErrorOutput = {
   stdout: string;
   stderr: string;
   streamId: string;
+  boundary: WorkspaceExecutionBoundary;
 };
-
-function failedReasonForResult({
-  timedOut,
-  killed,
-  isMaxBuffer,
-}: {
-  timedOut: boolean;
-  killed: boolean;
-  isMaxBuffer: boolean;
-}): BashFailedReason | undefined {
-  if (timedOut) return "timeout";
-  if (killed) return "killed";
-  if (isMaxBuffer) return "max_buffer";
-  return undefined;
-}
 
 function looksLikeSearchCommand(command: string): boolean {
   const trimmed = command.trim();

--- a/src/agent/tools/format.ts
+++ b/src/agent/tools/format.ts
@@ -12,7 +12,7 @@ import {
   assertPathGuardAllowed,
   normalizeRelPath,
 } from "./file-guardrails";
-import { runWorkspaceProcess } from "./process";
+import { runWorkspaceProcess } from "@/src/workspace/process-runner";
 import {
   detectPackageManager,
   execCommand,

--- a/src/agent/tools/git.ts
+++ b/src/agent/tools/git.ts
@@ -4,7 +4,7 @@ import { tool } from "ai";
 
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt, resolveInWorkspace, SandboxError } from "../sandbox";
 import { assertPathGuardAllowed, normalizeRelPath } from "./file-guardrails";
-import { runWorkspaceProcess } from "./process";
+import { runWorkspaceProcess } from "@/src/workspace/process-runner";
 
 const pathListSchema = z
   .array(z.string())
@@ -352,10 +352,10 @@ function assertSafeGitRef(ref: string): void {
   }
 }
 
-function gitError(result: { stderr: string; stdout: string; exitCode: number }) {
+function gitError(result: { stderr: string; stdout: string; exitCode: number | null }) {
   return {
     ok: false as const,
-    exitCode: result.exitCode,
+    exitCode: result.exitCode ?? 1,
     error: result.stderr || result.stdout || "git command failed",
   };
 }

--- a/src/agent/tools/grep.ts
+++ b/src/agent/tools/grep.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { execa } from "execa";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { tool, type JSONValue } from "ai";
 import { globToRegex } from "./glob";
 import { compactGrepForModel } from "./model-output";
+import { runWorkspaceProcess } from "@/src/workspace/process-runner";
 import {
   resolveInWorkspace,
   SandboxError,
@@ -66,20 +66,18 @@ export function createGrepTool(workspaceRoot?: string) {
       }
       args.push("--", pattern, target);
 
-      const result = await execa("rg", args, {
-        cwd: root,
-        reject: false,
-        maxBuffer: MAX_OUTPUT_BYTES * 4,
+      const result = await runWorkspaceProcess("rg", args, root, {
+        outputCapBytes: MAX_OUTPUT_BYTES,
       });
 
       if (result.exitCode === 2) {
         return {
           ok: false as const,
-          error: result.stderr?.trim() || "ripgrep failed",
+          error: result.stderr.trim() || "ripgrep failed",
         };
       }
 
-      const rawLines = (result.stdout ?? "")
+      const rawLines = result.stdout
         .split("\n")
         .filter((line) => line.length > 0)
         .slice(0, MAX_RESULTS);

--- a/src/agent/tools/post-edit-lint.ts
+++ b/src/agent/tools/post-edit-lint.ts
@@ -9,7 +9,7 @@ import {
   runScriptCommand,
   scriptNames,
 } from "./package-manager";
-import { runWorkspaceProcess } from "./process";
+import { runWorkspaceProcess } from "@/src/workspace/process-runner";
 
 export type PostEditLintIssue = {
   line: number;

--- a/src/agent/tools/process.ts
+++ b/src/agent/tools/process.ts
@@ -1,88 +1,11 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-import { buildBashEnvironment } from "../command-policy";
-import { redactText } from "@/src/lib/redaction";
-
-const execFileAsync = promisify(execFile);
-const MAX_OUTPUT_BYTES = 64 * 1024;
-
-export type ProcessResult = {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-  timedOut?: boolean;
-  failedToStart?: boolean;
-};
-
-export async function runWorkspaceProcess(
-  file: string,
-  args: readonly string[],
-  cwd: string,
-  options: { timeoutMs?: number } = {},
-): Promise<ProcessResult> {
-  try {
-    const result = await execFileAsync(file, [...args], {
-      cwd,
-      env: buildBashEnvironment() as NodeJS.ProcessEnv,
-      windowsHide: true,
-      timeout: options.timeoutMs,
-      maxBuffer: MAX_OUTPUT_BYTES * 4,
-    });
-    return {
-      exitCode: 0,
-      stdout: truncate(result.stdout),
-      stderr: truncate(result.stderr),
-    };
-  } catch (err) {
-    return {
-      exitCode: exitCode(err),
-      stdout: truncate(outputText(err, "stdout")),
-      stderr: truncate(outputText(err, "stderr") || errorMessage(err)),
-      timedOut: timedOut(err),
-      failedToStart: failedToStart(err),
-    };
-  }
-}
-
-function truncate(output: string): string {
-  const redacted = redactText(output);
-  const buf = Buffer.from(redacted, "utf8");
-  if (buf.byteLength <= MAX_OUTPUT_BYTES) return redacted;
-  const head = buf.subarray(0, MAX_OUTPUT_BYTES).toString("utf8");
-  return `${head}\n...[truncated ${buf.byteLength - MAX_OUTPUT_BYTES} bytes]`;
-}
-
-function outputText(err: unknown, key: "stdout" | "stderr"): string {
-  if (typeof err !== "object" || err === null || !(key in err)) return "";
-  const value = (err as Record<typeof key, unknown>)[key];
-  return typeof value === "string" ? value : "";
-}
-
-function exitCode(err: unknown): number {
-  if (typeof err !== "object" || err === null || !("code" in err)) return 1;
-  const code = (err as { code: unknown }).code;
-  return typeof code === "number" ? code : 1;
-}
-
-function timedOut(err: unknown): boolean {
-  if (typeof err !== "object" || err === null || !("killed" in err)) return false;
-  const record = err as { killed?: unknown; signal?: unknown };
-  return record.killed === true && record.signal === "SIGTERM";
-}
-
-function failedToStart(err: unknown): boolean {
-  if (typeof err !== "object" || err === null || !("code" in err)) return false;
-  const code = (err as { code: unknown }).code;
-  return (
-    code === "ENOENT" ||
-    code === "EACCES" ||
-    code === "EPERM" ||
-    code === "UNKNOWN"
-  );
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
+export {
+  getWorkspaceExecutionBoundary,
+  runWorkspaceProcess,
+  startWorkspaceProcess,
+  truncateWorkspaceProcessOutput,
+  type StartedWorkspaceProcess,
+  type WorkspaceExecutionBoundary,
+  type WorkspaceProcessFailedReason,
+  type WorkspaceProcessOptions,
+  type WorkspaceProcessResult,
+} from "@/src/workspace/process-runner";

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -14,7 +14,7 @@ import {
   runScriptCommand,
   type PackageManager,
 } from "./package-manager";
-import { runWorkspaceProcess } from "./process";
+import { runWorkspaceProcess } from "@/src/workspace/process-runner";
 import {
   compactVerifyForModel,
   verifyDefaultsForProfile,
@@ -190,8 +190,8 @@ export function createVerifyTool(
             ok,
             command: step.command.join(" "),
             timeoutMs: stepTimeoutMs,
-            exitCode: result.exitCode,
-            timedOut: result.timedOut ?? false,
+            exitCode: result.exitCode ?? undefined,
+            timedOut: result.timedOut,
             stdout: capOutput(result.stdout),
             stderr: capOutput(result.stderr),
             ...(result.failedToStart ? { commandBroken: true as const } : {}),

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -205,6 +205,11 @@ export type ApprovalMetadata = {
     cwd: string;
     timeoutMs: number;
     outputCapBytes: number;
+    boundary?: {
+      kind: "workspace-cwd";
+      confinement: "unconfined";
+      label: "Workspace cwd only";
+    };
     classification: {
       categories: string[];
       forbidden: boolean;
@@ -590,7 +595,27 @@ function structuredCommandMetadata(
     cwd: record.cwd,
     timeoutMs: record.timeoutMs,
     outputCapBytes: record.outputCapBytes,
+    boundary: structuredExecutionBoundary(record.boundary),
     classification,
+  };
+}
+
+function structuredExecutionBoundary(
+  value: unknown,
+): NonNullable<ApprovalMetadata["command"]>["boundary"] | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    record.kind !== "workspace-cwd" ||
+    record.confinement !== "unconfined" ||
+    record.label !== "Workspace cwd only"
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "workspace-cwd",
+    confinement: "unconfined",
+    label: "Workspace cwd only",
   };
 }
 

--- a/src/workspace/background-commands.ts
+++ b/src/workspace/background-commands.ts
@@ -2,10 +2,7 @@ import { randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { execa, type ResultPromise } from "execa";
-
 import {
-  buildBashEnvironment,
   evaluateBashCommandPolicy,
 } from "@/src/agent/command-policy";
 import {
@@ -32,6 +29,10 @@ import {
 import type { BackgroundCommandSession } from "@/src/db/schema";
 import { backgroundCommandStream } from "@/src/lib/background-command-stream";
 import { redactText } from "@/src/lib/redaction";
+import {
+  startWorkspaceProcess,
+  type StartedWorkspaceProcess,
+} from "@/src/workspace/process-runner";
 
 const execFileAsync = promisify(execFile);
 
@@ -46,7 +47,7 @@ const LOCALHOST_URL_RE =
   /https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(?::\d+)?(?:\/[^\s"'<>]*)?/gi;
 
 type ActiveProcess = {
-  subprocess: ResultPromise;
+  subprocess: StartedWorkspaceProcess["subprocess"];
 };
 
 const activeProcesses = new Map<string, ActiveProcess>();
@@ -368,17 +369,34 @@ async function spawnSessionProcess(
   cwd: string,
   spawnArgs: { file: string; args: string[]; shell?: false },
 ): Promise<void> {
-  const subprocess = execa(spawnArgs.file, spawnArgs.args, {
-    cwd,
-    env: buildBashEnvironment(),
-    extendEnv: false,
-    reject: false,
-    stripFinalNewline: false,
+  let stdoutTail = "";
+  let stderrTail = "";
+  let detectedUrls: string[] = [];
+
+  const processHandle = startWorkspaceProcess(spawnArgs.file, spawnArgs.args, cwd, {
     cleanup: true,
     forceKillAfterDelay: false,
-    windowsHide: true,
     detached: process.platform !== "win32",
+    onStdout: (text) => {
+      stdoutTail = capTail(stdoutTail + text);
+      detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
+      updateBackgroundCommandSession(sessionId, {
+        stdoutTail,
+        detectedUrls,
+      });
+      backgroundCommandStream.emitEvent(sessionId, { type: "stdout", chunk: text });
+    },
+    onStderr: (text) => {
+      stderrTail = capTail(stderrTail + text);
+      detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
+      updateBackgroundCommandSession(sessionId, {
+        stderrTail,
+        detectedUrls,
+      });
+      backgroundCommandStream.emitEvent(sessionId, { type: "stderr", chunk: text });
+    },
   });
+  const { subprocess } = processHandle;
 
   activeProcesses.set(sessionId, { subprocess });
 
@@ -388,32 +406,6 @@ async function spawnSessionProcess(
     startedAt: new Date(),
   });
   backgroundCommandStream.emitEvent(sessionId, { type: "status", status: "running" });
-
-  let stdoutTail = "";
-  let stderrTail = "";
-  let detectedUrls: string[] = [];
-
-  subprocess.stdout?.on("data", (chunk: Buffer) => {
-    const text = redactText(chunk.toString("utf8"));
-    stdoutTail = capTail(stdoutTail + text);
-    detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
-    updateBackgroundCommandSession(sessionId, {
-      stdoutTail,
-      detectedUrls,
-    });
-    backgroundCommandStream.emitEvent(sessionId, { type: "stdout", chunk: text });
-  });
-
-  subprocess.stderr?.on("data", (chunk: Buffer) => {
-    const text = redactText(chunk.toString("utf8"));
-    stderrTail = capTail(stderrTail + text);
-    detectedUrls = mergeDetectedUrls(detectedUrls, detectLocalhostUrls(text));
-    updateBackgroundCommandSession(sessionId, {
-      stderrTail,
-      detectedUrls,
-    });
-    backgroundCommandStream.emitEvent(sessionId, { type: "stderr", chunk: text });
-  });
 
   void subprocess.then((result) => {
     finalizeProcess(sessionId, {
@@ -480,7 +472,7 @@ function forceFinalizeStoppedSession(sessionId: string): void {
 }
 
 async function readSubprocessExit(
-  subprocess: ResultPromise,
+  subprocess: StartedWorkspaceProcess["subprocess"],
 ): Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }> {
   try {
     const result = await Promise.race([
@@ -504,7 +496,7 @@ async function readSubprocessExit(
 
 async function killProcessTreeGracefully(
   pid: number | undefined,
-  subprocess: ResultPromise,
+  subprocess: StartedWorkspaceProcess["subprocess"],
 ): Promise<void> {
   await sendGracefulTermination(pid, subprocess);
   if (await waitForSubprocessExit(subprocess, TERMINATION_GRACE_MS)) {
@@ -517,7 +509,7 @@ async function killProcessTreeGracefully(
 
 async function sendGracefulTermination(
   pid: number | undefined,
-  subprocess: ResultPromise,
+  subprocess: StartedWorkspaceProcess["subprocess"],
 ): Promise<void> {
   if (pid !== undefined && process.platform === "win32") {
     try {
@@ -554,7 +546,7 @@ async function sendGracefulTermination(
 
 async function sendForceTermination(
   pid: number | undefined,
-  subprocess: ResultPromise,
+  subprocess: StartedWorkspaceProcess["subprocess"],
 ): Promise<void> {
   if (pid !== undefined && process.platform === "win32") {
     try {
@@ -590,7 +582,7 @@ async function sendForceTermination(
 }
 
 async function waitForSubprocessExit(
-  subprocess: ResultPromise,
+  subprocess: StartedWorkspaceProcess["subprocess"],
   timeoutMs: number,
 ): Promise<boolean> {
   return Promise.race([

--- a/src/workspace/process-runner.ts
+++ b/src/workspace/process-runner.ts
@@ -1,0 +1,267 @@
+import { execa, type ResultPromise } from "execa";
+
+import { buildBashEnvironment } from "@/src/agent/command-policy";
+import { redactText } from "@/src/lib/redaction";
+
+const DEFAULT_OUTPUT_CAP_BYTES = 64 * 1024;
+
+export type WorkspaceExecutionBoundary = {
+  kind: "workspace-cwd";
+  confinement: "unconfined";
+  label: "Workspace cwd only";
+};
+
+export type WorkspaceProcessFailedReason =
+  | "timeout"
+  | "killed"
+  | "max_buffer"
+  | "error";
+
+export type WorkspaceProcessResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  killed: boolean;
+  failedToStart: boolean;
+  failedReason?: WorkspaceProcessFailedReason;
+  boundary: WorkspaceExecutionBoundary;
+};
+
+export type WorkspaceProcessOptions = {
+  timeoutMs?: number;
+  outputCapBytes?: number;
+  maxBufferBytes?: number;
+  cleanup?: boolean;
+  detached?: boolean;
+  forceKillAfterDelay?: false | number;
+  onStdout?: (chunk: string) => void;
+  onStderr?: (chunk: string) => void;
+};
+
+export type StartedWorkspaceProcess = {
+  subprocess: ResultPromise;
+  stdoutChunks: string[];
+  stderrChunks: string[];
+  result: Promise<WorkspaceProcessResult>;
+  boundary: WorkspaceExecutionBoundary;
+};
+
+const WORKSPACE_EXECUTION_BOUNDARY: WorkspaceExecutionBoundary = {
+  kind: "workspace-cwd",
+  confinement: "unconfined",
+  label: "Workspace cwd only",
+};
+
+export function getWorkspaceExecutionBoundary(): WorkspaceExecutionBoundary {
+  return WORKSPACE_EXECUTION_BOUNDARY;
+}
+
+export async function runWorkspaceProcess(
+  file: string,
+  args: readonly string[],
+  cwd: string,
+  options: WorkspaceProcessOptions = {},
+): Promise<WorkspaceProcessResult> {
+  const started = startWorkspaceProcess(file, args, cwd, options);
+  return await started.result;
+}
+
+export function startWorkspaceProcess(
+  file: string,
+  args: readonly string[],
+  cwd: string,
+  options: WorkspaceProcessOptions = {},
+): StartedWorkspaceProcess {
+  const outputCapBytes = options.outputCapBytes ?? DEFAULT_OUTPUT_CAP_BYTES;
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const subprocess = execa(file, [...args], {
+    cwd,
+    env: buildBashEnvironment(),
+    extendEnv: false,
+    timeout: options.timeoutMs,
+    reject: false,
+    stripFinalNewline: false,
+    cleanup: options.cleanup ?? true,
+    windowsHide: true,
+    detached: options.detached,
+    maxBuffer: options.maxBufferBytes ?? outputCapBytes * 4,
+    ...(options.forceKillAfterDelay !== undefined
+      ? { forceKillAfterDelay: options.forceKillAfterDelay }
+      : {}),
+  });
+
+  subprocess.stdout?.on("data", (chunk: Buffer) => {
+    const text = redactText(chunk.toString("utf8"));
+    stdoutChunks.push(text);
+    options.onStdout?.(text);
+  });
+
+  subprocess.stderr?.on("data", (chunk: Buffer) => {
+    const text = redactText(chunk.toString("utf8"));
+    stderrChunks.push(text);
+    options.onStderr?.(text);
+  });
+
+  const result = subprocess
+    .then((execaResult) =>
+      resultFromCompletedProcess({
+        execaResult,
+        stdout: stdoutChunks.join(""),
+        stderr: stderrChunks.join(""),
+        outputCapBytes,
+      }),
+    )
+    .catch((err: unknown) =>
+      resultFromFailedProcess({
+        err,
+        stdout: stdoutChunks.join("") || outputText(err, "stdout"),
+        stderr: stderrChunks.join("") || outputText(err, "stderr") || errorMessage(err),
+        outputCapBytes,
+      }),
+    );
+
+  return {
+    subprocess,
+    stdoutChunks,
+    stderrChunks,
+    result,
+    boundary: getWorkspaceExecutionBoundary(),
+  };
+}
+
+export function truncateWorkspaceProcessOutput(
+  output: string,
+  outputCapBytes = DEFAULT_OUTPUT_CAP_BYTES,
+): string {
+  const redacted = redactText(output);
+  const buf = Buffer.from(redacted, "utf8");
+  if (buf.byteLength <= outputCapBytes) return redacted;
+  const head = buf.subarray(0, outputCapBytes).toString("utf8");
+  return `${head}\n...[truncated ${buf.byteLength - outputCapBytes} bytes]`;
+}
+
+function resultFromCompletedProcess({
+  execaResult,
+  stdout,
+  stderr,
+  outputCapBytes,
+}: {
+  execaResult: unknown;
+  stdout: string;
+  stderr: string;
+  outputCapBytes: number;
+}): WorkspaceProcessResult {
+  const result = asProcessRecord(execaResult);
+  const timedOut = result.timedOut === true;
+  const killed = result.isCanceled === true && !timedOut;
+  const isMaxBuffer = result.isMaxBuffer === true;
+  const failedReason = failedReasonForResult({ timedOut, killed, isMaxBuffer });
+  return {
+    exitCode: typeof result.exitCode === "number" ? result.exitCode : null,
+    stdout: truncateWorkspaceProcessOutput(stdout, outputCapBytes),
+    stderr: truncateWorkspaceProcessOutput(stderr, outputCapBytes),
+    timedOut,
+    killed,
+    failedToStart: false,
+    ...(failedReason ? { failedReason } : {}),
+    boundary: getWorkspaceExecutionBoundary(),
+  };
+}
+
+function resultFromFailedProcess({
+  err,
+  stdout,
+  stderr,
+  outputCapBytes,
+}: {
+  err: unknown;
+  stdout: string;
+  stderr: string;
+  outputCapBytes: number;
+}): WorkspaceProcessResult {
+  const timedOut = timedOutError(err);
+  const failedToStart = failedToStartError(err);
+  const killed = killedError(err) && !timedOut;
+  const isMaxBuffer = maxBufferError(err);
+  return {
+    exitCode: exitCode(err),
+    stdout: truncateWorkspaceProcessOutput(stdout, outputCapBytes),
+    stderr: truncateWorkspaceProcessOutput(stderr, outputCapBytes),
+    timedOut,
+    killed,
+    failedToStart,
+    failedReason: timedOut
+      ? "timeout"
+      : killed
+        ? "killed"
+        : isMaxBuffer
+          ? "max_buffer"
+          : "error",
+    boundary: getWorkspaceExecutionBoundary(),
+  };
+}
+
+function failedReasonForResult(input: {
+  timedOut: boolean;
+  killed: boolean;
+  isMaxBuffer: boolean;
+}): WorkspaceProcessFailedReason | undefined {
+  if (input.timedOut) return "timeout";
+  if (input.killed) return "killed";
+  if (input.isMaxBuffer) return "max_buffer";
+  return undefined;
+}
+
+function outputText(err: unknown, key: "stdout" | "stderr"): string {
+  if (typeof err !== "object" || err === null || !(key in err)) return "";
+  const value = (err as Record<typeof key, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+function exitCode(err: unknown): number | null {
+  if (typeof err !== "object" || err === null || !("exitCode" in err)) return null;
+  const code = (err as { exitCode: unknown }).exitCode;
+  return typeof code === "number" ? code : null;
+}
+
+function timedOutError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return (err as { timedOut?: unknown }).timedOut === true;
+}
+
+function killedError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return (err as { isCanceled?: unknown; killed?: unknown }).isCanceled === true;
+}
+
+function maxBufferError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return (err as { isMaxBuffer?: unknown }).isMaxBuffer === true;
+}
+
+function failedToStartError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null || !("code" in err)) return false;
+  const code = (err as { code: unknown }).code;
+  return (
+    code === "ENOENT" ||
+    code === "EACCES" ||
+    code === "EPERM" ||
+    code === "UNKNOWN"
+  );
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function asProcessRecord(value: unknown): {
+  exitCode?: unknown;
+  timedOut?: unknown;
+  isCanceled?: unknown;
+  isMaxBuffer?: unknown;
+} {
+  return typeof value === "object" && value !== null ? value : {};
+}


### PR DESCRIPTION
﻿## Summary

Closes #162.

Centralizes Anton-controlled workspace process launches behind `src/workspace/process-runner.ts` and records the current execution boundary as `Workspace cwd only` / `Unconfined`.

## Changes

- Added a shared workspace process runner with normalized result fields, redaction, env allowlist, output caps, timeout handling, `windowsHide`, and streaming callbacks.
- Migrated scoped harness process paths: `bash`, `verify`, native git tools, `format`, post-edit lint, `grep`/`rg`, and custom/script background commands.
- Kept `src/agent/tools/process.ts` as a compatibility re-export.
- Added shell approval and terminal trace metadata for command policy mode, cwd, timeout/output cap, execution boundary, and confinement.
- Reworded shell approval copy so it does not imply OS sandboxing in this phase.
- Added a roadmap risk noting that process execution is still not OS-confined.

## Verification

- `pnpm typecheck` passed.
- `pnpm lint` passed.
- `git diff --check` and `git diff --cached --check` passed.
- `pnpm build` passed. It reported the existing Turbopack NFT tracing warning through `next.config.ts` -> `src/workspace/project-inspect.ts` -> project status route.
- Browser smoke check passed at `http://127.0.0.1:3000/`: title `Anton`, app text visible, no console errors.

## Notes

Direct `tsx` runtime probes of the execa-backed runner are blocked in this local Node 24 environment by the known `ERR_PACKAGE_PATH_NOT_EXPORTED` path in the `tsx`/`execa` dependency chain. I verified the real call paths by source inspection plus typecheck/lint/build instead.

## Prompt-cache-sensitive surfaces

No changes were made to the `bash` input schema, profile tool lists, system prompt, or `activeTools` behavior.
