### PR TITLE
Redesign trace sidebar tabs (PR, Files, Diff) against mockups design system

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,6 +158,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Replace duplicate workspace/settings UI paths with one canonical Settings implementation.
 - [✔️] Clean up layout formatting and UI polish issues that are not core behavior.
 - [✔️] Adopted the `design/mockups.pen` design-system theme: layered neutral surface tokens, orange accent, Inter + JetBrains Mono fonts, and the redesigned Settings shell and Workspaces screen (#166).
+- [✔️] Redesigned the PR right-sidebar (header, sub-tabs, Changes/Description/Discussion/Commits/Checks, and the PR switcher) against `design/mockups.pen`, including `@pierre/diffs` diff-body theming (#169).
 - [] Fix project file code view scrollbar corner styling when both scrollbars are visible.
 
 ## Phase 7: Evaluation

--- a/app/globals.css
+++ b/app/globals.css
@@ -188,21 +188,25 @@
     background-clip: padding-box;
   }
   .anton-file-tree {
+    /* Metrics mirror design/mockups.pen "Files · Tree" (W3nOF): mono 11px rows,
+       5px radius, 8px row padding, 7px icon↔label gap, compact row height. */
     --trees-accent-override: var(--primary);
     --trees-bg-override: transparent;
-    --trees-bg-muted-override: color-mix(in oklch, var(--foreground) 6%, transparent);
+    --trees-bg-muted-override: var(--muted); /* bg-hover #1A1A1A */
     --trees-border-color-override: var(--border);
-    --trees-border-radius-override: var(--radius-sm);
-    --trees-fg-muted-override: var(--muted-foreground);
+    --trees-border-radius-override: 5px;
+    --trees-fg-muted-override: var(--text-tertiary);
     --trees-fg-override: var(--foreground);
     --trees-focus-ring-color-override: var(--ring);
     --trees-font-family-override: var(--font-jetbrains-mono);
     --trees-font-size-override: 11px;
-    --trees-gap-override: 0px;
+    --trees-item-height: 22px;
+    --trees-gap-override: 1px;
+    --trees-level-gap-override: 12px;
     --trees-item-margin-x-override: 2px;
-    --trees-item-padding-x-override: 4px;
-    --trees-padding-inline-override: 2px;
-    --trees-search-bg-override: var(--secondary);
+    --trees-item-padding-x-override: 8px;
+    --trees-item-row-gap-override: 7px;
+    --trees-padding-inline-override: 8px;
     --trees-search-fg-override: var(--foreground);
     --trees-git-added-color-override: var(--success);
     --trees-git-deleted-color-override: var(--destructive);
@@ -210,11 +214,11 @@
     --trees-git-modified-color-override: var(--info);
     --trees-git-renamed-color-override: var(--warning);
     --trees-git-untracked-color-override: var(--success);
-    --trees-selected-bg-override: color-mix(in oklch, var(--primary) 18%, transparent);
+    --trees-selected-bg-override: color-mix(in oklch, var(--primary) 10%, transparent); /* accent-soft */
     --trees-selected-fg-override: var(--foreground);
   }
   .project-file-code-view {
-    --project-file-code-surface: color-mix(in oklch, var(--background) 25%, var(--card));
+    --project-file-code-surface: var(--background);
   }
   .project-file-code-view::-webkit-scrollbar-corner {
     background: var(--project-file-code-surface);

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,8 @@
   --primary: oklch(0.63 0.16 58.84);
   --primary-foreground: oklch(0.985 0.004 80);
   --accent-muted: oklch(0.58 0.09 62);
+  --text-tertiary: oklch(0.533 0 0);
+  --thought: oklch(0.7217 0.1767 305.5);
   --secondary: oklch(0.92 0 0);
   --secondary-foreground: oklch(0.23 0 0);
   --muted: oklch(0.92 0 0);
@@ -61,6 +63,8 @@
   --primary: oklch(0.7288 0.1618 58.84); /* accent #F08A24 */
   --primary-foreground: oklch(0.1591 0 0); /* accent-text #0D0D0D */
   --accent-muted: oklch(0.6764 0.0853 62.72); /* accent-muted #C98A4B */
+  --text-tertiary: oklch(0.533 0 0); /* text-tertiary #6B6B6B */
+  --thought: oklch(0.7217 0.1767 305.5); /* thought #A78BFA */
   --secondary: oklch(0.252 0 0); /* bg-active #222222 */
   --secondary-foreground: oklch(0.9612 0 0);
   --muted: oklch(0.2178 0 0); /* bg-hover #1A1A1A */
@@ -114,6 +118,7 @@
   /* No --color-accent-muted: the "accent-" prefix collides with Tailwind's
      accent-color utility namespace, so text-accent-muted never generates.
      Use text-(--accent-muted) / bg-(--accent-muted) instead. */
+  --color-thought: var(--thought);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-success: var(--success);

--- a/components/features/run-trace/diff-view.tsx
+++ b/components/features/run-trace/diff-view.tsx
@@ -24,7 +24,292 @@ interface PatchDiffViewProps {
   previousFilename?: string | null;
   status?: string;
   className?: string;
+  variant?: "framed" | "embedded";
 }
+
+const COMPACT_DIFF_BASE_CSS = `
+  :host {
+    display: block;
+    min-width: 0;
+    width: 100%;
+    min-width: max-content;
+    max-width: none;
+    color: var(--foreground);
+    background: transparent;
+    font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 10px;
+    line-height: 1.45;
+    --diffs-bg: var(--background);
+    --diffs-fg: var(--foreground);
+    --diffs-fg-number: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+    --diffs-bg-context: transparent;
+    --diffs-bg-context-gutter: color-mix(in oklch, var(--muted) 34%, transparent);
+    --diffs-bg-separator: color-mix(in oklch, var(--muted) 42%, transparent);
+    --diffs-bg-buffer: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
+    --diffs-addition-base: var(--success);
+    --diffs-deletion-base: var(--destructive);
+    --diffs-selection-base: var(--primary);
+    --diffs-bg-addition-override: color-mix(in oklab, var(--background) 90%, var(--success));
+    --diffs-bg-deletion-override: color-mix(in oklab, var(--background) 90%, var(--destructive));
+    --diffs-bg-addition-emphasis-override: color-mix(in oklab, var(--background) 78%, var(--success));
+    --diffs-bg-deletion-emphasis-override: color-mix(in oklab, var(--background) 78%, var(--destructive));
+    --diffs-fg-number-addition-override: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+    --diffs-fg-number-deletion-override: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+    --diffs-gap-block: 0;
+    --diffs-gap-inline: 0;
+    --diffs-scrollbar-gutter-override: 10px;
+    --diffs-min-number-column-width: 4ch;
+  }
+
+  [data-code] {
+    width: 100%;
+    min-width: max-content;
+    max-width: none;
+    background: transparent;
+    overflow: visible;
+    padding-bottom: 0;
+  }
+
+  [data-code]::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  [data-gutter] {
+    z-index: 5;
+    background-color: var(--diffs-bg);
+    box-shadow: none;
+  }
+
+  [data-overflow="scroll"] [data-gutter] {
+    position: relative;
+    left: auto;
+  }
+
+  [data-line],
+  [data-column-number],
+  [data-no-newline] {
+    min-height: 1.25rem;
+    padding-inline: 0.375rem;
+  }
+
+  [data-column-number] {
+    min-width: 4ch;
+    padding-inline: 0.5rem 0.375rem;
+    color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+  }
+
+  [data-line-number-content] {
+    min-width: 4ch;
+  }
+
+  [data-separator="line-info-basic"] {
+    height: 1.125rem;
+    min-height: 1.125rem;
+  }
+
+  [data-separator="line-info-basic"] [data-separator-wrapper] {
+    border-radius: 0.25rem;
+    color: var(--muted-foreground);
+    background-color: color-mix(in oklch, var(--muted) 50%, transparent);
+    font-size: 10px;
+    line-height: 1.125rem;
+  }
+
+  [data-separator="line-info-basic"] [data-separator-content] {
+    height: 1.125rem;
+    padding-inline: 0.5ch;
+  }
+`;
+
+const PR_EMBEDDED_HUNK_SEPARATOR_CSS = `
+  [data-separator="line-info-basic"] {
+    height: 24px;
+    position: relative;
+  }
+
+  /*
+   * Pierre renders separator markup in every gutter/content row. Target the
+   * left gutter only, following https://diffs.com/docs#hunk-separators
+   */
+  [data-diff-type="single"] [data-gutter] [data-separator-wrapper] {
+    position: absolute;
+    left: 100%;
+    display: flex;
+    align-items: center;
+    gap: unset;
+    width: max-content;
+    background: transparent;
+    color: var(--diffs-fg-number);
+    font-family: var(--diffs-header-font-family, var(--diffs-header-font-fallback));
+    font-size: 0.6875rem;
+    margin-left: calc(-2ch - 2px);
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-separator-wrapper][data-separator-multi-button] {
+    margin-left: calc(-3ch - 2px);
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-button],
+  [data-diff-type="single"] [data-gutter] [data-separator-content] {
+    display: block;
+    align-self: unset;
+    min-width: unset;
+    min-height: unset;
+    padding: 0;
+    flex-shrink: 0;
+    grid-column: unset;
+    border: none;
+    width: auto;
+    height: auto;
+    background-color: unset;
+    color: inherit;
+    font: inherit;
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-button]:not([data-expand-all-button]) svg {
+    display: none;
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-button][data-expand-down]::before {
+    content: "↑";
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-button][data-expand-up]::before {
+    content: "↓";
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-button][data-expand-both]::before {
+    content: "↕";
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-separator-content] {
+    background: transparent;
+    margin-left: calc(2px + 1ch);
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-separator-content]:hover,
+  [data-diff-type="single"] [data-gutter] [data-expand-button]:hover,
+  [data-diff-type="single"] [data-gutter] [data-expand-all-button]:hover {
+    color: var(--diffs-fg);
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-all-button] {
+    position: relative;
+    margin-left: 14px;
+    text-transform: lowercase;
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-all-button]:hover {
+    text-decoration: underline;
+  }
+
+  [data-diff-type="single"] [data-gutter] [data-expand-all-button]::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: -8px;
+    margin-top: -1px;
+    width: 3px;
+    height: 3px;
+    border-radius: 2px;
+    background-color: var(--diffs-fg-number);
+    pointer-events: none;
+  }
+`;
+
+const PR_EMBEDDED_DIFF_CSS = `
+  :host {
+    display: block;
+    min-width: 0;
+    width: 100%;
+    min-width: max-content;
+    max-width: none;
+    color: var(--muted-foreground);
+    background: transparent;
+    font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 10.5px;
+    line-height: 1.45;
+    --diffs-bg: var(--card);
+    --diffs-fg: var(--muted-foreground);
+    --diffs-fg-number: var(--text-tertiary);
+    --diffs-bg-context: var(--card);
+    --diffs-bg-context-gutter: var(--card);
+    --diffs-bg-separator: var(--input);
+    --diffs-bg-separator-override: var(--input);
+    --diffs-bg-buffer: color-mix(in oklch, var(--muted-foreground) 10%, var(--card));
+    --diffs-addition-base: var(--success);
+    --diffs-deletion-base: var(--destructive);
+    --diffs-selection-base: var(--primary);
+    --diffs-bg-addition-override: color-mix(in oklab, var(--success) 13%, var(--card));
+    --diffs-bg-deletion-override: color-mix(in oklab, var(--destructive) 13%, var(--card));
+    --diffs-bg-addition-emphasis-override: color-mix(in oklab, var(--success) 30%, var(--card));
+    --diffs-bg-deletion-emphasis-override: color-mix(in oklab, var(--destructive) 30%, var(--card));
+    --diffs-fg-addition-override: color-mix(in oklch, var(--success) 62%, var(--foreground));
+    --diffs-fg-deletion-override: color-mix(in oklch, var(--destructive) 62%, var(--foreground));
+    --diffs-fg-number-addition-override: var(--text-tertiary);
+    --diffs-fg-number-deletion-override: var(--text-tertiary);
+    --diffs-gap-block: 0;
+    --diffs-gap-inline: 0;
+    --diffs-min-number-column-width: 26px;
+    --diffs-indicator-width-override: 2px;
+    --diffs-header-font-family: var(--font-sans, system-ui, sans-serif);
+  }
+
+  [data-code] {
+    width: 100%;
+    min-width: max-content;
+    max-width: none;
+    background: transparent;
+    overflow: visible;
+    padding: 0;
+  }
+
+  [data-code]::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  [data-gutter] {
+    z-index: 3;
+    background-color: var(--card);
+    box-shadow: none;
+  }
+
+  [data-gutter] [data-column-number],
+  [data-gutter] [data-gutter-buffer] {
+    background-color: var(--diffs-line-bg, var(--card));
+  }
+
+  [data-content] {
+    background-color: transparent;
+  }
+
+  [data-line] {
+    min-height: auto;
+    padding-block: 2px;
+    padding-inline: 10px 6px;
+  }
+
+  [data-column-number] {
+    width: 26px;
+    min-width: 26px;
+    max-width: 26px;
+    padding-inline: 0;
+    font-size: 9.5px;
+    text-align: right;
+    color: var(--text-tertiary);
+  }
+
+  [data-line-number-content] {
+    min-width: 26px;
+  }
+
+  ${PR_EMBEDDED_HUNK_SEPARATOR_CSS}
+`;
 
 const COMPACT_DIFF_OPTIONS = {
   theme: { light: "pierre-light", dark: "pierre-dark" },
@@ -38,95 +323,12 @@ const COMPACT_DIFF_OPTIONS = {
   maxLineDiffLength: 500,
   overflow: "scroll",
   tokenizeMaxLineLength: 500,
-  unsafeCSS: `
-    :host {
-      display: block;
-      min-width: 0;
-      width: 100%;
-      min-width: max-content;
-      max-width: none;
-      color: var(--foreground);
-      background: transparent;
-      font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-      font-size: 10px;
-      line-height: 1.45;
-      --diffs-bg: var(--background);
-      --diffs-fg: var(--foreground);
-      --diffs-fg-number: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
-      --diffs-bg-context: transparent;
-      --diffs-bg-context-gutter: color-mix(in oklch, var(--muted) 34%, transparent);
-      --diffs-bg-separator: color-mix(in oklch, var(--muted) 42%, transparent);
-      --diffs-bg-buffer: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
-      --diffs-addition-base: oklch(0.76 0.16 153);
-      --diffs-deletion-base: var(--destructive);
-      --diffs-selection-base: var(--primary);
-      --diffs-gap-block: 0;
-      --diffs-gap-inline: 0;
-      --diffs-scrollbar-gutter-override: 10px;
-      --diffs-min-number-column-width: 4ch;
-    }
+  unsafeCSS: COMPACT_DIFF_BASE_CSS,
+} satisfies NonNullable<DiffBasePropsReact<undefined>["options"]>;
 
-    [data-code] {
-      width: 100%;
-      min-width: max-content;
-      max-width: none;
-      background: transparent;
-      overflow: visible;
-      padding-bottom: 0;
-    }
-
-    [data-code]::-webkit-scrollbar {
-      display: none;
-      width: 0;
-      height: 0;
-    }
-
-    [data-gutter] {
-      z-index: 5;
-      background-color: var(--diffs-bg);
-      box-shadow: 1px 0 0 var(--border);
-    }
-
-    [data-overflow="scroll"] [data-gutter] {
-      position: relative;
-      left: auto;
-    }
-
-    [data-line],
-    [data-column-number],
-    [data-no-newline] {
-      min-height: 1.25rem;
-      padding-inline: 0.375rem;
-    }
-
-    [data-column-number] {
-      min-width: 4ch;
-      padding-inline: 0.5rem 0.375rem;
-      color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
-    }
-
-    [data-line-number-content] {
-      min-width: 4ch;
-    }
-
-    [data-separator="line-info-basic"] {
-      height: 1.125rem;
-      min-height: 1.125rem;
-    }
-
-    [data-separator="line-info-basic"] [data-separator-wrapper] {
-      border-radius: 0.25rem;
-      color: var(--muted-foreground);
-      background-color: color-mix(in oklch, var(--muted) 50%, transparent);
-      font-size: 10px;
-      line-height: 1.125rem;
-    }
-
-    [data-separator="line-info-basic"] [data-separator-content] {
-      height: 1.125rem;
-      padding-inline: 0.5ch;
-    }
-  `,
+const PR_EMBEDDED_PATCH_DIFF_OPTIONS = {
+  ...COMPACT_DIFF_OPTIONS,
+  unsafeCSS: PR_EMBEDDED_DIFF_CSS,
 } satisfies NonNullable<DiffBasePropsReact<undefined>["options"]>;
 
 export function DiffView({
@@ -166,6 +368,7 @@ export function PatchDiffView({
   previousFilename,
   status,
   className,
+  variant = "framed",
 }: PatchDiffViewProps) {
   const normalizedPatch = useMemo(
     () =>
@@ -184,15 +387,32 @@ export function PatchDiffView({
     return <DiffFallback>Diff preview unavailable for this file.</DiffFallback>;
   }
 
-  return (
-    <DiffFrame className={className}>
-      <PatchDiff
-        patch={normalizedPatch}
-        options={COMPACT_DIFF_OPTIONS}
-        className="block min-w-0 max-w-full"
-      />
-    </DiffFrame>
+  const options =
+    variant === "embedded" ? PR_EMBEDDED_PATCH_DIFF_OPTIONS : COMPACT_DIFF_OPTIONS;
+  const diff = (
+    <PatchDiff
+      patch={normalizedPatch}
+      options={options}
+      className="block min-w-0 max-w-full"
+    />
   );
+
+  if (variant === "embedded") {
+    return (
+      <div
+        className={cn(
+          "min-w-0 max-w-full overflow-hidden bg-transparent",
+          className,
+        )}
+      >
+        <div className="anton-diff-scrollbar min-w-0 max-w-full overflow-x-auto overflow-y-hidden">
+          {diff}
+        </div>
+      </div>
+    );
+  }
+
+  return <DiffFrame className={className}>{diff}</DiffFrame>;
 }
 
 function DiffFrame({

--- a/components/features/run-trace/pr-sidebar.tsx
+++ b/components/features/run-trace/pr-sidebar.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   AlertCircle,
+  ArrowLeft,
+  Bot,
   Check,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
   Clock,
   ExternalLink,
+  FileCode,
   FileText,
-  GitBranch,
-  GitCommit,
+  GitCommitHorizontal,
+  GitMerge,
   GitPullRequest,
   Loader2,
   MessageSquare,
@@ -27,12 +30,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import type {
   ProjectGitStatusSummary,
@@ -46,13 +43,24 @@ import type {
 } from "@/src/lib/api-types";
 import { errorMessage, getJson } from "@/src/lib/client-fetch";
 import { Markdown } from "@/components/features/chat/markdown";
-import { PopupSectionHeader } from "@/components/shared/popup-section-header";
-import { MetricTile } from "@/components/shared/metric-tile";
 import {
   PopupSortSelect,
   type PopupSortOption,
 } from "@/components/shared/popup-sort-select";
 import { PatchDiffView } from "./diff-view";
+
+type PrTabId = "changes" | "description" | "discussion" | "commits" | "checks";
+
+const PR_META_SECTION = "flex flex-col gap-[9px] px-3.5 py-3";
+const PR_TABS_ROW = "flex shrink-0 items-center gap-1 px-3.5 pb-2.5";
+const PR_CONTENT_SCROLL = "min-h-0 flex-1 overflow-y-auto border-t border-layout-border";
+const PR_BODY_PAD = "px-3.5 pt-3 pb-3.5";
+
+const PR_ICON_BUTTON =
+  "inline-flex size-6 shrink-0 items-center justify-center rounded-md text-(--text-tertiary) transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60";
+
+const PR_MARKDOWN_CLASSNAME =
+  "min-w-0 space-y-2.5 text-[12.5px] leading-[1.55] text-muted-foreground wrap-break-word [&_a]:text-primary [&_a]:no-underline hover:[&_a]:underline [&_code]:rounded [&_code]:bg-input [&_code]:px-1.5 [&_code]:py-px [&_code]:font-mono [&_code]:text-[11px] [&_code]:text-muted-foreground [&_h1]:text-[12.5px] [&_h1]:font-bold [&_h1]:leading-tight [&_h1]:text-foreground [&_h2]:text-[12.5px] [&_h2]:font-bold [&_h2]:leading-tight [&_h2]:text-foreground [&_h3]:text-[12.5px] [&_h3]:font-bold [&_h3]:leading-tight [&_h3]:text-foreground [&_li]:leading-[1.55] [&_ol]:space-y-2 [&_p]:leading-[1.55] [&_strong]:text-foreground [&_table]:w-full [&_table]:border-separate [&_table]:border-spacing-0 [&_table]:overflow-hidden [&_table]:rounded-md [&_table]:border [&_table]:border-border [&_table]:text-[11.5px] [&_th]:border-b [&_th]:border-layout-border [&_th]:bg-input [&_th]:px-2.5 [&_th]:py-1.5 [&_th]:text-left [&_th]:text-[10.5px] [&_th]:font-semibold [&_th]:text-(--text-tertiary) [&_td]:px-2.5 [&_td]:py-1.5 [&_td]:align-top [&_tbody_tr+tr_td]:border-t [&_tbody_tr+tr_td]:border-layout-border [&_ul]:space-y-2";
 
 export function PullRequestPanel({
   pullRequest,
@@ -72,110 +80,147 @@ export function PullRequestPanel({
   onRefresh: () => void;
   onSelectPullRequest: (number: number) => void;
 }) {
+  const [activeTab, setActiveTab] = useState<PrTabId>("changes");
+
+  const tabs: { id: PrTabId; label: string; count?: number }[] = [
+    { id: "changes", label: "Changes" },
+    { id: "description", label: "Description" },
+    { id: "discussion", label: "Discussion", count: pullRequest.discussion.length },
+    { id: "commits", label: "Commits", count: pullRequest.commitItems.length },
+    { id: "checks", label: "Checks" },
+  ];
+
   return (
-    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-      <section className="border-b border-layout-border px-3 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
-              <StateBadge pullRequest={pullRequest} />
-              <PullRequestSelector
-                project={project}
-                pullRequest={pullRequest}
-                onSelect={onSelectPullRequest}
-              />
-            </div>
-            <h2 className="mt-1 line-clamp-2 text-sm font-semibold leading-5">
-              {pullRequest.title}
-            </h2>
-            <div className="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
-              <span className="inline-flex items-center gap-1">
-                <span className="rounded bg-secondary px-1.5 py-0.5">
-                  {pullRequest.baseBranch}
-                </span>
-                <span
-                  aria-hidden
-                  className="inline-flex w-3.5 ml-1 shrink-0 items-center justify-center"
-                >
-                  &lt;-
-                </span>
-                <span className="rounded bg-secondary px-1.5 py-0.5">
-                  {pullRequest.headBranch}
-                </span>
-              </span>
-              <span className="text-muted-foreground/50">|</span>
-              <InlineStat value={pullRequest.changedFiles} label="files" />
-              <InlineStat value={`+${pullRequest.additions}`} tone="add" />
-              <InlineStat value={`-${pullRequest.deletions}`} tone="delete" />
-            </div>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      <div className={PR_META_SECTION}>
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <StateBadge pullRequest={pullRequest} />
+            <PullRequestSelector
+              project={project}
+              pullRequest={pullRequest}
+              onSelect={onSelectPullRequest}
+            />
           </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
+          <div className="flex shrink-0 items-center gap-2.5">
+            <button
               type="button"
-              size="icon-sm"
-              variant="ghost"
+              className={PR_ICON_BUTTON}
               onClick={onRefresh}
               disabled={loading}
               aria-label="Refresh pull request"
               title="Refresh pull request"
             >
-              <RefreshCw className={cn(loading && "animate-spin")} />
-            </Button>
-            <Button
-              type="button"
-              size="icon-sm"
-              variant="ghost"
-              asChild
+              <RefreshCw className={cn("size-3.5", loading && "animate-spin")} />
+            </button>
+            <a
+              href={pullRequest.htmlUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={PR_ICON_BUTTON}
               aria-label="Open pull request on GitHub"
               title="Open pull request on GitHub"
             >
-              <a href={pullRequest.htmlUrl} target="_blank" rel="noreferrer">
-                <ExternalLink />
-              </a>
-            </Button>
+              <ExternalLink className="size-3.5" />
+            </a>
           </div>
         </div>
 
+        <h2 className="line-clamp-2 text-[14.5px] font-semibold leading-[1.4] text-foreground">
+          {pullRequest.title}
+        </h2>
+
+        <div className="flex flex-wrap items-center gap-x-[7px] gap-y-1.5">
+          <BranchChip label={pullRequest.baseBranch} />
+          <ArrowLeft className="size-3.5 shrink-0 text-(--text-tertiary)" />
+          <BranchChip label={pullRequest.headBranch} />
+          <span className="text-[11.5px] text-(--text-tertiary)">
+            {pullRequest.changedFiles} files
+          </span>
+          <span className="font-mono text-[12px] font-semibold tabular-nums text-success">
+            +{pullRequest.additions}
+          </span>
+          <span className="font-mono text-[12px] font-semibold tabular-nums text-destructive">
+            -{pullRequest.deletions}
+          </span>
+        </div>
+
         {error ? (
-          <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+          <div className="rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
             {error}
           </div>
         ) : null}
-      </section>
+      </div>
 
-      <Tabs defaultValue="changes" className="min-w-0 gap-0">
-        <TabsList variant="workspace" className="overflow-x-auto pl-3 scrollbar-hide">
-          <TabsTrigger value="changes">Changes</TabsTrigger>
-          <TabsTrigger value="description">Description</TabsTrigger>
-          <TabsTrigger value="discussion">
-            Discussion {pullRequest.discussion.length}
-          </TabsTrigger>
-          <TabsTrigger value="commits">
-            Commits {pullRequest.commitItems.length}
-          </TabsTrigger>
-          <TabsTrigger value="checks">Checks</TabsTrigger>
-        </TabsList>
-        <TabsContent value="changes" className="m-0 min-w-0">
+      <div
+        role="tablist"
+        aria-label="Pull request sections"
+        className={PR_TABS_ROW}
+      >
+        {tabs.map((tab) => (
+          <PrTabButton
+            key={tab.id}
+            active={activeTab === tab.id}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.count !== undefined ? `${tab.label} ${tab.count}` : tab.label}
+          </PrTabButton>
+        ))}
+      </div>
+
+      <div className={PR_CONTENT_SCROLL}>
+        {activeTab === "changes" ? (
           <LocalChangesView files={pullRequest.files} />
-        </TabsContent>
-        <TabsContent value="description" className="m-0">
+        ) : activeTab === "description" ? (
           <DescriptionView description={pullRequest.description} />
-        </TabsContent>
-        <TabsContent value="discussion" className="m-0">
+        ) : activeTab === "discussion" ? (
           <DiscussionView items={pullRequest.discussion} />
-        </TabsContent>
-        <TabsContent value="commits" className="m-0">
+        ) : activeTab === "commits" ? (
           <CommitsView commits={pullRequest.commitItems} />
-        </TabsContent>
-        <TabsContent value="checks" className="m-0">
+        ) : (
           <ChecksView
             pullRequest={pullRequest}
             projectId={projectId}
             onRefresh={onRefresh}
           />
-        </TabsContent>
-      </Tabs>
+        )}
+      </div>
     </div>
+  );
+}
+
+function PrTabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-[26px] items-center rounded-lg px-3 text-[12.5px] leading-none whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        active
+          ? "border border-border bg-secondary font-semibold text-foreground"
+          : "border border-transparent font-medium text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function BranchChip({ label }: { label: string }) {
+  return (
+    <span className="rounded-md border border-border bg-secondary px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
+      {label}
+    </span>
   );
 }
 
@@ -206,48 +251,51 @@ export function PullRequestEmptyPanel({
       : null;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <section className="border-b border-layout-border px-3 py-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border">
-                <GitPullRequest className="size-3" />
-                No PR
-              </span>
-              <PullRequestSelector
-                project={project}
-                pullRequest={null}
-                onSelect={onSelectPullRequest}
-              />
-            </div>
-            <h2 className="mt-2 text-sm font-semibold">Pull request</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              {emptyPullRequestMessage(gitStatus)}
-            </p>
+      <section className={PR_META_SECTION}>
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-secondary px-2.5 py-1 text-[12px] font-semibold text-muted-foreground">
+              <GitPullRequest className="size-3" />
+              No PR
+            </span>
+            <PullRequestSelector
+              project={project}
+              pullRequest={null}
+              onSelect={onSelectPullRequest}
+            />
           </div>
-          <Button
+          <button
             type="button"
-            size="icon-sm"
-            variant="ghost"
+            className={PR_ICON_BUTTON}
             onClick={onRefresh}
             disabled={loading}
             aria-label="Refresh pull request"
             title="Refresh pull request"
           >
-            <RefreshCw className={cn(loading && "animate-spin")} />
-          </Button>
+            <RefreshCw className={cn("size-3", loading && "animate-spin")} />
+          </button>
+        </div>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-[14.5px] font-semibold leading-[1.4] text-foreground">
+            Pull request
+          </h2>
+          <p className="text-[12px] leading-[1.55] text-muted-foreground">
+            {emptyPullRequestMessage(gitStatus)}
+          </p>
         </div>
         {gitStatus ? (
-          <div className="mt-3 grid grid-cols-2 gap-2 text-[11px]">
-            <MetricTile label="Branch" value={gitStatus.branch ?? "detached"} />
-            <MetricTile label="Dirty" value={gitStatus.dirtyCount} />
+          <div className="flex flex-wrap items-center gap-x-[7px] gap-y-1.5">
+            <BranchChip label={gitStatus.branch ?? "detached"} />
+            <span className="text-[11.5px] text-(--text-tertiary)">
+              {gitStatus.dirtyCount} dirty
+            </span>
           </div>
         ) : null}
         {canShowCreateAction ? (
           <Button
             type="button"
             size="sm"
-            className="mt-3"
+            className="mt-1 self-start"
             onClick={onCreatePullRequest}
             disabled={!createReady || loading || creating}
             title={createBlocker ?? "Create pull request"}
@@ -261,12 +309,10 @@ export function PullRequestEmptyPanel({
           </Button>
         ) : null}
         {createBlocker ? (
-          <p className="mt-3 text-[11px] text-muted-foreground">
-            {createBlocker}
-          </p>
+          <p className="text-[11px] text-muted-foreground/70">{createBlocker}</p>
         ) : null}
         {error ? (
-          <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+          <div className="rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
             {error}
           </div>
         ) : null}
@@ -342,70 +388,70 @@ export function LocalChangesView({
   };
 
   if (files.length === 0) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        No changed files reported.
-      </div>
-    );
+    return <EmptyTabMessage>No changed files reported.</EmptyTabMessage>;
   }
 
   return (
-    <div className="min-h-0 min-w-0 overflow-y-auto px-2 py-2">
-      <ol className="grid min-w-0 gap-1.5">
-        {files.map((file) => {
-          const expanded = visibleExpandedFiles.has(file.filename);
-          return (
-            <li
-              key={file.filename}
-              className="min-w-0 overflow-hidden rounded-md bg-background/35 ring-1 ring-border/70"
+    <ol className={cn(PR_BODY_PAD, "grid min-w-0 gap-2")}>
+      {files.map((file) => {
+        const expanded = visibleExpandedFiles.has(file.filename);
+        return (
+          <li
+            key={file.filename}
+            className="min-w-0 overflow-hidden rounded-xl border border-border bg-card"
+          >
+            <button
+              type="button"
+              onClick={() => toggleFile(file.filename)}
+              aria-expanded={expanded}
+              aria-controls={diffPanelId(file.filename)}
+              className={cn(
+                "flex w-full items-center gap-2 px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                expanded && "border-b border-layout-border",
+              )}
             >
-              <button
-                type="button"
-                onClick={() => toggleFile(file.filename)}
-                aria-expanded={expanded}
-                aria-controls={diffPanelId(file.filename)}
-                className={cn(
-                  "grid w-full grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-1 px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                  expanded && "bg-accent/35",
-                )}
-              >
-                <span className="inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-accent/50">
-                  {expanded ? (
-                    <ChevronDown className="size-3 text-muted-foreground" />
-                  ) : (
-                    <ChevronRight className="size-3 text-muted-foreground" />
+              {expanded ? (
+                <ChevronDown className="size-3.5 shrink-0 text-(--text-tertiary)" />
+              ) : (
+                <ChevronRight className="size-3.5 shrink-0 text-(--text-tertiary)" />
+              )}
+              <FileKindBadge status={file.status} />
+              <span className="min-w-0 flex-1">
+                <span
+                  className={cn(
+                    "block truncate font-mono text-[12.5px] text-foreground",
+                    expanded ? "font-semibold" : "font-normal",
                   )}
+                >
+                  {file.filename}
                 </span>
-                <FileStatusBadge status={file.status} />
-                <span className="min-w-0 pl-1.5">
-                  <span className="block truncate font-medium">{file.filename}</span>
-                  {file.previousFilename ? (
-                    <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                      from {file.previousFilename}
-                    </span>
-                  ) : null}
-                </span>
-                <span className="font-mono text-[10px] tabular-nums">
-                  <span className="text-emerald-500">+{file.additions}</span>
-                  <span className="mx-1 text-muted-foreground/50">/</span>
-                  <span className="text-destructive">-{file.deletions}</span>
-                </span>
-              </button>
-              {expanded ? <PatchView file={file} /> : null}
-            </li>
-          );
-        })}
-      </ol>
-    </div>
+                {file.previousFilename ? (
+                  <span className="block truncate font-mono text-[10.5px] text-(--text-tertiary)">
+                    from {file.previousFilename}
+                  </span>
+                ) : null}
+              </span>
+              <span className="font-mono text-[11.5px] font-semibold tabular-nums text-success">
+                +{file.additions}
+              </span>
+              <span className="font-mono text-[11.5px] font-semibold tabular-nums text-destructive">
+                -{file.deletions}
+              </span>
+            </button>
+            {expanded ? <PatchView file={file} /> : null}
+          </li>
+        );
+      })}
+    </ol>
   );
 }
 
-function FileStatusBadge({ status }: { status: string }) {
+function FileKindBadge({ status }: { status: string }) {
   const meta = fileStatusMeta(status);
   return (
     <span
       className={cn(
-        "inline-flex size-3.5 items-center justify-center rounded-sm font-mono text-[9px] font-semibold leading-none ring-1",
+        "inline-flex size-[17px] shrink-0 items-center justify-center rounded-md text-[9.5px] font-bold leading-none",
         meta.className,
       )}
       title={meta.label}
@@ -426,33 +472,33 @@ function fileStatusMeta(status: string): {
       return {
         char: "A",
         label: "Added",
-        className: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
+        className: "bg-success/10 text-success",
       };
     case "modified":
     case "changed":
       return {
         char: "M",
         label: "Modified",
-        className: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+        className: "bg-primary/10 text-primary",
       };
     case "removed":
     case "deleted":
       return {
         char: "D",
         label: "Deleted",
-        className: "bg-destructive/15 text-red-300 ring-destructive/30",
+        className: "bg-destructive/10 text-destructive",
       };
     case "renamed":
       return {
         char: "R",
         label: "Renamed",
-        className: "bg-sky-500/15 text-sky-300 ring-sky-500/30",
+        className: "bg-info/10 text-info",
       };
     default:
       return {
         char: status.slice(0, 1).toUpperCase() || "?",
         label: status || "Unknown",
-        className: "bg-secondary text-muted-foreground ring-border",
+        className: "bg-secondary text-muted-foreground",
       };
   }
 }
@@ -461,14 +507,14 @@ function PatchView({ file }: { file: ProjectPullRequestFileSummary }) {
   return (
     <div
       id={diffPanelId(file.filename)}
-      className="min-w-0 max-w-full overflow-hidden border-t border-border/60"
+      className="min-w-0 max-w-full overflow-hidden"
     >
       <PatchDiffView
         patch={file.patch}
         filename={file.filename}
         previousFilename={file.previousFilename}
         status={file.status}
-        className="rounded-none ring-0"
+        variant="embedded"
       />
     </div>
   );
@@ -489,24 +535,22 @@ function ChecksView({
 }) {
   const meta = checkStateMeta(pullRequest.checks.state);
   if (pullRequest.checks.total === 0) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        No check runs reported.
-      </div>
-    );
+    return <EmptyTabMessage>No check runs reported.</EmptyTabMessage>;
   }
 
   return (
-    <div className="min-w-0 max-w-full px-2 py-2">
-      <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2 text-xs">
-        <meta.Icon className={cn("size-3.5", meta.className)} />
-        <span className="font-medium">{meta.label}</span>
-        <span className="text-muted-foreground">
-          {pullRequest.checks.passed} passed / {pullRequest.checks.pending} pending /{" "}
+    <div className={cn(PR_BODY_PAD, "min-w-0 max-w-full")}>
+      <div className="mb-1 flex min-w-0 flex-wrap items-center gap-2 pb-1">
+        <meta.Icon className={cn("size-4 shrink-0", meta.className)} />
+        <span className="text-[13px] font-semibold text-foreground">
+          {meta.label}
+        </span>
+        <span className="font-mono text-[11.5px] text-(--text-tertiary)">
+          {pullRequest.checks.passed} passed · {pullRequest.checks.pending} pending ·{" "}
           {pullRequest.checks.failed} failed
         </span>
       </div>
-      <ol className="grid min-w-0 max-w-full gap-1">
+      <ol className="grid min-w-0 max-w-full gap-2">
         {pullRequest.checks.runs.map((run) => (
           <li key={`${run.name}:${run.id ?? ""}`} className="min-w-0 max-w-full">
             <CheckRunRow
@@ -589,46 +633,56 @@ function CheckRunRow({
   };
 
   const runMeta = runStateMeta(run);
+  const statusLabel = run.conclusion ?? run.status;
+  const statusToneClass =
+    run.status !== "completed"
+      ? "text-warning"
+      : ["success", "neutral", "skipped"].includes(run.conclusion ?? "")
+        ? "text-success"
+        : "text-destructive";
 
   return (
-    <div className="min-w-0 max-w-full overflow-hidden rounded-md border border-border/40 bg-background/20">
-      <div className="flex min-w-0 items-center justify-between gap-2 px-2 py-1.5 text-xs hover:bg-accent/15">
+    <div className="min-w-0 max-w-full overflow-hidden rounded-xl border border-border bg-card">
+      <div className="flex min-w-0 items-center gap-2.5 px-3 py-2.5">
+        <runMeta.Icon className={cn("size-4 shrink-0", runMeta.className)} />
         <button
           type="button"
           onClick={toggleExpand}
           disabled={!canLoadLogs}
-          className="grid min-w-0 flex-1 grid-cols-[0.875rem_1fr] items-start gap-2 text-left"
+          className="min-w-0 flex-1 text-left focus-visible:outline-none disabled:cursor-default"
           title={canLoadLogs ? "View logs" : "No workflow job logs available for this check"}
         >
-          <runMeta.Icon className={cn("size-3.5 shrink-0 pt-0.5", runMeta.className)} />
-          <span className="min-w-0">
-            <span className="block truncate font-medium">{run.name}</span>
-            <span className="block truncate font-mono text-[10px] text-muted-foreground">
-              {run.conclusion ?? run.status}
-              {jobId ? ` | job ${jobId}` : " | GitHub check"}
+          <span className="block truncate text-[13px] font-semibold text-foreground">
+            {run.name}
+          </span>
+          <span className="mt-[3px] flex min-w-0 items-center gap-1.5 font-mono text-[11px]">
+            <span className={cn("font-semibold", statusToneClass)}>{statusLabel}</span>
+            <span className="text-(--text-tertiary)">|</span>
+            <span className="truncate text-(--text-tertiary)">
+              {jobId ? `job ${jobId}` : "GitHub check"}
             </span>
           </span>
         </button>
 
-        <div className="flex shrink-0 items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+        <div
+          className="flex shrink-0 items-center gap-2.5"
+          onClick={(e) => e.stopPropagation()}
+        >
           {run.htmlUrl ?? run.detailsUrl ? (
-            <Button
-              type="button"
-              size="icon-xs"
-              variant="ghost"
-              asChild
+            <a
+              href={run.htmlUrl ?? run.detailsUrl ?? ""}
+              target="_blank"
+              rel="noreferrer"
+              className={PR_ICON_BUTTON}
               title="Open check on GitHub"
             >
-              <a href={run.htmlUrl ?? run.detailsUrl ?? ""} target="_blank" rel="noreferrer">
-                <ExternalLink className="size-3" />
-              </a>
-            </Button>
+              <ExternalLink className="size-3" />
+            </a>
           ) : null}
           {canRerun ? (
-            <Button
+            <button
               type="button"
-              size="icon-xs"
-              variant="ghost"
+              className={PR_ICON_BUTTON}
               onClick={rerunJob}
               disabled={rerunning}
               title="Rerun failed job"
@@ -638,37 +692,43 @@ function CheckRunRow({
               ) : (
                 <RotateCcw className="size-3" />
               )}
-            </Button>
+            </button>
           ) : null}
           {canLoadLogs ? (
-            <Button
+            <button
               type="button"
-              size="icon-xs"
-              variant="ghost"
+              className={cn(
+                PR_ICON_BUTTON,
+                expanded && "text-muted-foreground",
+              )}
               onClick={toggleExpand}
               title="View logs"
             >
-              <FileText className="size-3" />
-            </Button>
+              {expanded ? (
+                <ChevronDown className="size-3" />
+              ) : (
+                <FileText className="size-3" />
+              )}
+            </button>
           ) : null}
         </div>
       </div>
 
       {expanded && (
-        <div className="min-w-0 max-w-full border-t border-border/40 bg-background/50 p-2 font-mono text-[10px]">
+        <div className="px-[11px] pb-2.5">
           {loadingLogs ? (
-            <div className="flex items-center gap-2 text-muted-foreground py-2 justify-center">
+            <div className="flex items-center justify-center gap-2 rounded-lg border border-layout-border bg-background px-2.5 py-3 text-[11.5px] text-(--text-tertiary)">
               <Loader2 className="size-3.5 animate-spin" />
               <span>Loading logs from GitHub...</span>
             </div>
           ) : error ? (
-            <div className="flex min-w-0 items-center justify-between gap-2 py-1 text-destructive">
+            <div className="flex min-w-0 items-center justify-between gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-[11px] text-destructive">
               <span className="min-w-0 whitespace-pre-wrap break-words">{error}</span>
               <Button
                 type="button"
                 size="xs"
                 variant="outline"
-                className="h-5 px-1.5 text-[9px]"
+                className="h-5 shrink-0 px-1.5 text-[9px]"
                 onClick={fetchLogs}
               >
                 Retry
@@ -676,25 +736,25 @@ function CheckRunRow({
             </div>
           ) : logs ? (
             <div className="relative min-w-0 max-w-full">
-              <pre className="block max-h-72 w-full max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-background/70 p-2 font-mono text-[10px] leading-normal text-foreground/90 wrap-break-word">
+              <pre className="block max-h-72 w-full max-w-full overflow-auto whitespace-pre-wrap break-words rounded-lg border border-layout-border bg-background px-3 py-2.5 font-mono text-[10px] leading-relaxed text-foreground/90 wrap-break-word">
                 {logs}
               </pre>
-              <div className="mt-1.5 flex justify-end">
-                <Button
+              <div className="mt-2 flex justify-end">
+                <button
                   type="button"
-                  size="xs"
-                  variant="outline"
-                  className="h-5 px-2 text-[9px]"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-secondary px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
                   onClick={fetchLogs}
                   disabled={loadingLogs}
                 >
-                  <RefreshCw className="mr-1 size-2.5" />
+                  <RefreshCw className="size-3" />
                   Reload Logs
-                </Button>
+                </button>
               </div>
             </div>
           ) : (
-            <div className="py-1 text-center font-sans text-muted-foreground">No logs available.</div>
+            <div className="rounded-lg border border-layout-border bg-background py-2 text-center text-[11.5px] text-(--text-tertiary)">
+              No logs available.
+            </div>
           )}
         </div>
       )}
@@ -715,19 +775,13 @@ function DescriptionView({ description }: { description: string | null }) {
   const body = description?.trim();
 
   if (!body) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        No PR description provided.
-      </div>
-    );
+    return <EmptyTabMessage>No PR description provided.</EmptyTabMessage>;
   }
 
   return (
-    <div className="px-2 py-2">
-      <article className="min-w-0 rounded-md bg-background/45 px-2.5 py-2 ring-1 ring-border">
-        <Markdown className="min-w-0 space-y-1 text-xs leading-snug wrap-break-word [&_h1]:mt-1 [&_h1]:text-sm [&_h1]:leading-tight [&_h2]:mt-1 [&_h2]:text-sm [&_h2]:leading-tight [&_h3]:mt-1 [&_h3]:leading-tight [&_li]:leading-snug [&_ol]:space-y-0 [&_p]:leading-snug [&_table]:text-[11px] [&_td]:px-1.5 [&_td]:py-0.5 [&_th]:px-1.5 [&_th]:py-0.5 [&_ul]:space-y-0">
-          {body}
-        </Markdown>
+    <div className={PR_BODY_PAD}>
+      <article className="min-w-0 rounded-xl border border-border bg-card px-4 py-3.5">
+        <Markdown className={PR_MARKDOWN_CLASSNAME}>{body}</Markdown>
       </article>
     </div>
   );
@@ -735,72 +789,63 @@ function DescriptionView({ description }: { description: string | null }) {
 
 function DiscussionView({ items }: { items: ProjectPullRequestDiscussionItem[] }) {
   if (items.length === 0) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        No discussion comments reported.
-      </div>
-    );
+    return <EmptyTabMessage>No discussion comments reported.</EmptyTabMessage>;
   }
 
   const orderedItems = orderDiscussionItems(items);
   const depthById = getDiscussionDepths(items);
 
   return (
-    <ol className="grid min-w-0 gap-1.5 px-2 py-2">
+    <ol className={cn(PR_BODY_PAD, "grid min-w-0 gap-2")}>
       {orderedItems.map((item) => {
         const depth = depthById.get(item.id) ?? 0;
         const isReply = depth > 0;
+        const isBot = item.authorLogin.endsWith("[bot]");
 
         return (
           <li
             key={`${item.kind}:${item.id}`}
-            className={cn(
-              "min-w-0",
-              isReply && "ml-3 border-l border-border pl-2",
-            )}
+            className={cn("min-w-0", isReply && "ml-3 border-l border-border pl-2")}
           >
-            <article className="min-w-0 rounded-md bg-background/45 px-2.5 py-2 ring-1 ring-border">
-              <div className="mb-1.5 flex min-w-0 items-start justify-between gap-2">
-                <div className="grid min-w-0 grid-cols-[0.875rem_minmax(0,1fr)] items-start gap-2">
-                  <MessageSquare
-                    className={cn(
-                      "mt-0.5 size-3.5 text-muted-foreground",
-                      isReply && "text-foreground/70",
-                    )}
-                  />
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs">
-                      <span className="truncate font-semibold">{item.authorLogin}</span>
-                      <span className="font-mono text-[10px] text-muted-foreground">
-                        {relativeTime(item.createdAt)}
-                      </span>
-                      <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                        {item.kind === "review_comment" ? "Review" : "Comment"}
-                      </span>
-                    </div>
-                    {item.path ? (
-                      <div className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">
-                        {item.path}
-                        {item.line ? `:${item.line}` : ""}
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  asChild
+            <article className="min-w-0 overflow-hidden rounded-xl border border-border bg-card">
+              <div className="flex min-w-0 items-center gap-2 border-b border-layout-border px-3 py-2.5">
+                {isBot ? (
+                  <Bot className="size-4 shrink-0 text-(--text-tertiary)" />
+                ) : (
+                  <MessageSquare className="size-4 shrink-0 text-(--text-tertiary)" />
+                )}
+                <span className="truncate text-[12.5px] font-semibold text-foreground">
+                  {item.authorLogin}
+                </span>
+                <span className="shrink-0 text-[11.5px] text-(--text-tertiary)">
+                  {relativeTime(item.createdAt)}
+                </span>
+                <span className="shrink-0 rounded-md border border-border bg-secondary px-2 py-0.5 text-[10.5px] font-medium text-muted-foreground">
+                  {item.kind === "review_comment" ? "Review" : "Comment"}
+                </span>
+                <span className="min-w-0 flex-1" />
+                <a
+                  href={item.htmlUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={PR_ICON_BUTTON}
                   title="Open comment on GitHub"
                 >
-                  <a href={item.htmlUrl} target="_blank" rel="noreferrer">
-                    <ExternalLink className="size-3" />
-                  </a>
-                </Button>
+                  <ExternalLink className="size-3" />
+                </a>
               </div>
-              <Markdown className="min-w-0 space-y-1 text-xs leading-snug wrap-break-word [&_h1]:mt-1 [&_h1]:text-sm [&_h1]:leading-tight [&_h2]:mt-1 [&_h2]:text-sm [&_h2]:leading-tight [&_h3]:mt-1 [&_h3]:leading-tight [&_li]:leading-snug [&_ol]:space-y-0 [&_p]:leading-snug [&_table]:text-[11px] [&_td]:px-1.5 [&_td]:py-0.5 [&_th]:px-1.5 [&_th]:py-0.5 [&_ul]:space-y-0">
-                {item.body}
-              </Markdown>
+              <div className="flex flex-col gap-2 px-3 py-2.5">
+                {item.path ? (
+                  <span className="inline-flex max-w-full items-center gap-1.5 self-start rounded border border-border bg-secondary px-2 py-0.5 font-mono text-[10.5px] text-muted-foreground">
+                    <FileCode className="size-3 shrink-0 text-(--text-tertiary)" />
+                    <span className="truncate">
+                      {item.path}
+                      {item.line ? `:${item.line}` : ""}
+                    </span>
+                  </span>
+                ) : null}
+                <Markdown className={PR_MARKDOWN_CLASSNAME}>{item.body}</Markdown>
+              </div>
             </article>
           </li>
         );
@@ -883,80 +928,63 @@ function CommitsView({
   commits: ProjectPullRequestCommitSummary[];
 }) {
   if (commits.length === 0) {
-    return (
-      <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-        No commits reported.
-      </div>
-    );
+    return <EmptyTabMessage>No commits reported.</EmptyTabMessage>;
   }
 
   return (
-    <ol className="grid min-w-0 gap-1.5 px-2 py-2">
+    <ol className={cn(PR_BODY_PAD, "grid min-w-0 gap-2")}>
       {commits.map((commit) => (
         <li
           key={commit.sha}
-          className="grid min-w-0 grid-cols-[0.875rem_minmax(0,1fr)_auto] items-start gap-2 rounded-md border border-border/40 bg-background/20 px-2 py-1.5 text-xs hover:bg-accent/25"
+          className="min-w-0 rounded-xl border border-border bg-card px-3 py-2.5"
         >
-          <GitCommit className="mt-0.5 size-3.5 text-muted-foreground" />
-          <div className="min-w-0">
+          <div className="flex min-w-0 items-start gap-2">
+            <GitCommitHorizontal className="mt-0.5 size-4 shrink-0 text-(--text-tertiary)" />
             <a
               href={commit.htmlUrl}
               target="_blank"
               rel="noreferrer"
-              className="block truncate font-semibold hover:underline"
+              className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-[1.4] text-foreground hover:underline"
             >
               {commit.title}
             </a>
-            <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
-              <span className="truncate">{commit.authorLogin ?? commit.authorName}</span>
-              <span>{relativeTime(commit.committedAt)}</span>
-              <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px]">
-                {commit.shortSha}
-              </span>
-            </div>
-            {commit.message !== commit.title ? (
-              <pre className="mt-1.5 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded bg-background/70 p-1.5 font-mono text-[10px] leading-normal text-muted-foreground">
-                {commit.message}
-              </pre>
-            ) : null}
-          </div>
-          <Button
-            type="button"
-            size="icon-xs"
-            variant="ghost"
-            asChild
-            title="Open commit on GitHub"
-          >
-            <a href={commit.htmlUrl} target="_blank" rel="noreferrer">
+            <a
+              href={commit.htmlUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(PR_ICON_BUTTON, "mt-0.5")}
+              title="Open commit on GitHub"
+            >
               <ExternalLink className="size-3" />
             </a>
-          </Button>
+          </div>
+          <div className="mt-2 flex min-w-0 flex-wrap items-center gap-2 pl-6">
+            <span className="truncate text-[11.5px] text-muted-foreground">
+              {commit.authorLogin ?? commit.authorName}
+            </span>
+            <span className="text-[11.5px] text-(--text-tertiary)">
+              {relativeTime(commit.committedAt)}
+            </span>
+            <span className="rounded-md border border-border bg-secondary px-1.5 py-px font-mono text-[10.5px] text-muted-foreground">
+              {commit.shortSha}
+            </span>
+          </div>
+          {commit.message !== commit.title ? (
+            <pre className="mt-2 min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-layout-border bg-background px-3 py-2.5 font-mono text-[10.5px] leading-[1.5] text-muted-foreground">
+              {commit.message}
+            </pre>
+          ) : null}
         </li>
       ))}
     </ol>
   );
 }
 
-function InlineStat({
-  value,
-  label,
-  tone,
-}: {
-  value: string | number;
-  label?: string;
-  tone?: "add" | "delete";
-}) {
+function EmptyTabMessage({ children }: { children: ReactNode }) {
   return (
-    <span
-      className={cn(
-        "font-mono tabular-nums",
-        tone === "add" && "text-emerald-400",
-        tone === "delete" && "text-destructive",
-      )}
-    >
-      {value}
-      {label ? <span className="ml-1 text-muted-foreground">{label}</span> : null}
-    </span>
+    <div className={cn(PR_BODY_PAD, "text-center text-[12px] text-(--text-tertiary)")}>
+      {children}
+    </div>
   );
 }
 
@@ -1100,62 +1128,60 @@ export function PullRequestSelector({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-0.5 rounded-sm px-1 py-0.5 font-mono text-[10px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-secondary px-2.5 py-1 font-mono text-[12px] text-muted-foreground transition-colors hover:bg-secondary/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label={pullRequest ? `Select pull request, current ${label}` : "Select pull request"}
         >
           <span className="truncate">{label}</span>
-          <ChevronDown className="size-3 shrink-0 opacity-70" />
+          <ChevronDown className="size-3.5 shrink-0 text-(--text-tertiary)" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" side="bottom" className="w-80 overflow-hidden p-0">
-        <div className="border-b border-layout-border p-1.5">
-          <div className="grid grid-cols-[0.75rem_1fr_auto] items-center gap-1.5 rounded-md bg-background/70 px-1.5 py-1 ring-1 ring-border">
-            <Search className="size-3 text-muted-foreground" />
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search pull requests"
-              className="min-w-0 bg-transparent font-mono text-[11px] outline-none placeholder:text-muted-foreground"
-              aria-label="Search pull requests"
-            />
-            <button
-              type="button"
-              onClick={() => void loadPullRequests()}
-              disabled={loading}
-              className="inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-              aria-label="Refresh pull requests"
-              title="Refresh pull requests"
-            >
-              {loading ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <RefreshCw className="size-3" />
-              )}
-            </button>
-          </div>
-        </div>
-        <div className="max-h-72 overflow-y-auto p-0.5">
-          <PopupSectionHeader
-            title="Pull requests"
-            action={
-              <PopupSortSelect
-                value={pullRequestSort}
-                options={PULL_REQUEST_SORT_OPTIONS}
-                onChange={setPullRequestSort}
-                aria-label="Sort pull requests"
-              />
-            }
+      <PopoverContent align="start" side="bottom" className="w-[360px] overflow-hidden p-0">
+        <div className="flex items-center gap-2 border-b border-layout-border px-3 py-2.5">
+          <Search className="size-4 shrink-0 text-(--text-tertiary)" />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search pull requests"
+            className="min-w-0 flex-1 bg-transparent text-[12.5px] outline-none placeholder:text-(--text-tertiary)"
+            aria-label="Search pull requests"
           />
+          <button
+            type="button"
+            onClick={() => void loadPullRequests()}
+            disabled={loading}
+            className={PR_ICON_BUTTON}
+            aria-label="Refresh pull requests"
+            title="Refresh pull requests"
+          >
+            {loading ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
+          </button>
+        </div>
+        <div className="max-h-80 overflow-y-auto">
+          <div className="flex items-center justify-between gap-2 px-3 pb-1 pt-2">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-(--text-tertiary)">
+              Pull requests
+            </span>
+            <PopupSortSelect
+              value={pullRequestSort}
+              options={PULL_REQUEST_SORT_OPTIONS}
+              onChange={setPullRequestSort}
+              aria-label="Sort pull requests"
+            />
+          </div>
           {error ? (
-            <div className="mx-1 rounded-md bg-destructive/10 px-1.5 py-1 text-[11px] text-destructive">
+            <div className="mx-2 mb-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
               {error}
             </div>
           ) : filteredPullRequests.length === 0 ? (
-            <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
+            <div className="px-3 py-6 text-center text-[11.5px] text-(--text-tertiary)">
               {loading ? "Loading pull requests..." : "No pull requests found."}
             </div>
           ) : (
-            <ul className="grid gap-0.5">
+            <ul className="grid gap-0.5 px-1.5 pb-1.5">
               {filteredPullRequests.map((item) => {
                 const selected = pullRequest?.number === item.number;
                 const stateLabel = item.merged
@@ -1168,32 +1194,35 @@ export function PullRequestSelector({
                     <button
                       type="button"
                       onClick={() => selectPullRequest(item)}
-                      className="grid w-full grid-cols-[0.75rem_minmax(0,1fr)_0.75rem] items-start gap-1.5 rounded-md px-1.5 py-1 text-left text-[11px] transition-colors hover:bg-accent disabled:opacity-60"
-                    >
-                      {selecting === item.number ? (
-                        <Loader2 className="mt-0.5 size-3 animate-spin text-primary" />
-                      ) : (
-                        <GitBranch
-                          className={cn(
-                            "mt-0.5 size-3",
-                            item.merged
-                              ? "text-purple-400"
-                              : item.state === "open"
-                                ? "text-emerald-400"
-                                : "text-muted-foreground",
-                          )}
-                        />
+                      className={cn(
+                        "flex w-full items-start gap-2.5 rounded-md px-2 py-[7px] text-left transition-colors hover:bg-secondary/60 disabled:opacity-60",
+                        selected && "bg-secondary",
                       )}
-                      <span className="min-w-0">
-                        <span className="block truncate font-medium">
+                    >
+                      <span className="pt-px">
+                        {selecting === item.number ? (
+                          <Loader2 className="size-4 animate-spin text-primary" />
+                        ) : (
+                          <PullRequestStateIcon item={item} />
+                        )}
+                      </span>
+                      <span className="grid min-w-0 flex-1 gap-[3px]">
+                        <span
+                          className={cn(
+                            "truncate text-[12.5px] text-foreground",
+                            selected ? "font-semibold" : "font-medium",
+                          )}
+                        >
                           #{item.number} {item.title}
                         </span>
-                        <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                          {item.headBranch} {"->"} {item.baseBranch} | {stateLabel} |{" "}
+                        <span className="truncate font-mono text-[10.5px] text-(--text-tertiary)">
+                          {item.headBranch} → {item.baseBranch} · {stateLabel} ·{" "}
                           {relativePullRequestTime(item.updatedAt)}
                         </span>
                       </span>
-                      {selected ? <Check className="mt-0.5 size-3 text-primary" /> : null}
+                      {selected ? (
+                        <Check className="mt-px size-4 shrink-0 text-primary" />
+                      ) : null}
                     </button>
                   </li>
                 );
@@ -1206,29 +1235,42 @@ export function PullRequestSelector({
   );
 }
 
+function PullRequestStateIcon({ item }: { item: ProjectPullRequestListItem }) {
+  if (item.merged) {
+    return <GitMerge className="size-4 text-thought" />;
+  }
+  return (
+    <GitPullRequest
+      className={cn(
+        "size-4",
+        item.state === "open" ? "text-success" : "text-(--text-tertiary)",
+      )}
+    />
+  );
+}
+
 function StateBadge({
   pullRequest,
 }: {
   pullRequest: ProjectPullRequestSummary;
 }) {
-  const label = pullRequest.merged
-    ? "Merged"
-    : pullRequest.state === "open"
-      ? "Open"
-      : "Closed";
-  const className = pullRequest.merged
-    ? "bg-purple-500/15 text-purple-300 ring-purple-500/30"
-    : pullRequest.state === "open"
-      ? "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30"
-      : "bg-secondary text-muted-foreground ring-border";
+  const merged = pullRequest.merged;
+  const open = !merged && pullRequest.state === "open";
+  const label = merged ? "Merged" : open ? "Open" : "Closed";
+  const className = merged
+    ? "bg-thought/12 text-thought"
+    : open
+      ? "bg-success/10 text-success"
+      : "bg-secondary text-muted-foreground";
+  const Icon = merged ? GitMerge : GitPullRequest;
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-mono text-[10px] ring-1",
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-1 text-[12px] font-semibold",
         className,
       )}
     >
-      <GitPullRequest className="size-3" />
+      <Icon className="size-3" />
       {label}
     </span>
   );
@@ -1253,10 +1295,10 @@ function runStateMeta(
   run: ProjectPullRequestSummary["checks"]["runs"][number],
 ) {
   if (run.status !== "completed") {
-    return { Icon: Clock, className: "text-amber-400" };
+    return { Icon: Clock, className: "text-warning" };
   }
   if (["success", "neutral", "skipped"].includes(run.conclusion ?? "")) {
-    return { Icon: CheckCircle2, className: "text-emerald-400" };
+    return { Icon: CheckCircle2, className: "text-success" };
   }
   return { Icon: XCircle, className: "text-destructive" };
 }

--- a/components/features/run-trace/project-diff-panel.tsx
+++ b/components/features/run-trace/project-diff-panel.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { RefreshCw } from "lucide-react";
+import { GitBranch, RefreshCw } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import {
   EmptyState,
   ErrorBanner,
@@ -111,64 +110,102 @@ export function ProjectDiffPanel({
   }
 
   const files = localDiff?.files ?? [];
+  const additions = files.reduce((sum, file) => sum + file.additions, 0);
+  const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      <section className="shrink-0 border-b border-layout-border px-3 py-2">
-        <div className="flex items-center justify-between gap-2">
-          <div className="min-w-0 text-[11px] text-muted-foreground">
-            {gitStatus ? (
-              <p className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-                <span className="font-mono text-foreground">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-layout-border px-3.5 py-[9px]">
+        <div className="flex min-w-0 items-center gap-2 font-mono text-[10.5px]">
+          {gitStatus ? (
+            <>
+              <span className="inline-flex min-w-0 items-center gap-[5px] rounded-[5px] border border-border bg-input px-2 py-0.5">
+                <GitBranch className="size-[11px] shrink-0 text-(--text-tertiary)" />
+                <span className="truncate font-semibold text-foreground">
                   {gitStatus.branch ?? "detached"}
                 </span>
-                <span>·</span>
-                <span>{gitStatus.dirtyCount} dirty</span>
-                {gitStatus.ahead !== null && gitStatus.behind !== null ? (
-                  <>
-                    <span>·</span>
-                    <span>
-                      {gitStatus.ahead}↑ {gitStatus.behind}↓
-                    </span>
-                  </>
-                ) : null}
-              </p>
-            ) : (
-              <p>Loading git state…</p>
-            )}
-          </div>
-          <Button
-            type="button"
-            size="icon-sm"
-            variant="ghost"
-            onClick={() => {
-              notifyProjectGitChanged(project.id);
-            }}
-            disabled={loading}
-            aria-label="Refresh diff"
-            title="Refresh diff"
-          >
-            <RefreshCw className={cn(loading && "animate-spin")} />
-          </Button>
+              </span>
+              <span
+                className={cn(
+                  "shrink-0",
+                  gitStatus.dirtyCount > 0
+                    ? "text-primary"
+                    : "text-(--text-tertiary)",
+                )}
+              >
+                {gitStatus.dirtyCount} dirty
+              </span>
+              {gitStatus.ahead !== null && gitStatus.behind !== null ? (
+                <>
+                  <span className="shrink-0 text-(--text-tertiary)">·</span>
+                  <span
+                    className={cn(
+                      "shrink-0",
+                      gitStatus.ahead > 0
+                        ? "text-success"
+                        : "text-(--text-tertiary)",
+                    )}
+                  >
+                    {gitStatus.ahead}↑
+                  </span>
+                  <span className="shrink-0 text-(--text-tertiary)">
+                    {gitStatus.behind}↓
+                  </span>
+                </>
+              ) : null}
+            </>
+          ) : (
+            <span className="text-(--text-tertiary)">Loading git state…</span>
+          )}
         </div>
-        {error ? (
-          <div className="mt-2">
-            <ErrorBanner message={error} />
-          </div>
-        ) : null}
-      </section>
+        <button
+          type="button"
+          onClick={() => {
+            notifyProjectGitChanged(project.id);
+          }}
+          disabled={loading}
+          aria-label="Refresh diff"
+          title="Refresh diff"
+          className="inline-flex size-5 shrink-0 items-center justify-center rounded text-(--text-tertiary) transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60"
+        >
+          <RefreshCw className={cn("size-3", loading && "animate-spin")} />
+        </button>
+      </div>
 
       {loading && files.length === 0 ? (
-        <div className="px-3 py-4">
+        <div className="px-3.5 py-4">
           <LoadingState label="Loading changes..." />
         </div>
+      ) : error ? (
+        <div className="px-3.5 pt-3">
+          <ErrorBanner message={error} />
+        </div>
       ) : files.length > 0 ? (
-        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
+          <div className="flex shrink-0 items-center gap-2 px-3.5 pt-3 font-mono text-[11px]">
+            <span className="font-sans text-[11.5px] text-(--text-tertiary)">
+              {files.length} file{files.length === 1 ? "" : "s"} changed
+            </span>
+            <span className="font-semibold tabular-nums text-success">
+              +{additions}
+            </span>
+            <span className="font-semibold tabular-nums text-destructive">
+              -{deletions}
+            </span>
+          </div>
           <LocalChangesView files={files} />
         </div>
       ) : (
-        <div className="px-3 py-4">
-          <EmptyState message="Working tree clean." />
+        <div className="px-3.5 pt-3">
+          <div className="flex flex-col items-center gap-2 rounded-lg border border-border bg-card px-6 py-9 text-center">
+            <GitBranch className="size-5 text-(--text-tertiary)" />
+            <span className="text-[12.5px] font-medium text-muted-foreground">
+              Working tree clean
+            </span>
+            <span className="text-[11.5px] text-(--text-tertiary)">
+              Uncommitted changes in this project will show up here.
+            </span>
+          </div>
         </div>
       )}
     </div>

--- a/components/features/run-trace/project-file-code-view.tsx
+++ b/components/features/run-trace/project-file-code-view.tsx
@@ -24,14 +24,14 @@ const codeViewerOptions = {
       width: 100%;
       min-width: max-content;
       max-width: none;
-      --project-file-code-surface: color-mix(in oklch, var(--background) 25%, var(--card));
+      --project-file-code-surface: var(--background);
       --diffs-bg: var(--project-file-code-surface);
       --diffs-dark-bg: var(--project-file-code-surface);
       --diffs-dark: #ededed;
       --diffs-font-size: 11px;
       --diffs-line-height: 19px;
       --diffs-font-family: var(--font-jetbrains-mono), "SF Mono", Monaco, Consolas, "Liberation Mono", monospace;
-      --diffs-fg-number-override: rgba(255, 255, 255, 0.34);
+      --diffs-fg-number-override: var(--text-tertiary);
       --diffs-gap-block: 0;
       --diffs-gap-inline: 0;
     }
@@ -39,7 +39,7 @@ const codeViewerOptions = {
       width: 100%;
       min-width: max-content;
       max-width: none;
-      padding-block: 0;
+      padding-block: 10px 14px;
       overflow: visible;
       background: transparent;
     }
@@ -51,23 +51,22 @@ const codeViewerOptions = {
     [data-gutter] {
       z-index: 5;
       background-color: var(--project-file-code-surface);
-      box-shadow: 1px 0 0 var(--border);
     }
     [data-overflow="scroll"] [data-gutter] {
       position: sticky;
       left: 0;
     }
     [data-column-number] {
-      min-width: 3.5ch;
-      padding-inline: 0.375rem 0.5rem;
+      min-width: 2.5ch;
+      padding-inline: 0.5rem 0.75rem;
+      font-size: 10px;
       background-color: var(--project-file-code-surface);
-      border-right: 1px solid rgba(255, 255, 255, 0.08);
     }
     [data-line-number-content] {
-      min-width: 3.5ch;
+      min-width: 2.5ch;
     }
     [data-line] {
-      padding-inline: 0.625rem 1rem;
+      padding-inline: 0.5rem 0.875rem;
     }
   `,
 };

--- a/components/features/run-trace/project-files-panel.tsx
+++ b/components/features/run-trace/project-files-panel.tsx
@@ -2,26 +2,27 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import {
+  Braces,
   FileCode,
-  FileJson,
   FileText,
   Image as FileImage,
   Music as FileAudio,
   Video as FileVideo,
   FolderTree,
+  ImageOff,
   Loader2,
+  Palette,
   RefreshCw,
+  Search,
   X,
 } from "lucide-react";
 import type { GitStatusEntry } from "@pierre/trees";
-import type { CSSProperties } from "react";
 import {
   FileTree,
   useFileTree,
   useFileTreeSearch,
 } from "@pierre/trees/react";
 
-import { Button } from "@/components/ui/button";
 import { useProjectFileTree } from "@/components/features/projects/hooks";
 import type {
   ProjectFileContentSummary,
@@ -31,18 +32,11 @@ import { errorMessage, getJson } from "@/src/lib/client-fetch";
 import { cn } from "@/lib/utils";
 import { ProjectFileCodeView } from "./project-file-code-view";
 
-const fileTreeStyle = {
-  "--trees-search-bg-override": "var(--secondary)",
-} as CSSProperties;
-
 function countBadgeGitChanges(
   gitStatus: readonly Pick<GitStatusEntry, "status">[],
 ): number {
   return gitStatus.filter((entry) => entry.status !== "ignored").length;
 }
-
-const projectFilesHeaderRowClass =
-  "flex shrink-0 items-center border-b border-layout-border p-1.5";
 
 type OpenFileState = {
   path: string;
@@ -203,8 +197,7 @@ function ProjectFileTree({
     initialExpansion: 1,
     gitStatus,
     paths: sortedPaths,
-    search: true,
-    searchBlurBehavior: "retain",
+    search: false,
     onSelectionChange: (selectedPaths) => {
       const path = selectedPaths.at(-1);
       if (!path || path.endsWith("/")) return;
@@ -230,8 +223,8 @@ function ProjectFileTree({
 
   return (
     <div className={cn("flex min-h-0 min-w-0 flex-col", className)}>
-      <div className={cn(projectFilesHeaderRowClass, "justify-between gap-2")}>
-        <div className="min-w-0 ml-1 truncate font-mono text-[11px] text-muted-foreground">
+      <div className="flex h-[41px] shrink-0 items-center justify-between gap-2 border-b border-layout-border pl-3.5 pr-3">
+        <div className="min-w-0 flex-1 truncate font-mono text-[10.5px] leading-relaxed text-muted-foreground">
           {search.value
             ? `${search.matchingPaths.length.toLocaleString()} match${search.matchingPaths.length === 1 ? "" : "es"}`
             : project?.localPath || "Project"}
@@ -240,23 +233,42 @@ function ProjectFileTree({
             : ""}
           {truncated ? ` · showing ${paths.length.toLocaleString()}` : ""}
         </div>
-        <Button
+        <button
           type="button"
-          size="icon-sm"
-          variant="ghost"
           onClick={onRefresh}
           disabled={refreshing}
           aria-label="Refresh file tree"
           title="Refresh file tree"
+          className="inline-flex size-5 shrink-0 items-center justify-center rounded text-(--text-tertiary) transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60"
         >
-          {refreshing ? <Loader2 className="animate-spin" /> : <RefreshCw />}
-        </Button>
+          {refreshing ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3" />
+          )}
+        </button>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden px-1 py-1">
+      <div className="shrink-0 px-3 pb-1.5 pt-2.5">
+        <div className="flex items-center gap-[7px] rounded-md border border-border bg-input px-2.5 py-[7px] transition-colors focus-within:border-ring/60">
+          <Search className="size-3 shrink-0 text-(--text-tertiary)" />
+          <input
+            type="text"
+            value={search.value}
+            onChange={(event) => {
+              const value = event.target.value;
+              search.setValue(value.length > 0 ? value : null);
+            }}
+            placeholder="Search files…"
+            aria-label="Search files"
+            spellCheck={false}
+            className="min-w-0 flex-1 bg-transparent text-[12px] leading-none text-foreground outline-none placeholder:text-(--text-tertiary)"
+          />
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden pb-3 pt-1">
         <FileTree
           model={model}
           className="anton-file-tree h-full overflow-hidden"
-          style={fileTreeStyle}
           aria-label="Project file tree"
         />
       </div>
@@ -285,6 +297,29 @@ function ProjectFilesEmptyState({
   );
 }
 
+function isUnsupportedFileError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("not valid utf-8") ||
+    normalized.includes("binary file content")
+  );
+}
+
+function ProjectFileUnsupportedState({ message }: { message: string }) {
+  const title = message.charAt(0).toUpperCase() + message.slice(1);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2.5 bg-background px-6 py-14 text-center">
+      <ImageOff className="size-[22px] text-(--text-tertiary)" />
+      <span className="text-[12.5px] font-medium text-muted-foreground">
+        {title}
+      </span>
+      <span className="text-[11.5px] text-(--text-tertiary)">
+        Binary files can&apos;t be previewed in the editor.
+      </span>
+    </div>
+  );
+}
+
 function ProjectFileViewer({
   files,
   activePath,
@@ -299,12 +334,9 @@ function ProjectFileViewer({
   onClose: (path: string) => void;
 }) {
   return (
-    <div className="flex min-h-0 min-w-0 flex-col bg-background/25">
+    <div className="flex min-h-0 min-w-0 flex-col">
       <div
-        className={cn(
-          projectFilesHeaderRowClass,
-          "min-w-0 gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide",
-        )}
+        className="flex h-[41px] shrink-0 items-center gap-1 overflow-x-auto overflow-y-hidden border-b border-layout-border px-2.5 scrollbar-hide"
         onWheel={(e) => {
           if (e.deltaY !== 0) {
             e.currentTarget.scrollLeft += e.deltaY;
@@ -312,53 +344,59 @@ function ProjectFileViewer({
           }
         }}
       >
-        {files.map((file) => (
-          <div
-            key={file.path}
-            className={cn(
-              "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center rounded text-[11px] font-normal transition-colors",
-              activePath === file.path
-                ? "bg-secondary text-foreground"
-                : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
-            )}
-            role="group"
-            aria-label={`${baseName(file.path)} tab`}
-            title={file.path}
-          >
-            <button
-              type="button"
-              onClick={() => onClose(file.path)}
-              className="group/close relative ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              aria-label={`Close ${file.path}`}
-              title={`Close ${baseName(file.path)}`}
+        {files.map((file) => {
+          const isActive = activePath === file.path;
+          return (
+            <div
+              key={file.path}
+              className={cn(
+                "inline-flex h-[26px] min-w-0 max-w-44 shrink-0 items-center gap-1.5 rounded-md border px-[9px] font-mono text-[10.5px] leading-none transition-colors",
+                isActive
+                  ? "border-border bg-secondary text-foreground"
+                  : "border-transparent text-(--text-tertiary) hover:bg-muted hover:text-muted-foreground",
+              )}
+              role="group"
+              aria-label={`${baseName(file.path)} tab`}
+              title={file.path}
             >
-              <FileIcon path={file.path} className="size-3 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
-              <X className="absolute size-3 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
-            </button>
-            <button
-              type="button"
-              onClick={() => onSelect(file.path)}
-              className="min-w-0 rounded pl-0 pr-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              aria-pressed={activePath === file.path}
-            >
-              <span className="block truncate">{baseName(file.path)}</span>
-            </button>
-          </div>
-        ))}
+              <button
+                type="button"
+                onClick={() => onClose(file.path)}
+                className="group/close relative inline-flex size-[15px] shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-background/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-label={`Close ${file.path}`}
+                title={`Close ${baseName(file.path)}`}
+              >
+                <FileIcon
+                  path={file.path}
+                  className="size-[11px] transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0"
+                />
+                <X className="absolute size-[11px] text-(--text-tertiary) opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
+              </button>
+              <button
+                type="button"
+                onClick={() => onSelect(file.path)}
+                className="min-w-0 rounded-sm pr-0.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-pressed={isActive}
+              >
+                <span className="block truncate">{baseName(file.path)}</span>
+              </button>
+            </div>
+          );
+        })}
       </div>
       {activeFile ? (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className={cn(projectFilesHeaderRowClass, "justify-between gap-2.5")}>
-            <div className="min-w-0 ml-1 flex items-center gap-1 font-mono text-xs text-muted-foreground">
+          <div className="flex shrink-0 items-center justify-between gap-2.5 border-b border-layout-border px-3.5 py-2">
+            <div className="flex min-w-0 items-center gap-1 font-mono text-[10.5px] text-muted-foreground">
               {activeFile.path.split("/").filter(Boolean).map((segment, index, array) => (
                 <span key={index} className="flex items-center gap-1">
-                  <span className="truncate hover:text-foreground transition-colors">{segment}</span>
-                  {index < array.length - 1 && <span className="shrink-0 text-muted-foreground/50">/</span>}
+                  <span className="truncate transition-colors hover:text-foreground">{segment}</span>
+                  {index < array.length - 1 && <span className="shrink-0 text-(--text-tertiary)">/</span>}
                 </span>
               ))}
             </div>
             {activeFile.sizeBytes !== null ? (
-              <span className="shrink-0 mr-1 font-mono text-[11px] text-muted-foreground">
+              <span className="shrink-0 font-mono text-[10.5px] text-(--text-tertiary)">
                 {formatBytes(activeFile.sizeBytes)}
               </span>
             ) : null}
@@ -366,7 +404,11 @@ function ProjectFileViewer({
           {activeFile.loading ? (
             <ProjectFilesEmptyState message="Loading file..." loading />
           ) : activeFile.error ? (
-            <ProjectFilesEmptyState message={activeFile.error} />
+            isUnsupportedFileError(activeFile.error) ? (
+              <ProjectFileUnsupportedState message={activeFile.error} />
+            ) : (
+              <ProjectFilesEmptyState message={activeFile.error} />
+            )
           ) : activeFile.content !== null ? (
             <ProjectFileCodeView
               key={`${activeFile.path}:${activeFile.content.length}`}
@@ -424,27 +466,37 @@ function formatBytes(sizeBytes: number): string {
 
 
 
+// File-type icon hues mirror the colored icons in design/mockups.pen (W3nOF).
 function FileIcon({ path, className }: { path: string; className?: string }) {
   const extension = path.split(".").pop()?.toLowerCase() || "";
-  
-  if (["js", "jsx", "ts", "tsx", "vue", "py", "rs", "go", "css", "scss", "html"].includes(extension)) {
-    return <FileCode className={className} />;
+
+  if (["tsx", "jsx"].includes(extension)) {
+    return <FileCode className={className} style={{ color: "#38BDF8" }} />;
   }
-  if (extension === "json" || extension === "yaml" || extension === "yml") {
-    return <FileJson className={className} />;
+  if (["ts", "js", "mjs", "cjs", "py", "rs", "go", "rb", "java", "c", "cpp", "vue", "html", "sh"].includes(extension)) {
+    return <FileCode className={className} style={{ color: "#5EA0EF" }} />;
   }
-  if (["png", "jpg", "jpeg", "gif", "svg", "webp"].includes(extension)) {
-    return <FileImage className={className} />;
+  if (["css", "scss", "sass", "less"].includes(extension)) {
+    return <Palette className={className} style={{ color: "#A78BFA" }} />;
+  }
+  if (["json", "yaml", "yml", "toml"].includes(extension)) {
+    return <Braces className={className} style={{ color: "#FACC15" }} />;
+  }
+  if (extension === "svg") {
+    return <FileImage className={className} style={{ color: "var(--primary)" }} />;
+  }
+  if (["png", "jpg", "jpeg", "gif", "webp", "ico", "avif"].includes(extension)) {
+    return <FileImage className={className} style={{ color: "#F472B6" }} />;
   }
   if (["mp3", "wav", "ogg", "flac"].includes(extension)) {
-    return <FileAudio className={className} />;
+    return <FileAudio className={className} style={{ color: "var(--text-tertiary)" }} />;
   }
   if (["mp4", "webm", "mov", "avi"].includes(extension)) {
-    return <FileVideo className={className} />;
+    return <FileVideo className={className} style={{ color: "var(--text-tertiary)" }} />;
   }
-  if (extension === "md" || extension === "markdown") {
-    return <FileText className={className} />;
+  if (["md", "markdown", "mdx"].includes(extension)) {
+    return <FileText className={className} style={{ color: "#7AA2F7" }} />;
   }
-  
-  return <FileCode className={className} />;
+
+  return <FileText className={className} style={{ color: "var(--text-tertiary)" }} />;
 }

--- a/components/features/run-trace/worklog.tsx
+++ b/components/features/run-trace/worklog.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction } from "ai";
 import {
   FileText,
-  GitBranch,
   GitCompareArrows,
+  GitPullRequest,
   FolderTree,
   Info,
   ListTodo,
@@ -23,7 +23,6 @@ import {
   type AntonUIMessage,
   type ToolTraceEntry,
 } from "@/src/lib/trace";
-import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/shared/feedback-states";
 import { cn } from "@/lib/utils";
 import { Markdown } from "@/components/features/chat/markdown";
@@ -43,16 +42,19 @@ import type {
 } from "@/src/lib/api-types";
 
 const traceWorkspaceHeaderRowClass =
-  "flex shrink-0 items-center border-b border-layout-border p-1.5";
+  "flex shrink-0 items-center border-b border-layout-border px-3.5 py-2.5";
 
 const traceWorkspaceTabClass =
-  "inline-flex h-6 min-w-0 max-w-44 shrink-0 items-center gap-1.5 rounded pl-1.5 pr-2 text-[11px] font-normal transition-colors duration-150";
+  "group/tab inline-flex h-[25px] min-w-0 max-w-44 shrink-0 items-center gap-1 rounded-[6px] border border-transparent pl-2 pr-2.5 text-[12.5px] leading-none transition-colors duration-150";
 
 const traceWorkspaceTabCloseButtonClass =
-  "group/close relative inline-flex size-4 shrink-0 items-center justify-center rounded transition-colors hover:bg-background/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+  "relative inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] text-(--text-tertiary) transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 const traceWorkspaceTabLabelButtonClass =
-  "min-w-0 rounded text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+  "flex min-w-0 items-center gap-1.5 rounded-[4px] text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+const traceWorkspaceIconButtonClass =
+  "inline-flex size-6 shrink-0 items-center justify-center rounded-md text-(--text-tertiary) transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-60";
 
 export type WorklogEntry = ToolTraceEntry;
 type SidebarTab = "worklog" | "plans" | "todos" | "pr" | "files" | "diff" | "status";
@@ -163,14 +165,15 @@ export function Worklog({
           <div className="flex min-w-0 items-center gap-1 overflow-x-auto overflow-y-hidden scrollbar-hide">
             {tabs.map((tab) => {
               const meta = tabMeta(tab);
+              const isActive = activeTab === tab;
               return (
                 <div
                   key={tab}
                   className={cn(
                     traceWorkspaceTabClass,
-                    activeTab === tab
-                      ? "bg-secondary text-foreground"
-                      : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
+                    isActive
+                      ? "border-border bg-secondary font-semibold text-foreground"
+                      : "font-medium text-muted-foreground hover:bg-muted hover:text-foreground",
                   )}
                   role="group"
                   aria-label={`${meta.label} tab`}
@@ -178,39 +181,42 @@ export function Worklog({
                   <button
                     type="button"
                     onClick={() => closeTab(tab)}
-                    className={traceWorkspaceTabCloseButtonClass}
+                    className={cn(
+                      traceWorkspaceTabCloseButtonClass,
+                      "group/close",
+                      isActive && "text-foreground",
+                    )}
                     aria-label={`Close ${meta.label} tab`}
                     title={`Close ${meta.label}`}
                   >
-                    <meta.Icon className="size-3 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
-                    <X className="absolute size-3 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
+                    <meta.Icon className="size-3 shrink-0 transition-opacity group-hover/close:opacity-0 group-focus-visible/close:opacity-0" />
+                    <X className="pointer-events-none absolute size-3 shrink-0 opacity-0 transition-opacity group-hover/close:opacity-100 group-focus-visible/close:opacity-100" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setActiveTab(tab)}
                     className={traceWorkspaceTabLabelButtonClass}
-                    aria-pressed={activeTab === tab}
+                    aria-pressed={isActive}
                   >
-                    <span className="block truncate">{meta.label}</span>
+                    <span className="truncate">{meta.label}</span>
                   </button>
                 </div>
               );
             })}
           </div>
 
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex shrink-0 items-center gap-2.5">
             <div className="relative">
-              <Button
+              <button
                 type="button"
-                size="icon-sm"
-                variant="ghost"
+                className={traceWorkspaceIconButtonClass}
                 onClick={() => setMenuOpen((open) => !open)}
                 disabled={availableTabs.length === 0}
                 aria-label="Add sidebar tab"
                 aria-expanded={menuOpen}
               >
-                <Plus />
-              </Button>
+                <Plus className="size-3.5" />
+              </button>
               {menuOpen && availableTabs.length > 0 && (
                 <div className="absolute right-0 top-full z-50 mt-1 w-36 min-w-36 overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-border">
                   <ul className="p-0.5">
@@ -236,27 +242,29 @@ export function Worklog({
               )}
             </div>
             {onExpandToggle && (
-              <Button
+              <button
                 type="button"
-                size="icon-sm"
-                variant="ghost"
+                className={traceWorkspaceIconButtonClass}
                 onClick={onExpandToggle}
                 aria-label={expanded ? "Shrink trace workspace" : "Expand trace workspace"}
                 aria-pressed={expanded}
               >
-                {expanded ? <Minimize2 /> : <Maximize2 />}
-              </Button>
+                {expanded ? (
+                  <Minimize2 className="size-[13px]" />
+                ) : (
+                  <Maximize2 className="size-[13px]" />
+                )}
+              </button>
             )}
             {onClose && (
-              <Button
+              <button
                 type="button"
-                size="icon-sm"
-                variant="ghost"
+                className={traceWorkspaceIconButtonClass}
                 onClick={onClose}
                 aria-label="Close trace workspace"
               >
-                <X />
-              </Button>
+                <X className="size-3.5" />
+              </button>
             )}
           </div>
         </header>
@@ -316,7 +324,7 @@ const SIDEBAR_TABS = [
   { id: "worklog", label: "Worklog", Icon: TerminalSquare },
   { id: "plans", label: "Plans", Icon: FileText },
   { id: "todos", label: "Todos", Icon: ListTodo },
-  { id: "pr", label: "PR", Icon: GitBranch },
+  { id: "pr", label: "PR", Icon: GitPullRequest },
   { id: "files", label: "Files", Icon: FolderTree },
   { id: "diff", label: "Diff", Icon: GitCompareArrows },
   { id: "status", label: "Status", Icon: Info },


### PR DESCRIPTION
## Summary

Brings the right-sidebar trace workspace tabs in line with `design/mockups.pen`, completing the design-system rollout for the workspace panels. Resolves #169.

### PR tab
- **Header** — state badge (Merged/Open/Closed), PR selector, base ← head branch chips, and `+/-` file stats.
- **Sub-tabs** — custom Changes / Description / Discussion / Commits / Checks tabs pinned to the mockup heights, with hover + active states.
- **Changes** — file cards (expand/collapse, kind badges, counts) and `@pierre/diffs` body theming: `oklab` green/red line tints, stronger word-level emphasis, dim line numbers, clean gutter, indicator bars.
- **Description / Discussion / Commits / Checks** — markdown card, comment cards (bot/user header, kind chip, file-mention chip, bordered tables), and title/meta/SHA cards with expandable detail.
- **PR switcher** — redesigned search + sort + result popover.

### Files tab
- **Tree** — retuned `@pierre/trees` metrics (5px radius, 8px row padding, 22px rows, accent-soft selection, muted hover, tertiary chevrons) to match the mockup.
- **Search** — replaced the built-in shadow-DOM input with a custom `bg-input` search box (leading magnifier + "Search files…") wired to the model search API.
- **File viewer** — open tabs (active bg+border, mono 10.5, colored file-type icons, X overlaying the icon only on icon hover), breadcrumb row, and a code surface on `bg-base` with tertiary line numbers and top/bottom padding.
- **Binary files** — added the `image-off` "File is not valid UTF-8 text" unsupported-file state.

### Diff tab
- **Branch row** — branch chip (`bg-input` + git-branch), accent `N dirty` / success `X↑` counts, plain refresh icon; height aligned with the Files path row.
- **Summary row** — `N files changed +X -Y`.
- **Empty state** — card-style "Working tree clean" with sub-text.
- File cards/patches reuse the shared `LocalChangesView` from the PR tab.

### Misc
- Worklog header tab sizing/hover alignment and a `--text-tertiary` token.

## Verification

- `pnpm typecheck` — passes.
- `pnpm lint` — passes.
- Visual: compared each tab (PR sub-tabs, Files tree + viewer + binary state, Diff clean/dirty) against the corresponding `design/mockups.pen` nodes; iterated on tab heights, icon alignment, spacing, and diff colors.

> Note: these panels render only with a ready project (PR panel also needs a GitHub project + open PR), so verification was against real local data plus the mockups; no automated UI test exists for this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)