### PR TITLE
[codex] Add conservative exact-text edit recovery

### DIFF
--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -8,9 +8,19 @@ import {
 } from "./sandbox";
 import {
   DIFF_PREVIEW_BYTES,
+  TEXT_FILE_MAX_BYTES,
   applySingleFilePatch,
   sha256,
 } from "./tools/edit-utils";
+import { pathGuardReasons } from "./tools/file-guardrails";
+import {
+  applyTextEditsToContent,
+  detectLineEnding,
+  normalizeToLF,
+  planTextReplacement,
+  restoreLineEndings,
+  type TextEdit,
+} from "./tools/text-edits";
 import { planFormatCommand } from "./tools/format";
 import {
   classifyBashCommand as classifyBashCommandByPolicy,
@@ -862,17 +872,12 @@ function buildEditTextApproval(
 ): ToolApprovalMetadata {
   const relPath = stringValue(input.path);
   const edits = Array.isArray(input.edits) ? input.edits : [];
-  const first = isRecord(edits[0]) ? edits[0] : undefined;
-  const oldText = typeof first?.oldText === "string" ? first.oldText : "";
-  const newText = typeof first?.newText === "string" ? first.newText : "";
-  const diff = buildReplaceTextDiffPreview({
+  const diff = buildEditTextDiffPreview({
     relPath,
-    find: oldText,
-    replace: newText,
-    expectedHash: undefined,
+    edits,
     workspaceRoot,
   });
-  const previewDetails = diff.message ? [diff.message] : [];
+  const previewDetails = diffPreviewDetails(diff);
 
   return {
     title: "Edit workspace file (exact text)",
@@ -902,10 +907,11 @@ function buildReplaceTextApproval(
     relPath,
     find,
     replace,
+    replaceAll: booleanValue(input.replaceAll),
     expectedHash: stringValue(input.expectedHash),
     workspaceRoot,
   });
-  const previewDetails = diff.message ? [diff.message] : [];
+  const previewDetails = diffPreviewDetails(diff);
 
   return {
     title: "Replace text in workspace file",
@@ -932,17 +938,13 @@ function buildMultiReplaceTextApproval(
 ): ToolApprovalMetadata {
   const relPath = stringValue(input.path);
   const replacements = Array.isArray(input.replacements) ? input.replacements : [];
-  const first = isRecord(replacements[0]) ? replacements[0] : undefined;
-  const find = typeof first?.find === "string" ? first.find : "";
-  const replace = typeof first?.replace === "string" ? first.replace : "";
-  const diff = buildReplaceTextDiffPreview({
+  const diff = buildMultiReplaceTextDiffPreview({
     relPath,
-    find,
-    replace,
+    replacements,
     expectedHash: stringValue(input.expectedHash),
     workspaceRoot,
   });
-  const previewDetails = diff.message ? [diff.message] : [];
+  const previewDetails = diffPreviewDetails(diff);
 
   return {
     title: "Apply ordered replacements in workspace file",
@@ -1105,6 +1107,19 @@ function lineRangeDetail(startLine: unknown, endLine: unknown): string {
   return `Line range: ${start ?? "default"} to ${end ?? "default"}`;
 }
 
+function diffPreviewDetails(diff: TextDiffPreviewResult): string[] {
+  const details: string[] = [];
+  if (diff.message) details.push(diff.message);
+  if (diff.recoveredEditCount && diff.recoveredEditCount > 0) {
+    details.push(
+      diff.recoveredEditCount === 1
+        ? "Diff preview uses one unique indentation-only match."
+        : `Diff preview uses ${diff.recoveredEditCount} unique indentation-only matches.`,
+    );
+  }
+  return details;
+}
+
 function fileStatusDetail(
   relPath: string | undefined,
   workspaceRoot: string | undefined,
@@ -1148,6 +1163,34 @@ function pathsDetail(value: unknown, workspaceRoot: string | undefined): string 
 function stringArrayValue(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === "string");
+}
+
+function textEditsFromUnknown(edits: unknown[]): TextEdit[] {
+  return edits.flatMap((edit) => {
+    if (!isRecord(edit)) return [];
+    const oldText = stringValue(edit.oldText);
+    const newText = stringValue(edit.newText);
+    if (oldText === undefined || newText === undefined) return [];
+    return [
+      {
+        oldText,
+        newText,
+        ...(booleanValue(edit.replaceAll) ? { replaceAll: true } : {}),
+      },
+    ];
+  });
+}
+
+function replacementsFromUnknown(
+  replacements: unknown[],
+): Array<{ find: string; replace: string }> {
+  return replacements.flatMap((replacement) => {
+    if (!isRecord(replacement)) return [];
+    const find = stringValue(replacement.find);
+    const replace = stringValue(replacement.replace);
+    if (find === undefined || replace === undefined) return [];
+    return [{ find, replace }];
+  });
 }
 
 function isVerificationTarget(
@@ -1197,22 +1240,76 @@ function buildEditFileDiffPreview(
   }
 }
 
+type TextDiffPreviewResult = {
+  preview?: ToolApprovalMetadata["diffPreview"];
+  message?: string;
+  recoveredEditCount?: number;
+};
+
+function buildEditTextDiffPreview({
+  relPath,
+  edits,
+  workspaceRoot,
+}: {
+  relPath: string | undefined;
+  edits: unknown[];
+  workspaceRoot: string | undefined;
+}): TextDiffPreviewResult {
+  if (!relPath) return { message: "Diff preview unavailable: path is missing." };
+  if (edits.length === 0) {
+    return { message: "Diff preview unavailable: no text edits provided." };
+  }
+  const normalizedEdits = textEditsFromUnknown(edits);
+  if (normalizedEdits.length !== edits.length) {
+    return { message: "Diff preview unavailable: text edits are invalid." };
+  }
+  try {
+    const current = readPreviewTextSync(relPath, workspaceRoot);
+    if (!current.ok) return { message: current.message };
+    const result = applyTextEditsToContent(current.content, normalizedEdits, {
+      allowIndentationRecovery: !current.guarded,
+      maxBytes: TEXT_FILE_MAX_BYTES,
+      recoveryDisabledReason: current.guarded ? "guarded" : undefined,
+    });
+    if (!result.ok) {
+      return {
+        message: `Diff preview unavailable: edit ${result.index + 1} would fail with ${result.code}: ${result.message}.`,
+      };
+    }
+    if (Buffer.byteLength(result.content, "utf8") > DIFF_PREVIEW_BYTES) {
+      return {
+        message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,
+      };
+    }
+    return {
+      preview: {
+        path: relPath,
+        previous: current.content,
+        next: result.content,
+        truncated: false,
+      },
+      recoveredEditCount: result.recoveredEditCount,
+    };
+  } catch (err) {
+    return { message: `Diff preview unavailable: ${errorMessage(err)}.` };
+  }
+}
+
 function buildReplaceTextDiffPreview({
   relPath,
   find,
   replace,
+  replaceAll,
   expectedHash,
   workspaceRoot,
 }: {
   relPath: string | undefined;
   find: string;
   replace: string;
+  replaceAll: boolean;
   expectedHash: string | undefined;
   workspaceRoot: string | undefined;
-}): {
-  preview?: ToolApprovalMetadata["diffPreview"];
-  message?: string;
-} {
+}): TextDiffPreviewResult {
   if (!relPath) return { message: "Diff preview unavailable: path is missing." };
   if (!find) return { message: "Diff preview unavailable: find text is missing." };
   try {
@@ -1223,10 +1320,26 @@ function buildReplaceTextDiffPreview({
         message: `Diff preview unavailable because expectedHash does not match current file hash ${current.sha256}.`,
       };
     }
-    if (!current.content.includes(find)) {
-      return { message: "Diff preview unavailable: find text is not present in the file." };
+    const lineEnding = detectLineEnding(current.content);
+    const plan = planTextReplacement({
+      content: normalizeToLF(current.content),
+      find: normalizeToLF(find),
+      replace: normalizeToLF(replace),
+      replaceAll,
+      allowIndentationRecovery: !current.guarded && !replaceAll,
+      maxBytes: TEXT_FILE_MAX_BYTES,
+      recoveryDisabledReason: current.guarded
+        ? "guarded"
+        : replaceAll
+          ? "replaceAll"
+          : undefined,
+    });
+    if (!plan.ok) {
+      return {
+        message: `Diff preview unavailable: replacement would fail with ${plan.code}: ${plan.message}.`,
+      };
     }
-    const next = current.content.replace(find, replace);
+    const next = restoreLineEndings(plan.content, lineEnding);
     if (Buffer.byteLength(next, "utf8") > DIFF_PREVIEW_BYTES) {
       return {
         message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,
@@ -1239,6 +1352,74 @@ function buildReplaceTextDiffPreview({
         next,
         truncated: false,
       },
+      recoveredEditCount: plan.strategy === "indentation" ? 1 : 0,
+    };
+  } catch (err) {
+    return { message: `Diff preview unavailable: ${errorMessage(err)}.` };
+  }
+}
+
+function buildMultiReplaceTextDiffPreview({
+  relPath,
+  replacements,
+  expectedHash,
+  workspaceRoot,
+}: {
+  relPath: string | undefined;
+  replacements: unknown[];
+  expectedHash: string | undefined;
+  workspaceRoot: string | undefined;
+}): TextDiffPreviewResult {
+  if (!relPath) return { message: "Diff preview unavailable: path is missing." };
+  if (replacements.length === 0) {
+    return { message: "Diff preview unavailable: no replacements provided." };
+  }
+  const normalizedReplacements = replacementsFromUnknown(replacements);
+  if (normalizedReplacements.length !== replacements.length) {
+    return { message: "Diff preview unavailable: replacements are invalid." };
+  }
+  try {
+    const current = readPreviewTextSync(relPath, workspaceRoot);
+    if (!current.ok) return { message: current.message };
+    if (expectedHash && current.sha256 !== expectedHash) {
+      return {
+        message: `Diff preview unavailable because expectedHash does not match current file hash ${current.sha256}.`,
+      };
+    }
+    const lineEnding = detectLineEnding(current.content);
+    let stagedContent = normalizeToLF(current.content);
+    let recoveredEditCount = 0;
+    for (const [index, replacement] of normalizedReplacements.entries()) {
+      const plan = planTextReplacement({
+        content: stagedContent,
+        find: normalizeToLF(replacement.find),
+        replace: normalizeToLF(replacement.replace),
+        allowIndentationRecovery: !current.guarded,
+        maxBytes: TEXT_FILE_MAX_BYTES,
+        recoveryDisabledReason: current.guarded ? "guarded" : undefined,
+      });
+      if (!plan.ok) {
+        return {
+          message: `Diff preview unavailable: replacement ${index + 1} would fail with ${plan.code}: ${plan.message}.`,
+        };
+      }
+      stagedContent = plan.content;
+      if (plan.strategy === "indentation") recoveredEditCount += 1;
+    }
+    const next = restoreLineEndings(stagedContent, lineEnding);
+    if (Buffer.byteLength(next, "utf8") > DIFF_PREVIEW_BYTES) {
+      return {
+        message: `Diff preview omitted because patched content is too large and exceeds ${DIFF_PREVIEW_BYTES} bytes.`,
+      };
+    }
+    return {
+      preview: {
+        path: relPath,
+        previous: current.content,
+        next,
+        truncated: false,
+      },
+      recoveredEditCount,
     };
   } catch (err) {
     return { message: `Diff preview unavailable: ${errorMessage(err)}.` };
@@ -1354,7 +1535,7 @@ function readPreviewTextSync(
   relPath: string,
   workspaceRoot: string | undefined,
 ):
-  | { ok: true; content: string; sha256: string }
+  | { ok: true; content: string; sha256: string; guarded: boolean }
   | { ok: false; reason: "missing" | "too-large" | "invalid"; message: string } {
   const root = workspaceRoot
     ? ensureWorkspaceRootAt(workspaceRoot)
@@ -1367,6 +1548,7 @@ function readPreviewTextSync(
       message: "Diff preview treats this as a new file.",
     };
   }
+  const lstat = fs.lstatSync(abs);
   const stat = fs.statSync(abs);
   if (!stat.isFile()) {
     return {
@@ -1400,7 +1582,12 @@ function readPreviewTextSync(
       message: "Diff preview unavailable because target appears to be binary.",
     };
   }
-  return { ok: true, content, sha256: sha256(bytes) };
+  return {
+    ok: true,
+    content,
+    sha256: sha256(bytes),
+    guarded: lstat.isSymbolicLink() || pathGuardReasons(relPath).length > 0,
+  };
 }
 
 function toolMetadata(

--- a/src/agent/tool-policy.ts
+++ b/src/agent/tool-policy.ts
@@ -1254,7 +1254,18 @@ function hashKey(value: string): string {
 }
 
 function stableJson(value: unknown): string {
-  return JSON.stringify(value ?? null);
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  return `{${Object.entries(value)
+    .filter(([, nested]) => nested !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, nested]) => `${JSON.stringify(key)}:${stableJson(nested)}`)
+    .join(",")}}`;
 }
 
 function finiteNumber(value: unknown): number | undefined {

--- a/src/agent/tools/edit-text.ts
+++ b/src/agent/tools/edit-text.ts
@@ -50,10 +50,14 @@ export function createEditTextTool(workspaceRoot?: string) {
     execute: async ({ path: relPath, edits, allowGuarded = false }) => {
       try {
         const abs = resolveInWorkspace(relPath, workspaceRoot);
-        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const metadata = await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
         const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
 
-        const result = applyTextEditsToContent(previous.content, edits);
+        const result = applyTextEditsToContent(previous.content, edits, {
+          allowIndentationRecovery: !metadata.guard.guarded,
+          maxBytes: TEXT_FILE_MAX_BYTES,
+          recoveryDisabledReason: metadata.guard.guarded ? "guarded" : undefined,
+        });
         if (!result.ok) {
           const failed = edits[result.index];
           return structuredError({
@@ -108,6 +112,16 @@ export function createEditTextTool(workspaceRoot?: string) {
           diff,
           patchPreview,
           priorReadStale: true as const,
+          ...(result.recoveredEditCount > 0
+            ? {
+                matchStrategy:
+                  result.recoveredEditCount === result.appliedCount
+                    ? "indentation"
+                    : "mixed",
+                recoveredEditCount: result.recoveredEditCount,
+                matchedLineRanges: result.matchedLineRanges,
+              }
+            : {}),
           ...(lint.skipped
             ? { postEditLint: "skipped" as const, postEditLintReason: lint.reason }
             : lint.ok
@@ -250,6 +264,15 @@ function compactEditTextModelOutput(output: unknown): JSONValue {
     nextHash: stringValue(output.nextHash),
     diff: stringValue(output.diff),
     priorReadStale: true,
+    ...(numberValue(output.recoveredEditCount) > 0
+      ? {
+          matchStrategy: stringValue(output.matchStrategy),
+          recoveredEditCount: numberValue(output.recoveredEditCount),
+          matchedLineRanges: Array.isArray(output.matchedLineRanges)
+            ? output.matchedLineRanges.slice(0, 10)
+            : [],
+        }
+      : {}),
     ...(stringValue(output.postEditLint)
       ? { postEditLint: stringValue(output.postEditLint) }
       : {}),
@@ -291,10 +314,10 @@ function recommendedNextForEditTextFailure(code: string): string {
     return "Use nearMatches or re-read the relevant range, then retry with current text.";
   }
   if (code === "FIND_NOT_UNIQUE") {
-    return "Narrow the oldText snippet or set replaceAll only when every match is intended.";
+    return "Include more surrounding context or use replace_lines.";
   }
   if (code === "GUARD_REJECTED") {
-    return "Set allowGuarded only if this guarded edit is intentional.";
+    return "Use exact text or replace_lines; automatic recovery is disabled for guarded files.";
   }
   if (code === "SYNTAX_OR_LINT_FAILED") {
     return "Use the lint issues and failed patch preview to make a smaller valid edit.";

--- a/src/agent/tools/multi-replace-text.ts
+++ b/src/agent/tools/multi-replace-text.ts
@@ -9,6 +9,13 @@ import {
 } from "./edit-utils";
 import { assertGuardAllowed } from "./file-guardrails";
 import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
+import {
+  detectLineEnding,
+  normalizeToLF,
+  planTextReplacement,
+  restoreLineEndings,
+  type MatchedLineRange,
+} from "./text-edits";
 
 const replacementSchema = z.object({
   find: z.string().min(1).describe("Exact text to find in the file."),
@@ -44,7 +51,7 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
     execute: async ({ path: relPath, expectedHash, replacements, allowGuarded = false }) => {
       try {
         const abs = resolveInWorkspace(relPath, workspaceRoot);
-        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const metadata = await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
         const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
         if (previous.sha256 !== expectedHash) {
           return structuredError({
@@ -56,35 +63,44 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
           });
         }
 
-        let nextContent = previous.content;
+        const lineEnding = detectLineEnding(previous.content);
+        let nextContent = normalizeToLF(previous.content);
         let replacementCount = 0;
+        let recoveredEditCount = 0;
+        const matchedLineRanges: MatchedLineRange[] = [];
         for (const [index, replacement] of replacements.entries()) {
-          const occurrences = countOccurrences(nextContent, replacement.find);
-          if (occurrences === 0) {
+          const plan = planTextReplacement({
+            content: nextContent,
+            find: normalizeToLF(replacement.find),
+            replace: normalizeToLF(replacement.replace),
+            allowIndentationRecovery: !metadata.guard.guarded,
+            maxBytes: TEXT_FILE_MAX_BYTES,
+            recoveryDisabledReason: metadata.guard.guarded ? "guarded" : undefined,
+          });
+          if (!plan.ok) {
             return structuredError({
-              code: "FIND_NOT_FOUND",
+              code: plan.code,
               path: relPath,
               expectedHash,
-              message: `${relPath} exists and hash matched, but replacement ${index + 1} find snippet was not found`,
+              message: `${relPath} exists and hash matched, but replacement ${index + 1} failed: ${plan.message}`,
               failedReplacementIndex: index,
               matchedReplacementCount: replacementCount,
               find: replacement.find,
-              content: previous.content,
+              content: nextContent,
             });
           }
-          if (occurrences > 1) {
-            return structuredError({
-              code: "FIND_NOT_UNIQUE",
-              path: relPath,
-              expectedHash,
-              message: `replacement ${index + 1}: find text occurs ${occurrences} times in ${relPath}; narrow find`,
-            });
+          nextContent = plan.content;
+          replacementCount += plan.replacementCount;
+          if (plan.strategy === "indentation") {
+            recoveredEditCount += 1;
+            if (plan.matchedLineRange) {
+              matchedLineRanges.push(plan.matchedLineRange);
+            }
           }
-          nextContent = nextContent.replace(replacement.find, replacement.replace);
-          replacementCount += 1;
         }
 
-        if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
+        const restoredContent = restoreLineEndings(nextContent, lineEnding);
+        if (Buffer.byteLength(restoredContent, "utf8") > TEXT_FILE_MAX_BYTES) {
           return structuredError({
             code: "WRITE_FAILED",
             path: relPath,
@@ -93,14 +109,24 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
           });
         }
 
-        await atomicWriteTextFile(abs, nextContent);
+        await atomicWriteTextFile(abs, restoredContent);
         return {
           ok: true as const,
           path: relPath,
           replacementCount,
           previousHash: previous.sha256,
-          nextHash: sha256(nextContent),
-          bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+          nextHash: sha256(restoredContent),
+          bytesWritten: Buffer.byteLength(restoredContent, "utf8"),
+          ...(recoveredEditCount > 0
+            ? {
+                matchStrategy:
+                  recoveredEditCount === replacementCount
+                    ? "indentation"
+                    : "mixed",
+                recoveredEditCount,
+                matchedLineRanges,
+              }
+            : {}),
         };
       } catch (err) {
         if (err instanceof SandboxError && err.message.includes("guard")) {
@@ -123,19 +149,6 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
 }
 
 export const multiReplaceTextTool = createMultiReplaceTextTool();
-
-function countOccurrences(source: string, find: string): number {
-  if (find.length === 0) return 0;
-  let count = 0;
-  let index = 0;
-  while (index <= source.length - find.length) {
-    const next = source.indexOf(find, index);
-    if (next === -1) break;
-    count += 1;
-    index = next + find.length;
-  }
-  return count;
-}
 
 function structuredError(input: {
   code:
@@ -213,6 +226,15 @@ function compactMultiReplaceModelOutput(output: unknown): JSONValue {
     previousHash: stringValue(output.previousHash),
     nextHash: stringValue(output.nextHash),
     bytesWritten: numberValue(output.bytesWritten),
+    ...(numberValue(output.recoveredEditCount) > 0
+      ? {
+          matchStrategy: stringValue(output.matchStrategy),
+          recoveredEditCount: numberValue(output.recoveredEditCount),
+          matchedLineRanges: Array.isArray(output.matchedLineRanges)
+            ? output.matchedLineRanges.slice(0, 10)
+            : [],
+        }
+      : {}),
   };
 }
 

--- a/src/agent/tools/replace-text.ts
+++ b/src/agent/tools/replace-text.ts
@@ -9,6 +9,12 @@ import {
 } from "./edit-utils";
 import { assertGuardAllowed } from "./file-guardrails";
 import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
+import {
+  detectLineEnding,
+  normalizeToLF,
+  planTextReplacement,
+  restoreLineEndings,
+} from "./text-edits";
 
 export function createReplaceTextTool(workspaceRoot?: string) {
   return tool({
@@ -49,7 +55,7 @@ export function createReplaceTextTool(workspaceRoot?: string) {
     }) => {
       try {
         const abs = resolveInWorkspace(relPath, workspaceRoot);
-        await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
+        const metadata = await assertGuardAllowed({ absPath: abs, relPath, allowGuarded });
         const previous = await readTextFileSnapshot(abs, TEXT_FILE_MAX_BYTES);
         if (previous.sha256 !== expectedHash) {
           return structuredReplaceError({
@@ -61,29 +67,32 @@ export function createReplaceTextTool(workspaceRoot?: string) {
           });
         }
 
-        const occurrences = countOccurrences(previous.content, find);
-        if (occurrences === 0) {
+        const lineEnding = detectLineEnding(previous.content);
+        const plan = planTextReplacement({
+          content: normalizeToLF(previous.content),
+          find: normalizeToLF(find),
+          replace: normalizeToLF(replace),
+          replaceAll,
+          allowIndentationRecovery: !metadata.guard.guarded && !replaceAll,
+          maxBytes: TEXT_FILE_MAX_BYTES,
+          recoveryDisabledReason: metadata.guard.guarded
+            ? "guarded"
+            : replaceAll
+              ? "replaceAll"
+              : undefined,
+        });
+        if (!plan.ok) {
           return structuredReplaceError({
-            code: "FIND_NOT_FOUND",
+            code: plan.code,
             path: relPath,
             expectedHash,
-            message: `${relPath} exists and hash matched, but the find snippet was not found`,
+            message: `${relPath} exists and hash matched, but replacement failed: ${plan.message}`,
             find,
             content: previous.content,
           });
         }
-        if (!replaceAll && occurrences > 1) {
-          return structuredReplaceError({
-            code: "FIND_NOT_UNIQUE",
-            path: relPath,
-            expectedHash,
-            message: `find text occurs ${occurrences} times in ${relPath}; set replaceAll: true or narrow find`,
-          });
-        }
 
-        const nextContent = replaceAll
-          ? previous.content.split(find).join(replace)
-          : previous.content.replace(find, replace);
+        const nextContent = restoreLineEndings(plan.content, lineEnding);
         if (Buffer.byteLength(nextContent, "utf8") > TEXT_FILE_MAX_BYTES) {
           return structuredReplaceError({
             code: "WRITE_FAILED",
@@ -97,10 +106,19 @@ export function createReplaceTextTool(workspaceRoot?: string) {
         return {
           ok: true as const,
           path: relPath,
-          replacementCount: replaceAll ? occurrences : 1,
+          replacementCount: plan.replacementCount,
           previousHash: previous.sha256,
           nextHash: sha256(nextContent),
           bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+          ...(plan.strategy === "indentation"
+            ? {
+                matchStrategy: "indentation",
+                recoveredEditCount: 1,
+                matchedLineRanges: plan.matchedLineRange
+                  ? [plan.matchedLineRange]
+                  : [],
+              }
+            : {}),
         };
       } catch (err) {
         if (err instanceof SandboxError && err.message.includes("guard")) {
@@ -123,19 +141,6 @@ export function createReplaceTextTool(workspaceRoot?: string) {
 }
 
 export const replaceTextTool = createReplaceTextTool();
-
-function countOccurrences(source: string, find: string): number {
-  if (find.length === 0) return 0;
-  let count = 0;
-  let index = 0;
-  while (index <= source.length - find.length) {
-    const next = source.indexOf(find, index);
-    if (next === -1) break;
-    count += 1;
-    index = next + find.length;
-  }
-  return count;
-}
 
 function structuredReplaceError(input: {
   code:
@@ -199,6 +204,15 @@ function compactReplaceTextModelOutput(output: unknown): JSONValue {
     previousHash: stringValue(output.previousHash),
     nextHash: stringValue(output.nextHash),
     bytesWritten: numberValue(output.bytesWritten),
+    ...(numberValue(output.recoveredEditCount) > 0
+      ? {
+          matchStrategy: stringValue(output.matchStrategy),
+          recoveredEditCount: numberValue(output.recoveredEditCount),
+          matchedLineRanges: Array.isArray(output.matchedLineRanges)
+            ? output.matchedLineRanges.slice(0, 10)
+            : [],
+        }
+      : {}),
   };
 }
 

--- a/src/agent/tools/text-edits.ts
+++ b/src/agent/tools/text-edits.ts
@@ -5,8 +5,48 @@ export type TextEdit = {
 };
 
 export type ApplyTextEditsResult =
-  | { ok: true; content: string; appliedCount: number }
-  | { ok: false; index: number; code: "FIND_NOT_FOUND" | "FIND_NOT_UNIQUE"; message: string };
+  | {
+      ok: true;
+      content: string;
+      appliedCount: number;
+      recoveredEditCount: number;
+      matchedLineRanges: MatchedLineRange[];
+    }
+  | {
+      ok: false;
+      index: number;
+      code: TextReplacementFailureCode;
+      message: string;
+    };
+
+export type TextReplacementStrategy = "exact" | "indentation";
+
+export type TextReplacementFailureCode =
+  | "FIND_NOT_FOUND"
+  | "FIND_NOT_UNIQUE"
+  | "WRITE_FAILED";
+
+export type MatchedLineRange = {
+  startLine: number;
+  endLine: number;
+  strategy: "indentation";
+};
+
+export type PlanTextReplacementResult =
+  | {
+      ok: true;
+      content: string;
+      strategy: TextReplacementStrategy;
+      replacementCount: number;
+      matchedLineRange?: MatchedLineRange;
+    }
+  | {
+      ok: false;
+      code: TextReplacementFailureCode;
+      message: string;
+    };
+
+type RecoveryDisabledReason = "guarded" | "replaceAll";
 
 const MODEL_DIFF_MAX_CHARS = 4_000;
 
@@ -26,10 +66,17 @@ export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string 
 export function applyTextEditsToContent(
   source: string,
   edits: readonly TextEdit[],
+  options: {
+    allowIndentationRecovery?: boolean;
+    maxBytes?: number;
+    recoveryDisabledReason?: RecoveryDisabledReason;
+  } = {},
 ): ApplyTextEditsResult {
   const lineEnding = detectLineEnding(source);
   let content = normalizeToLF(source);
   let appliedCount = 0;
+  let recoveredEditCount = 0;
+  const matchedLineRanges: MatchedLineRange[] = [];
 
   for (let index = 0; index < edits.length; index += 1) {
     const edit = edits[index];
@@ -37,10 +84,17 @@ export function applyTextEditsToContent(
     const normalizedNew = normalizeToLF(edit.newText);
     if (normalizedOld === normalizedNew) continue;
 
-    const applied = applySingleEdit(content, {
-      oldText: normalizedOld,
-      newText: normalizedNew,
+    const applied = planTextReplacement({
+      content,
+      find: normalizedOld,
+      replace: normalizedNew,
       replaceAll: edit.replaceAll,
+      allowIndentationRecovery: options.allowIndentationRecovery,
+      maxBytes: options.maxBytes,
+      recoveryDisabledReason:
+        edit.replaceAll === true
+          ? "replaceAll"
+          : options.recoveryDisabledReason,
     });
     if (!applied.ok) {
       return {
@@ -56,12 +110,20 @@ export function applyTextEditsToContent(
     }
     content = applied.content;
     appliedCount += applied.replacementCount;
+    if (applied.strategy === "indentation") {
+      recoveredEditCount += 1;
+      if (applied.matchedLineRange) {
+        matchedLineRanges.push(applied.matchedLineRange);
+      }
+    }
   }
 
   return {
     ok: true,
     content: restoreLineEndings(content, lineEnding),
     appliedCount,
+    recoveredEditCount,
+    matchedLineRanges,
   };
 }
 
@@ -80,39 +142,139 @@ function formatEditFailureMessage(
   return baseMessage;
 }
 
-function applySingleEdit(
-  content: string,
-  edit: TextEdit,
-):
-  | { ok: true; content: string; replacementCount: number }
-  | { ok: false; code: "FIND_NOT_FOUND" | "FIND_NOT_UNIQUE"; message: string } {
-  const replaceAll = edit.replaceAll === true;
-  const occurrences = countOccurrences(content, edit.oldText);
-  if (occurrences === 0) {
+export function planTextReplacement({
+  content,
+  find,
+  replace,
+  replaceAll = false,
+  allowIndentationRecovery = false,
+  maxBytes,
+  recoveryDisabledReason,
+}: {
+  content: string;
+  find: string;
+  replace: string;
+  replaceAll?: boolean;
+  allowIndentationRecovery?: boolean;
+  maxBytes?: number;
+  recoveryDisabledReason?: RecoveryDisabledReason;
+}): PlanTextReplacementResult {
+  if (find.length === 0) {
     return {
       ok: false,
       code: "FIND_NOT_FOUND",
-      message: "oldText did not match file content exactly",
+      message: "find text is empty; re-read the relevant range and retry with current text",
     };
   }
+
+  const occurrences = countOccurrences(content, find);
+  if (occurrences === 0) {
+    if (replaceAll) {
+      return {
+        ok: false,
+        code: "FIND_NOT_FOUND",
+        message:
+          "find text did not match file content exactly; replaceAll does not use indentation recovery",
+      };
+    }
+    if (!allowIndentationRecovery) {
+      return {
+        ok: false,
+        code: "FIND_NOT_FOUND",
+        message: recoveryDisabledMessage(recoveryDisabledReason),
+      };
+    }
+    return planIndentationReplacement({ content, find, replace, maxBytes });
+  }
+
   if (!replaceAll && occurrences > 1) {
     return {
       ok: false,
       code: "FIND_NOT_UNIQUE",
-      message: `oldText occurs ${occurrences} times; set replaceAll: true or include more surrounding context`,
+      message: `find text occurs ${occurrences} times; include more surrounding context or use replace_lines`,
     };
   }
+
   const next = replaceAll
-    ? content.split(edit.oldText).join(edit.newText)
-    : content.replace(edit.oldText, edit.newText);
+    ? content.split(find).join(replace)
+    : content.replace(find, replace);
   return {
     ok: true,
     content: next,
+    strategy: "exact",
     replacementCount: replaceAll ? occurrences : 1,
   };
 }
 
-function countOccurrences(source: string, needle: string): number {
+function planIndentationReplacement({
+  content,
+  find,
+  replace,
+  maxBytes,
+}: {
+  content: string;
+  find: string;
+  replace: string;
+  maxBytes: number | undefined;
+}): PlanTextReplacementResult {
+  const matches = indentationEquivalentMatches(content, find);
+  if (matches.length === 0) {
+    return {
+      ok: false,
+      code: "FIND_NOT_FOUND",
+      message:
+        "find text did not match exactly and no unique indentation-only candidate was found; re-read the relevant range and retry with current text",
+    };
+  }
+  if (matches.length > 1) {
+    return {
+      ok: false,
+      code: "FIND_NOT_UNIQUE",
+      message: `find text did not match exactly and ${matches.length} trim-equivalent candidates were found; include more surrounding context or use replace_lines`,
+    };
+  }
+
+  const [match] = matches;
+  if (!match) {
+    return {
+      ok: false,
+      code: "FIND_NOT_FOUND",
+      message:
+        "find text did not match exactly and no unique indentation-only candidate was found; re-read the relevant range and retry with current text",
+    };
+  }
+
+  const replacement = indentationRecoveredReplacement({
+    findLines: match.findLines,
+    candidateLines: match.candidateLines,
+    replace,
+  });
+  const next =
+    content.slice(0, match.startOffset) +
+    replacement +
+    content.slice(match.endOffset);
+  if (maxBytes !== undefined && Buffer.byteLength(next, "utf8") > maxBytes) {
+    return {
+      ok: false,
+      code: "WRITE_FAILED",
+      message: `recovered replacement exceeds ${maxBytes} byte cap`,
+    };
+  }
+
+  return {
+    ok: true,
+    content: next,
+    strategy: "indentation",
+    replacementCount: 1,
+    matchedLineRange: {
+      startLine: match.startLine,
+      endLine: match.endLine,
+      strategy: "indentation",
+    },
+  };
+}
+
+export function countOccurrences(source: string, needle: string): number {
   if (needle.length === 0) return 0;
   let count = 0;
   let index = 0;
@@ -123,6 +285,144 @@ function countOccurrences(source: string, needle: string): number {
     index = next + needle.length;
   }
   return count;
+}
+
+function recoveryDisabledMessage(
+  reason: RecoveryDisabledReason | undefined,
+): string {
+  if (reason === "guarded") {
+    return "find text did not match exactly; automatic indentation recovery is disabled for guarded files. Use exact text or replace_lines";
+  }
+  if (reason === "replaceAll") {
+    return "find text did not match exactly; replaceAll does not use indentation recovery";
+  }
+  return "find text did not match file content exactly; re-read the relevant range and retry with current text";
+}
+
+function indentationEquivalentMatches(
+  content: string,
+  find: string,
+): Array<{
+  startOffset: number;
+  endOffset: number;
+  startLine: number;
+  endLine: number;
+  findLines: string[];
+  candidateLines: string[];
+}> {
+  const findLines = find.split("\n");
+  if (findLines.length === 0) return [];
+  const contentLines = content.split("\n");
+  if (findLines.length > contentLines.length) return [];
+
+  const lineStarts = lineStartOffsets(contentLines);
+  const matches: Array<{
+    startOffset: number;
+    endOffset: number;
+    startLine: number;
+    endLine: number;
+    findLines: string[];
+    candidateLines: string[];
+  }> = [];
+
+  for (
+    let start = 0;
+    start <= contentLines.length - findLines.length;
+    start += 1
+  ) {
+    const candidateLines = contentLines.slice(start, start + findLines.length);
+    if (!trimEquivalentLineBlock(findLines, candidateLines)) continue;
+    const candidateBlock = candidateLines.join("\n");
+    matches.push({
+      startOffset: lineStarts[start] ?? 0,
+      endOffset: (lineStarts[start] ?? 0) + candidateBlock.length,
+      startLine: start + 1,
+      endLine: start + findLines.length,
+      findLines,
+      candidateLines,
+    });
+  }
+
+  return matches;
+}
+
+function trimEquivalentLineBlock(
+  findLines: readonly string[],
+  candidateLines: readonly string[],
+): boolean {
+  if (findLines.length !== candidateLines.length) return false;
+  return findLines.every((findLine, index) => {
+    const candidateLine = candidateLines[index] ?? "";
+    if (findLine.trim().length === 0) {
+      return candidateLine.trim().length === 0;
+    }
+    if (candidateLine.trim().length === 0) return false;
+    return findLine.trim() === candidateLine.trim();
+  });
+}
+
+function indentationRecoveredReplacement({
+  findLines,
+  candidateLines,
+  replace,
+}: {
+  findLines: readonly string[];
+  candidateLines: readonly string[];
+  replace: string;
+}): string {
+  const replacementLines = replace.split("\n");
+  const baseIndent = firstIndentPair(findLines, candidateLines);
+  const adjusted = replacementLines.map((line, index) => {
+    if (line.trim().length === 0) return "";
+    const findLine = findLines[index];
+    const candidateLine = candidateLines[index];
+    if (
+      findLine !== undefined &&
+      candidateLine !== undefined &&
+      findLine.trim().length > 0 &&
+      line.trim() === findLine.trim()
+    ) {
+      return candidateLine;
+    }
+    if (!baseIndent) return line;
+    if (line.startsWith(baseIndent.findIndent)) {
+      return `${baseIndent.candidateIndent}${line.slice(baseIndent.findIndent.length)}`;
+    }
+    return `${baseIndent.candidateIndent}${line.trimStart()}`;
+  });
+  return adjusted.join("\n");
+}
+
+function firstIndentPair(
+  findLines: readonly string[],
+  candidateLines: readonly string[],
+): { findIndent: string; candidateIndent: string } | undefined {
+  for (let index = 0; index < findLines.length; index += 1) {
+    const findLine = findLines[index] ?? "";
+    const candidateLine = candidateLines[index] ?? "";
+    if (findLine.trim().length === 0 || candidateLine.trim().length === 0) {
+      continue;
+    }
+    return {
+      findIndent: leadingWhitespace(findLine),
+      candidateIndent: leadingWhitespace(candidateLine),
+    };
+  }
+  return undefined;
+}
+
+function leadingWhitespace(value: string): string {
+  return value.match(/^\s*/)?.[0] ?? "";
+}
+
+function lineStartOffsets(lines: readonly string[]): number[] {
+  const starts: number[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    starts.push(offset);
+    offset += line.length + 1;
+  }
+  return starts;
 }
 
 export function buildDisplayDiff(


### PR DESCRIPTION
## Summary
- Add shared exact-text replacement planning with exact-first matching and conservative unique indentation-only recovery.
- Wire `edit_text`, `replace_text`, `multi_replace_text`, and approval previews through the same planning semantics.
- Keep `replaceAll` and guarded targets exact-only, preserve near-match diagnostics for not-found cases, and add compact recovery metadata only when recovery is used.
- Canonicalize `ToolPolicyEngine` semantic duplicate keys without changing prompt-cache or transcript hashing.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (exit 0; Windows LF-to-CRLF warnings only)
- `git diff --staged --check`
- Focused `tsx` helper probe for exact success, CRLF preservation, unique indentation recovery, ambiguous/missing failures, `replaceAll` exact-only, guarded exact-only, empty-find guard, and multi-replacement staging.

Related: #171
