### PR TITLE
[codex] Phase 3 continuation-safe persistence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,7 +185,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [] Workspace process execution is centralized around cwd, environment allowlist, timeouts, output caps, and redaction, but does not provide OS-level confinement yet.
 - [✔️] MCP stdio server startup can execute configured commands before user approval.
 - [✔️] Full-file `write_file` replacement risk is resolved by patch-first editing.
-- [] Message persistence still deletes and reinserts the full session transcript in some recovery paths.
+- [✔️] Message persistence still deletes and reinserts the full session transcript in some recovery paths.
 - [] GitHub clone/fetch runs synchronously inside request handling and may exceed request duration for large repositories.
 - [] Installation tokens are injected into git through extra headers; keep redaction behavior current as clone/fetch behavior evolves.
 - [] New chats require explicit project selection; there is no default or durable user/workspace project preference yet.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -45,6 +45,7 @@ import {
   promptCacheAuditFromCostMetadata,
 } from "@/src/agent/prompt-cache-audit";
 import {
+  buildDroppedHistoryDigest,
   buildSessionContextDigest,
   RunContextCollector,
   type RunContextStatus,
@@ -108,7 +109,6 @@ import {
   type TokenUsageMetrics,
 } from "@/src/lib/token-usage";
 import {
-  collapseAssistantContinuationMessages,
   getApprovalMetadata,
   getAssistantTextDisplay,
   getToolTraceEntries,
@@ -421,18 +421,18 @@ export async function POST(req: Request) {
           latestUserText: userText,
           budgetChars: budget.workspaceContextChars,
         });
-  const contextDigestBytes = byteLength(
-    isProfileHandoffContinuation
-      ? (continuationNote ?? "")
-      : profile === "single-file-edit" &&
-          singleFileTargetResolution &&
-          "targetPath" in singleFileTargetResolution
-        ? singleFileTargetContext(singleFileTargetResolution)
-      : (modelOnlyContextMessageText({
+  const baseModelContextText = isProfileHandoffContinuation
+    ? continuationContextMessageText(continuationNote)
+    : profile === "single-file-edit" &&
+        singleFileTargetResolution &&
+        "targetPath" in singleFileTargetResolution
+      ? singleFileTargetContext(singleFileTargetResolution)
+      : modelOnlyContextMessageText({
           sessionContextDigest,
           workspaceContextDigest,
-        }) ?? ""),
-  );
+        });
+  let modelContextText = baseModelContextText;
+  let contextDigestBytes = byteLength(modelContextText ?? "");
   const preservation = modelContextPreservation(
     uiMessages,
     profile,
@@ -443,12 +443,37 @@ export async function POST(req: Request) {
     profile,
     isSegmentContinuation,
   );
-  const contextBudget = budgetMessagesForModel({
+  let contextBudget = budgetMessagesForModel({
     messages: preparedMessages,
     budget,
     ...preservation,
     contextDigestBytes,
   });
+  let droppedHistoryDigestInjected = false;
+  if (contextBudget.ok && contextBudget.droppedMessages.length > 0) {
+    const droppedHistoryDigest = buildDroppedHistoryDigest(
+      contextBudget.droppedMessages,
+    );
+    const nextModelContextText =
+      isProfileHandoffContinuation || profile === "single-file-edit"
+        ? combineModelContextText(baseModelContextText, droppedHistoryDigest)
+        : modelOnlyContextMessageText({
+            sessionContextDigest,
+            workspaceContextDigest,
+            droppedHistoryDigest,
+          });
+    if (nextModelContextText !== modelContextText) {
+      modelContextText = nextModelContextText;
+      contextDigestBytes = byteLength(modelContextText ?? "");
+      droppedHistoryDigestInjected = true;
+      contextBudget = budgetMessagesForModel({
+        messages: preparedMessages,
+        budget,
+        ...preservation,
+        contextDigestBytes,
+      });
+    }
+  }
   if (!contextBudget.ok) {
     return Response.json(
       {
@@ -493,19 +518,15 @@ export async function POST(req: Request) {
     startedAt,
   );
   const modelMessages = isProfileHandoffContinuation
-    ? appendModelOnlyContextMessage(convertedMessages, continuationNote ?? "")
-    : profile === "single-file-edit" &&
-        singleFileTargetResolution &&
-        "targetPath" in singleFileTargetResolution
-      ? addSingleFileTargetContextMessage(
-          convertedMessages,
-          singleFileTargetContext(singleFileTargetResolution),
-        )
-    : addModelOnlyContextMessage(convertedMessages, {
-        sessionContextDigest,
-        workspaceContextDigest,
-      });
+    ? appendModelOnlyContextMessage(convertedMessages, modelContextText)
+    : addModelOnlyContextMessage(convertedMessages, modelContextText);
   const contextCollector = new RunContextCollector(runId, sessionId);
+  contextCollector.noteContextBudget({
+    droppedMessages: contextBudget.report.droppedMessages,
+    preservedMessages: contextBudget.report.preservedMessages,
+    droppedHistoryDigestInjected,
+    contextDigestBytes: contextBudget.report.contextDigestBytes,
+  });
   let contextTerminalStatus: RunContextStatus = "completed";
   let contextTerminalError: unknown;
 
@@ -644,25 +665,12 @@ export async function POST(req: Request) {
       const visibleMessages = messages
         .map(stripDurableTraceParts)
         .filter(hasSubstantiveHistoryParts);
-      const persistedMessages =
-        collapseAssistantContinuationMessages(visibleMessages);
-      if (persistedMessages.length === 0) return;
+      if (visibleMessages.length === 0) return;
       persistFinalToolApprovalStates(runId, messages);
       try {
-        const approvalContinuation =
-          isToolApprovalContinuation(persistedMessages);
-        const profileHandoffContinuationPersisted = isProfileHandoffContinuation;
-        const collapsedContinuations =
-          persistedMessages.length < visibleMessages.length;
         saveMessagesIncrementally<AntonUIMessage>(
           sessionId,
-          redactValue(persistedMessages) as AntonUIMessage[],
-          {
-            pruneExtraAssistantTail:
-              approvalContinuation ||
-              profileHandoffContinuationPersisted ||
-              collapsedContinuations,
-          },
+          redactValue(visibleMessages) as AntonUIMessage[],
         );
         contextCollector.persist({
           status: contextTerminalStatus,
@@ -861,51 +869,24 @@ async function convertMessagesForRun(
 
 function appendModelOnlyContextMessage(
   messages: ModelMessage[],
-  continuationNote: string,
+  contextText: string | undefined,
 ): ModelMessage[] {
-  const text = continuationNote.trim();
+  const text = contextText?.trim();
   if (!text) return messages;
   return [
     ...messages,
     {
       role: "assistant",
-      content: [
-        "Model-only continuation note:",
-        text,
-      ].join("\n"),
+      content: text,
     },
   ];
 }
 
 function addModelOnlyContextMessage(
   messages: ModelMessage[],
-  context: {
-    sessionContextDigest: string | undefined;
-    workspaceContextDigest: string | undefined;
-  },
+  contextText: string | undefined,
 ): ModelMessage[] {
-  const text = modelOnlyContextMessageText(context);
-  if (!text) return messages;
-  const contextMessage: ModelMessage = {
-    role: "assistant",
-    content: text,
-  };
-  const latestUserIndex = messages.findLastIndex(
-    (message) => message.role === "user",
-  );
-  if (latestUserIndex === -1) return [...messages, contextMessage];
-  return [
-    ...messages.slice(0, latestUserIndex),
-    contextMessage,
-    ...messages.slice(latestUserIndex),
-  ];
-}
-
-function addSingleFileTargetContextMessage(
-  messages: ModelMessage[],
-  contextText: string,
-): ModelMessage[] {
-  const text = contextText.trim();
+  const text = contextText?.trim();
   if (!text) return messages;
   const contextMessage: ModelMessage = {
     role: "assistant",
@@ -925,11 +906,13 @@ function addSingleFileTargetContextMessage(
 function modelOnlyContextMessageText({
   sessionContextDigest,
   workspaceContextDigest,
+  droppedHistoryDigest,
 }: {
   sessionContextDigest: string | undefined;
   workspaceContextDigest: string | undefined;
+  droppedHistoryDigest?: string | undefined;
 }): string | undefined {
-  const blocks = [workspaceContextDigest, sessionContextDigest]
+  const blocks = [workspaceContextDigest, sessionContextDigest, droppedHistoryDigest]
     .map((block) => block?.trim())
     .filter((block): block is string => Boolean(block));
   if (blocks.length === 0) return undefined;
@@ -939,6 +922,27 @@ function modelOnlyContextMessageText({
     "",
     "Use this context for orientation and continuity. Re-read files or rerun commands when exact current state matters.",
   ].join("\n");
+}
+
+function continuationContextMessageText(
+  continuationNote: string | undefined,
+): string | undefined {
+  const text = continuationNote?.trim();
+  if (!text) return undefined;
+  return [
+    "Model-only continuation note:",
+    text,
+  ].join("\n");
+}
+
+function combineModelContextText(
+  primaryContextText: string | undefined,
+  droppedHistoryDigest: string | undefined,
+): string | undefined {
+  const blocks = [primaryContextText, droppedHistoryDigest]
+    .map((block) => block?.trim())
+    .filter((block): block is string => Boolean(block));
+  return blocks.length === 0 ? undefined : blocks.join("\n\n");
 }
 
 function isModelContextPart(

--- a/src/agent/context-budget.ts
+++ b/src/agent/context-budget.ts
@@ -12,6 +12,7 @@ export type ContextBudgetResult =
   | {
       ok: true;
       messages: AntonUIMessage[];
+      droppedMessages: AntonUIMessage[];
       report: ContextBudgetReport;
     }
   | {
@@ -113,18 +114,19 @@ export function budgetMessagesForModel({
     afterBytes = utf8Bytes(stableJson(selected));
   }
 
-  const droppedMessages = messages.length - selected.length;
+  const droppedMessages = droppedMessagesFromSelection(messages, selectedIndexes);
   return {
     ok: true,
     messages: selected,
+    droppedMessages,
     report: {
       beforeBytes,
       afterBytes,
       maxInputBytes: budget.maxInputBytes,
       latestUserBytes,
       preservedMessages: selected.length,
-      droppedMessages,
-      prunedMessages: droppedMessages,
+      droppedMessages: droppedMessages.length,
+      prunedMessages: droppedMessages.length,
       requiredMessages,
       contextDigestBytes,
       ok: true,
@@ -137,6 +139,13 @@ function selectedMessages(
   selectedIndexes: Set<number>,
 ): AntonUIMessage[] {
   return messages.filter((_, index) => selectedIndexes.has(index));
+}
+
+function droppedMessagesFromSelection(
+  messages: AntonUIMessage[],
+  selectedIndexes: Set<number>,
+): AntonUIMessage[] {
+  return messages.filter((_, index) => !selectedIndexes.has(index));
 }
 
 function firstRemovableIndex(

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -1,8 +1,14 @@
+import {
+  getToolName,
+  isToolUIPart,
+} from "ai";
+
 import type { RunContextSummary } from "@/src/db/schema";
 import {
   listRunContextSummariesForSession,
   upsertRunContextSummary,
 } from "@/src/db/queries";
+import type { AntonUIMessage } from "@/src/lib/trace";
 import { redactText } from "@/src/lib/redaction";
 import {
   outputExitCode,
@@ -15,6 +21,8 @@ const DEFAULT_CONTEXT_BUDGET_CHARS = 6_000;
 const MAX_SUMMARY_CHARS = 2_000;
 const MAX_TEXT_FIELD_CHARS = 1_200;
 const MAX_DIGEST_BLOCK_CHARS = 1_500;
+const MAX_DROPPED_HISTORY_DIGEST_CHARS = 1_500;
+const MAX_DROPPED_MESSAGE_TEXT_CHARS = 500;
 
 export type RunContextStatus = "completed" | "error" | "aborted";
 
@@ -64,6 +72,13 @@ type RunContextCommand = {
   error?: string;
   stdoutTail?: string;
   stderrTail?: string;
+};
+
+type RunContextBudgetFact = {
+  droppedMessages: number;
+  preservedMessages: number;
+  droppedHistoryDigestInjected: boolean;
+  contextDigestBytes: number;
 };
 
 type RunContextTool = {
@@ -163,6 +178,26 @@ export class RunContextCollector {
       status: blocker.forceFinal ? "error" : "completed",
       output: blocker.reason,
       blocker,
+    });
+  }
+
+  noteContextBudget(input: RunContextBudgetFact): void {
+    if (input.droppedMessages <= 0 && !input.droppedHistoryDigestInjected) {
+      return;
+    }
+    const summary = [
+      `Context budget: kept ${input.preservedMessages} message${input.preservedMessages === 1 ? "" : "s"}`,
+      `dropped ${input.droppedMessages}`,
+      input.droppedHistoryDigestInjected
+        ? "dropped-history digest injected"
+        : "dropped-history digest not injected",
+      `context digest ${input.contextDigestBytes} bytes`,
+    ].join("; ");
+    this.addFact(summary);
+    this.tools.push({
+      name: "context_budget",
+      status: "completed",
+      output: summary,
     });
   }
 
@@ -308,6 +343,76 @@ export function buildSessionContextDigest({
   }
 
   return blocks.length > 1 ? blocks.join("\n\n") : undefined;
+}
+
+export function buildDroppedHistoryDigest(
+  messages: AntonUIMessage[],
+  maxChars = MAX_DROPPED_HISTORY_DIGEST_CHARS,
+): string | undefined {
+  if (messages.length === 0 || maxChars <= 0) return undefined;
+
+  const digestLines = messages
+    .flatMap(droppedMessageDigestLines)
+    .filter(Boolean);
+  if (digestLines.length === 0) return undefined;
+
+  const header = "Dropped conversation context:";
+  const selected: string[] = [];
+  let remaining = maxChars - header.length - 1;
+
+  for (let index = digestLines.length - 1; index >= 0; index -= 1) {
+    if (remaining <= 0) break;
+    const line = digestLines[index];
+    const selectedLine =
+      line.length > remaining ? truncate(line, remaining) : line;
+    if (!selectedLine.trim()) break;
+    selected.unshift(selectedLine);
+    remaining -= selectedLine.length + 1;
+    if (line.length > selectedLine.length) break;
+  }
+
+  if (selected.length === 0) return undefined;
+  return compactBlock([header, ...selected].join("\n"), maxChars);
+}
+
+function droppedMessageDigestLines(message: AntonUIMessage): string[] {
+  const text = messageTextSnippet(message);
+  const tools = messageToolDigest(message);
+  const lines: string[] = [];
+
+  if (message.role === "user" && text) {
+    lines.push(`- User: ${text}`);
+  } else if (message.role === "assistant") {
+    if (text) lines.push(`- Assistant: ${text}`);
+    if (tools) lines.push(`- Tools: ${tools}`);
+  }
+
+  return lines;
+}
+
+function messageTextSnippet(message: AntonUIMessage): string {
+  return compactBlock(
+    message.parts
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n"),
+    MAX_DROPPED_MESSAGE_TEXT_CHARS,
+  );
+}
+
+function messageToolDigest(message: AntonUIMessage): string {
+  const tools = message.parts.flatMap((part): string[] => {
+    if (!isToolUIPart(part)) return [];
+    const name = compactLine(getToolName(part), 100);
+    if (!name) return [];
+    const state =
+      "state" in part && typeof part.state === "string"
+        ? compactLine(part.state, 80)
+        : "";
+    return [state ? `${name} (${state})` : name];
+  });
+
+  return uniqueStrings(tools).slice(0, 12).join(", ");
 }
 
 function selectSummaries(
@@ -878,6 +983,15 @@ function stringArray(value: unknown): string[] {
     .filter((item): item is string => typeof item === "string")
     .map((item) => compactLine(item, 500))
     .filter(Boolean);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
 }
 
 function stringValue(value: unknown): string {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -756,7 +756,6 @@ export function getMessagePersistenceConflict<UI extends UIMessage>(
 export function saveMessagesIncrementally<UI extends UIMessage>(
   sessionId: string,
   incoming: UI[],
-  options: { pruneExtraAssistantTail?: boolean } = {},
 ): void {
   db.transaction((tx) => {
     const existing = tx
@@ -807,16 +806,6 @@ export function saveMessagesIncrementally<UI extends UIMessage>(
         })
         .where(eq(messages.id, id))
         .run();
-    }
-
-    if (options.pruneExtraAssistantTail) {
-      const incomingIds = new Set(
-        incoming.map((message, index) => messageId(message, sessionId, index)),
-      );
-      for (const current of existing) {
-        if (incomingIds.has(current.id) || current.role !== "assistant") continue;
-        tx.delete(messages).where(eq(messages.id, current.id)).run();
-      }
     }
 
     tx


### PR DESCRIPTION
## Summary
- Preserve durable assistant continuation rows by saving final visible messages without display collapsing or assistant-tail pruning.
- Add internal dropped-message tracking to context budgeting and inject a bounded deterministic dropped-history digest after one budget recomputation.
- Persist context-budget pruning facts through existing `run_context_summaries` JSON fields and mark the resolved roadmap risk.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (clean exit; only standard CRLF warnings)
- Inline `tsx` budget/digest probes confirmed dropped messages are reported, text is redacted, tool names/statuses are included, and raw tool output/reasoning are excluded.
- Prompt/tool-surface source check confirmed no changes to system prompt, tool schema files, profile tool lists, or `activeTools` markers.

Closes #164
