### PR TITLE
Adopt mockups design system and responsive composer variants

### DIFF
--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -85,11 +85,54 @@ interface ComposerProps {
 const MIN_HEIGHT = 24;
 const MAX_HEIGHT = 44;
 
-const COMPOSER_CHIP =
-  "h-[26px] gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium leading-4 text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0";
+type ComposerVariant = "full" | "compact" | "inline";
 
-const COMPOSER_CHIP_OUTLINE =
-  "h-[26px] gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium leading-4 text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring";
+const COMPOSER_CONTROL_H = "h-[26px]";
+const COMPOSER_ICON_BTN = "size-[26px] rounded-md";
+
+const COMPOSER_CHIP = cn(
+  COMPOSER_CONTROL_H,
+  "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium leading-4 text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
+);
+
+const COMPOSER_CHIP_OUTLINE = cn(
+  COMPOSER_CONTROL_H,
+  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium leading-4 text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+);
+
+const MODEL_TRIGGER = cn(
+  COMPOSER_CONTROL_H,
+  "justify-between gap-2 rounded-md bg-input px-2 text-xs font-normal text-foreground shadow-none ring-1 ring-border hover:bg-input/80",
+);
+
+function resolveComposerVariant(width: number): ComposerVariant {
+  if (width < 320) return "compact";
+  if (width < 480) return "inline";
+  return "full";
+}
+
+function useComposerVariant() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [variant, setVariant] = useState<ComposerVariant>("full");
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const update = (width: number) => {
+      setVariant(resolveComposerVariant(width));
+    };
+
+    update(element.getBoundingClientRect().width);
+    const observer = new ResizeObserver(([entry]) => {
+      update(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, variant };
+}
 
 export function Composer({
   onSend,
@@ -122,7 +165,10 @@ export function Composer({
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { ref: composerWidthRef, variant } = useComposerVariant();
   const sendDisabled = disabled || (mode !== "chat" && !project);
+  const iconOnly = variant !== "full";
+  const compactContext = variant !== "full";
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -150,6 +196,88 @@ export function Composer({
     }
   };
 
+  const attachButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      className={cn(COMPOSER_ICON_BTN, "text-muted-foreground hover:text-foreground")}
+      disabled={disabled}
+      aria-label="Add context"
+    >
+      <Plus className="size-3.5" />
+    </Button>
+  );
+
+  const modeSelector = (
+    <ModeSelector value={mode} onChange={onModeChange} disabled={disabled} iconOnly={iconOnly} />
+  );
+
+  const permissionsDropdown = (
+    <PermissionsDropdown
+      value={permissionMode}
+      onChange={onPermissionModeChange}
+      iconOnly={iconOnly}
+    />
+  );
+
+  const mcpSelector = (
+    <McpSelector
+      servers={mcpServers}
+      selectedIds={selectedMcpServerIds}
+      onSelectedIdsChange={onSelectedMcpServerIdsChange}
+      disabled={disabled || mode !== "agent" || !project}
+      iconOnly={iconOnly}
+    />
+  );
+
+  const tokenCounter = (
+    <TokenCounter
+      tokenUsage={tokenUsage}
+      pending={streaming}
+      display={
+        variant === "full" ? "full" : variant === "compact" ? "compact" : "minimal"
+      }
+    />
+  );
+
+  const modelPicker = (
+    <ModelPicker
+      value={model}
+      onChange={onModelChange}
+      thinkingEnabled={thinkingEnabled}
+      onThinkingEnabledChange={onThinkingEnabledChange}
+      disabled={streaming}
+      triggerClassName={cn(
+        MODEL_TRIGGER,
+        variant === "compact" ? "min-w-0 flex-1" : "w-40 sm:w-48",
+      )}
+    />
+  );
+
+  const sendButton = streaming ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon-xs"
+      onClick={onStop}
+      className={COMPOSER_ICON_BTN}
+      aria-label="Stop generation"
+    >
+      <Square className="fill-current" />
+    </Button>
+  ) : (
+    <Button
+      type="submit"
+      size="icon-xs"
+      disabled={sendDisabled || !input.trim()}
+      className={COMPOSER_ICON_BTN}
+      aria-label="Send message"
+    >
+      <ArrowUp className="size-3.5" />
+    </Button>
+  );
+
   return (
     <form
       onSubmit={(e) => {
@@ -158,7 +286,10 @@ export function Composer({
       }}
       className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background px-3 pb-2 pt-1 sm:px-4"
     >
-      <div className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-[720px]">
+      <div
+        ref={composerWidthRef}
+        className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-[720px]"
+      >
         <div className="rounded-xl bg-card p-3 ring-1 ring-border">
           <Textarea
             ref={textareaRef}
@@ -171,68 +302,40 @@ export function Composer({
             className="field-sizing-fixed min-h-0 min-w-0 resize-none rounded-none border-0 bg-transparent p-0 font-mono text-[13px] leading-5 shadow-none ring-0 placeholder:font-mono placeholder:text-(--accent-muted) focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-[13px]"
             style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
           />
-          <div className="mt-3 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                className="size-[26px] rounded-md text-muted-foreground hover:text-foreground"
-                disabled={disabled}
-                aria-label="Add context"
-              >
-                <Plus className="size-3.5" />
-              </Button>
-              <ModeSelector value={mode} onChange={onModeChange} disabled={disabled} />
-              <PermissionsDropdown
-                value={permissionMode}
-                onChange={onPermissionModeChange}
-              />
-              <McpSelector
-                servers={mcpServers}
-                selectedIds={selectedMcpServerIds}
-                onSelectedIdsChange={onSelectedMcpServerIdsChange}
-                disabled={disabled || mode !== "agent" || !project}
-              />
+          {variant === "compact" ? (
+            <div className="mt-3 flex flex-col gap-2">
+              <div className="flex min-w-0 items-center gap-1.5">
+                {attachButton}
+                {modeSelector}
+                {permissionsDropdown}
+                {mcpSelector}
+                <div className="min-w-0 flex-1" />
+                {sendButton}
+              </div>
+              <div className="flex min-w-0 items-center gap-1.5">
+                {modelPicker}
+                {tokenCounter}
+              </div>
             </div>
-
-            <div className="flex min-w-0 items-center gap-1.5">
-              <TokenCounter tokenUsage={tokenUsage} pending={streaming} />
-              <ModelPicker
-                value={model}
-                onChange={onModelChange}
-                thinkingEnabled={thinkingEnabled}
-                onThinkingEnabledChange={onThinkingEnabledChange}
-                disabled={streaming}
-                triggerClassName="h-[26px] w-40 justify-between gap-2 rounded-md bg-input px-2.5 text-xs font-normal text-foreground shadow-none ring-1 ring-border hover:bg-input/80 sm:w-48"
-              />
-              {streaming ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-xs"
-                  onClick={onStop}
-                  className="size-[26px] rounded-md"
-                  aria-label="Stop generation"
-                >
-                  <Square className="fill-current" />
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  size="icon-xs"
-                  disabled={sendDisabled || !input.trim()}
-                  className="size-[26px] rounded-md"
-                  aria-label="Send message"
-                >
-                  <ArrowUp className="size-3.5" />
-                </Button>
-              )}
+          ) : (
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-1.5">
+                {attachButton}
+                {modeSelector}
+                {permissionsDropdown}
+                {mcpSelector}
+              </div>
+              <div className="flex min-w-0 items-center gap-1.5">
+                {variant === "inline" ? tokenCounter : null}
+                {modelPicker}
+                {variant === "full" ? tokenCounter : null}
+                {sendButton}
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
-        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 px-1.5 text-[12.5px] font-medium text-muted-foreground">
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 px-1.5 text-[12.5px] font-medium text-muted-foreground sm:gap-x-4">
           <ProjectPicker
             projects={readyProjects}
             selectedProjectId={selectedProjectId}
@@ -243,6 +346,7 @@ export function Composer({
             error={projectsError}
             onSelect={onSelectedProjectIdChange}
             onRefresh={onRefreshProjects}
+            compact={compactContext}
             className="max-w-[20rem]"
             contentAlign="start"
           />
@@ -288,10 +392,12 @@ function ModeSelector({
   value,
   onChange,
   disabled,
+  iconOnly = false,
 }: {
   value: ChatMode;
   onChange: (mode: ChatMode) => void;
   disabled: boolean;
+  iconOnly?: boolean;
 }) {
   const selected = MODE_ITEMS.find((item) => item.value === value) ?? MODE_ITEMS[1];
   return (
@@ -300,9 +406,20 @@ function ModeSelector({
       onValueChange={(next) => onChange(next as ChatMode)}
       disabled={disabled}
     >
-      <SelectTrigger className={COMPOSER_CHIP}>
+      <SelectTrigger
+        className={cn(
+          iconOnly ? COMPOSER_CHIP_OUTLINE : COMPOSER_CHIP,
+          iconOnly && "px-2",
+        )}
+        hideChevron={iconOnly}
+        aria-label={`Mode: ${selected.label}`}
+      >
         <selected.Icon className="size-3 shrink-0 text-muted-foreground" />
-        <SelectValue>{selected.label}</SelectValue>
+        {iconOnly ? (
+          <ChevronDown className="size-2.5 shrink-0 opacity-70" />
+        ) : (
+          <SelectValue>{selected.label}</SelectValue>
+        )}
       </SelectTrigger>
       <SelectContent align="start" className="min-w-[220px]">
         <SelectViewport className="p-1.5">
@@ -349,11 +466,13 @@ function McpSelector({
   selectedIds,
   onSelectedIdsChange,
   disabled,
+  iconOnly = false,
 }: {
   servers: McpServerSummary[];
   selectedIds: string[];
   onSelectedIdsChange: (ids: string[]) => void;
   disabled: boolean;
+  iconOnly?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const enabledServers = servers.filter((server) => server.enabled);
@@ -373,10 +492,10 @@ function McpSelector({
             selectedCount > 0 && "text-foreground",
           )}
           disabled={disabled}
-          aria-label="Select MCP servers"
+          aria-label={`MCP servers, ${selectedCount} enabled`}
         >
           <Server className="size-3 text-muted-foreground" />
-          MCP {selectedCount}
+          {iconOnly ? selectedCount : `MCP ${selectedCount}`}
           <ChevronDown className="size-3 shrink-0 opacity-70" />
         </Button>
       </PopoverTrigger>
@@ -453,9 +572,11 @@ const PERMISSION_MODE_ITEMS = [
 function PermissionsDropdown({
   value,
   onChange,
+  iconOnly = false,
 }: {
   value: PermissionMode;
   onChange: (mode: PermissionMode) => void;
+  iconOnly?: boolean;
 }) {
   const selected =
     PERMISSION_MODE_ITEMS.find((item) => item.value === value) ??
@@ -468,7 +589,10 @@ function PermissionsDropdown({
           COMPOSER_CHIP,
           isFullAccessMode &&
             "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+          iconOnly && "w-[26px] justify-center px-0",
         )}
+        hideChevron={iconOnly}
+        aria-label={`Permission mode: ${selected.label}`}
       >
         <selected.Icon
           className={cn(
@@ -476,7 +600,7 @@ function PermissionsDropdown({
             isFullAccessMode ? "text-primary" : "text-muted-foreground",
           )}
         />
-        <SelectValue>{selected.label}</SelectValue>
+        {iconOnly ? null : <SelectValue>{selected.label}</SelectValue>}
       </SelectTrigger>
       <SelectContent className="min-w-[210px]">
         <SelectViewport className="p-1.5">
@@ -508,10 +632,12 @@ function PermissionsDropdown({
 function TokenCounter({
   tokenUsage,
   pending,
+  display = "full",
 }: {
   tokenUsage: SessionTokenUsage;
   pending: boolean;
+  display?: "full" | "compact" | "minimal";
 }) {
   if (tokenUsage.effectiveTokens <= 0 && !pending) return null;
-  return <SessionMetricsHoverCard tokenUsage={tokenUsage} />;
+  return <SessionMetricsHoverCard tokenUsage={tokenUsage} display={display} />;
 }

--- a/components/features/chat/metrics-hover-card.tsx
+++ b/components/features/chat/metrics-hover-card.tsx
@@ -130,11 +130,23 @@ export function ResponseMetricsHoverCard({
   );
 }
 
+export type SessionMetricsDisplay = "full" | "compact" | "minimal";
+
 export function SessionMetricsHoverCard({
   tokenUsage,
+  display = "full",
 }: {
   tokenUsage: SessionTokenUsage;
+  display?: SessionMetricsDisplay;
 }) {
+  const tokens = formatCompactSessionTokens(tokenUsage.effectiveTokens);
+  const label =
+    display === "full"
+      ? `session · ${tokens} tok`
+      : display === "compact"
+        ? `${tokens} tok`
+        : tokens;
+
   return (
     <MetricsHoverCardShell
       headerLabel="Session"
@@ -145,7 +157,7 @@ export function SessionMetricsHoverCard({
           aria-label="Session token usage"
         >
           <Coins className="size-[11px]" aria-hidden />
-          session · {formatCompactSessionTokens(tokenUsage.effectiveTokens)} tok
+          {label}
         </button>
       }
       footer={

--- a/components/features/projects/project-picker.tsx
+++ b/components/features/projects/project-picker.tsx
@@ -32,6 +32,7 @@ export function ProjectPicker({
   onRefresh,
   className,
   contentAlign = "start",
+  compact = false,
 }: {
   projects: ProjectSummary[];
   selectedProjectId: string | null;
@@ -44,6 +45,7 @@ export function ProjectPicker({
   onRefresh: () => void;
   className?: string;
   contentAlign?: "start" | "center" | "end";
+  compact?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -64,7 +66,11 @@ export function ProjectPicker({
     );
   }, [projects, query]);
 
-  const label = displayProject?.fullName ?? "project";
+  const label = displayProject
+    ? compact
+      ? (displayProject.fullName.split("/").at(-1) ?? displayProject.fullName)
+      : displayProject.fullName
+    : "project";
 
   if (locked) {
     return (

--- a/design/mockups.pen
+++ b/design/mockups.pen
@@ -7364,6 +7364,7 @@
                   "type": "frame",
                   "id": "Wu7LP",
                   "name": "Mode Chip",
+                  "height": 26,
                   "fill": "$bg-active",
                   "cornerRadius": 6,
                   "gap": 5,
@@ -7371,6 +7372,7 @@
                     5,
                     9
                   ],
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
@@ -7409,6 +7411,7 @@
                   "type": "frame",
                   "id": "AfE7G",
                   "name": "Approval Chip",
+                  "height": 26,
                   "fill": "$accent-soft",
                   "cornerRadius": 6,
                   "gap": 5,
@@ -7416,6 +7419,7 @@
                     5,
                     9
                   ],
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
@@ -7454,6 +7458,7 @@
                   "type": "frame",
                   "id": "JvB84",
                   "name": "MCP Chip",
+                  "height": 26,
                   "cornerRadius": 6,
                   "stroke": "$border",
                   "strokeWidth": 1,
@@ -7462,6 +7467,7 @@
                     5,
                     9
                   ],
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
@@ -7510,6 +7516,7 @@
                   "y": 0,
                   "name": "Session Chip",
                   "enabled": false,
+                  "height": 26,
                   "cornerRadius": 6,
                   "stroke": "$border",
                   "strokeWidth": 1,
@@ -7518,6 +7525,7 @@
                     5,
                     9
                   ],
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
@@ -7546,15 +7554,17 @@
                   "type": "frame",
                   "id": "ixM5y",
                   "name": "Model Select",
+                  "height": 26,
                   "fill": "$bg-input",
                   "cornerRadius": 6,
                   "stroke": "$border",
                   "strokeWidth": 1,
                   "gap": 8,
                   "padding": [
-                    6,
-                    10
+                    5,
+                    9
                   ],
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
@@ -11374,6 +11384,113 @@
               ]
             }
           ]
+        },
+        {
+          "type": "frame",
+          "id": "Z64sq",
+          "name": "Row 5",
+          "gap": 56,
+          "alignItems": "end",
+          "children": [
+            {
+              "type": "frame",
+              "id": "W2WS3k",
+              "name": "State / Compact default",
+              "width": 320,
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "L3y6k7",
+                  "name": "Caption",
+                  "fill": "$text-tertiary",
+                  "content": "COMPACT · NARROW PANEL",
+                  "fontFamily": "$font",
+                  "fontSize": 11.5,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.8
+                },
+                {
+                  "id": "g4uPL",
+                  "type": "ref",
+                  "ref": "lCg6X",
+                  "name": "Composer Compact",
+                  "width": "fill_container"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nbX5i",
+              "name": "State / Compact with sidebar",
+              "width": 320,
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "v9m6r5",
+                  "name": "Caption",
+                  "fill": "$text-tertiary",
+                  "content": "COMPACT · SIDEBAR EXPANDED",
+                  "fontFamily": "$font",
+                  "fontSize": 11.5,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.8
+                },
+                {
+                  "id": "Fj9Pr",
+                  "type": "ref",
+                  "ref": "lCg6X",
+                  "name": "Composer Compact",
+                  "width": "fill_container",
+                  "descendants": {
+                    "jGXAN": {
+                      "content": "Go through the codebase and understand what this application does"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "qnsoE",
+          "name": "Row 6",
+          "gap": 56,
+          "alignItems": "end",
+          "children": [
+            {
+              "type": "frame",
+              "id": "GcPf2",
+              "name": "State / Inline single row",
+              "width": 480,
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "uml3q",
+                  "name": "Caption",
+                  "fill": "$text-tertiary",
+                  "content": "INLINE · SINGLE ROW",
+                  "fontFamily": "$font",
+                  "fontSize": 11.5,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.8
+                },
+                {
+                  "id": "UNe8N",
+                  "type": "ref",
+                  "ref": "rkFLV",
+                  "name": "Composer Inline",
+                  "width": "fill_container"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -12543,7 +12660,7 @@
                 "bottom": 1
               },
               "padding": [
-                12,
+                13,
                 14
               ],
               "justifyContent": "space_between",
@@ -43046,6 +43163,792 @@
                       ]
                     }
                   ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "lCg6X",
+      "x": 0,
+      "y": -2720,
+      "name": "Component / Composer Compact",
+      "reusable": true,
+      "width": "fill_container(320)",
+      "layout": "vertical",
+      "gap": 8,
+      "children": [
+        {
+          "type": "frame",
+          "id": "wI7ZZ",
+          "name": "Composer Card",
+          "width": "fill_container",
+          "fill": "$bg-card",
+          "cornerRadius": 12,
+          "stroke": "$border",
+          "strokeWidth": 1,
+          "layout": "vertical",
+          "gap": 12,
+          "padding": 12,
+          "children": [
+            {
+              "type": "text",
+              "id": "jGXAN",
+              "name": "Prompt Placeholder",
+              "fill": "$accent-muted",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Ask Anton to change the code",
+              "fontFamily": "$font-mono",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "E1yEX",
+              "name": "Controls Stack",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "w9RFY",
+                  "name": "Controls Row 1",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "B49NBa",
+                      "name": "Attach",
+                      "width": 26,
+                      "height": 26,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "RPqnk",
+                          "name": "Plus",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "plus",
+                          "library": "lucide",
+                          "fill": "$text-secondary"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bMT66",
+                      "name": "Mode Chip",
+                      "height": 26,
+                      "fill": "$bg-active",
+                      "cornerRadius": 6,
+                      "gap": 5,
+                      "padding": [
+                        5,
+                        9
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "q2jRy",
+                          "name": "Mode Icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "code-xml",
+                          "library": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "kLkxP",
+                          "name": "Chevron",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-tertiary"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IrxoX",
+                      "name": "Approval Chip",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$accent-soft",
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "sBVk0",
+                          "name": "Approval Icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "shield-off",
+                          "library": "lucide",
+                          "fill": "$accent"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gvAfV",
+                      "name": "MCP Chip",
+                      "height": 26,
+                      "cornerRadius": 6,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "gap": 5,
+                      "padding": [
+                        5,
+                        9
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "m4KC8",
+                          "name": "MCP Icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "server",
+                          "library": "lucide",
+                          "fill": "$text-secondary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EuEpC",
+                          "name": "MCP Count",
+                          "fill": "$text-primary",
+                          "content": "1",
+                          "fontFamily": "$font",
+                          "fontSize": 12.5,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "ptaXI",
+                          "name": "Chevron",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-tertiary"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xWejr",
+                      "name": "Spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lYdXY",
+                      "name": "Send Button",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "$accent",
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "yZUGa",
+                          "name": "Send Icon",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "arrow-up",
+                          "library": "lucide",
+                          "fill": "$accent-text"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AlepC",
+                  "name": "Controls Row 2",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hH45W",
+                      "name": "Model Select",
+                      "width": "fill_container",
+                      "height": 26,
+                      "fill": "$bg-input",
+                      "cornerRadius": 6,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "gap": 8,
+                      "padding": [
+                        5,
+                        9
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "xj2RU",
+                          "name": "Model Label",
+                          "fill": "$text-primary",
+                          "content": "DeepSeek V4 Flash",
+                          "fontFamily": "$font",
+                          "fontSize": 12.5,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "XVbIx",
+                          "name": "Chevron",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-tertiary"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L732Zk",
+                      "name": "Session Chip",
+                      "height": 26,
+                      "cornerRadius": 6,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "gap": 5,
+                      "padding": [
+                        5,
+                        9
+                      ],
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "LaVnG",
+                          "name": "Token Icon",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "coins",
+                          "library": "lucide",
+                          "fill": "$text-tertiary"
+                        },
+                        {
+                          "type": "text",
+                          "id": "RqOOB",
+                          "name": "Session Label",
+                          "fill": "$text-tertiary",
+                          "content": "95k tok",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 11.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WpHgz",
+          "name": "Context Row",
+          "gap": 12,
+          "padding": [
+            0,
+            4
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Y6TB5",
+              "name": "Project Chip",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "d4fvLA",
+                  "name": "Project Icon",
+                  "width": 13,
+                  "height": 13,
+                  "icon": "folder-git-2",
+                  "library": "lucide",
+                  "fill": "$text-secondary"
+                },
+                {
+                  "type": "text",
+                  "id": "NHAlF",
+                  "name": "Project Label",
+                  "fill": "$text-secondary",
+                  "content": "notes",
+                  "fontFamily": "$font",
+                  "fontSize": 12.5,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon",
+                  "id": "yM5fP",
+                  "name": "Chevron",
+                  "width": 11,
+                  "height": 11,
+                  "icon": "chevron-down",
+                  "library": "lucide",
+                  "fill": "$text-tertiary"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hTXJq",
+              "name": "Branch Chip",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "eOPlO",
+                  "name": "Branch Icon",
+                  "width": 13,
+                  "height": 13,
+                  "icon": "git-branch",
+                  "library": "lucide",
+                  "fill": "$text-secondary"
+                },
+                {
+                  "type": "text",
+                  "id": "u0k6rt",
+                  "name": "Branch Label",
+                  "fill": "$text-secondary",
+                  "content": "fix/quick-switcher...",
+                  "fontFamily": "$font",
+                  "fontSize": 12.5,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon",
+                  "id": "XYhme",
+                  "name": "Chevron",
+                  "width": 11,
+                  "height": 11,
+                  "icon": "chevron-down",
+                  "library": "lucide",
+                  "fill": "$text-tertiary"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rkFLV",
+      "x": 0,
+      "y": -2980,
+      "name": "Component / Composer Inline",
+      "reusable": true,
+      "width": "fill_container(480)",
+      "fill": "$bg-base",
+      "stroke": "$border",
+      "layout": "vertical",
+      "gap": 8,
+      "children": [
+        {
+          "type": "frame",
+          "id": "XaFIa",
+          "name": "Composer Card",
+          "width": "fill_container",
+          "fill": "$bg-card",
+          "cornerRadius": 12,
+          "stroke": "$border",
+          "strokeWidth": 1,
+          "layout": "vertical",
+          "gap": 12,
+          "padding": 12,
+          "children": [
+            {
+              "type": "text",
+              "id": "s9rkPi",
+              "name": "Prompt Placeholder",
+              "fill": "$accent-muted",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Ask Anton to change the code",
+              "fontFamily": "$font-mono",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "yxKjG",
+              "name": "Controls",
+              "width": "fill_container",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WvjjF",
+                  "name": "Attach",
+                  "width": 26,
+                  "height": 26,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Ikwpd",
+                      "name": "Plus",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "plus",
+                      "library": "lucide",
+                      "fill": "$text-secondary"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vSJar",
+                  "name": "Mode Chip",
+                  "height": 26,
+                  "fill": "$bg-active",
+                  "cornerRadius": 6,
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 5,
+                  "padding": [
+                    5,
+                    9
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "TJbAQ",
+                      "name": "Mode Icon",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "code-xml",
+                      "library": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "AK5eH",
+                      "name": "Chevron",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "$text-tertiary"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LHqX5",
+                  "name": "Approval Chip",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "$accent-soft",
+                  "cornerRadius": 6,
+                  "gap": 5,
+                  "padding": [
+                    5,
+                    9
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "PMZ1L",
+                      "name": "Approval Icon",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "shield-off",
+                      "library": "lucide",
+                      "fill": "$accent"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Rbr3M",
+                  "name": "MCP Chip",
+                  "height": 26,
+                  "cornerRadius": 6,
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 5,
+                  "padding": [
+                    5,
+                    9
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "acUXg",
+                      "name": "MCP Icon",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "server",
+                      "library": "lucide",
+                      "fill": "$text-secondary"
+                    },
+                    {
+                      "type": "text",
+                      "id": "W2D23r",
+                      "name": "MCP Count",
+                      "fill": "$text-primary",
+                      "content": "1",
+                      "fontFamily": "$font",
+                      "fontSize": 12.5,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "MwUqI",
+                      "name": "Chevron",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "$text-tertiary"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "G1hosD",
+                  "name": "Spacer",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Ztjle",
+                  "name": "Session Chip",
+                  "height": 26,
+                  "cornerRadius": 6,
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 5,
+                  "padding": [
+                    5,
+                    9
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "jiGvA",
+                      "name": "Token Icon",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "coins",
+                      "library": "lucide",
+                      "fill": "$text-tertiary"
+                    },
+                    {
+                      "type": "text",
+                      "id": "isEBy",
+                      "name": "Session Count",
+                      "fill": "$text-tertiary",
+                      "content": "95k",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 11.5,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qH867",
+                  "name": "Model Select",
+                  "height": 26,
+                  "fill": "$bg-input",
+                  "cornerRadius": 6,
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 8,
+                  "padding": [
+                    5,
+                    9
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "I3S1z",
+                      "name": "Model Label",
+                      "fill": "$text-primary",
+                      "content": "DeepSeek V4 Flash",
+                      "fontFamily": "$font",
+                      "fontSize": 12.5,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "HIqzv",
+                      "name": "Chevron",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "$text-tertiary"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "N13Rv",
+                  "name": "Send Button",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "$accent",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "XADpB",
+                      "name": "Send Icon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "arrow-up",
+                      "library": "lucide",
+                      "fill": "$accent-text"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "w9oc0",
+          "name": "Context Row",
+          "gap": 12,
+          "padding": [
+            0,
+            4
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "L5mfa",
+              "name": "Project Chip",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "DaZAn",
+                  "name": "Project Icon",
+                  "width": 13,
+                  "height": 13,
+                  "icon": "folder-git-2",
+                  "library": "lucide",
+                  "fill": "$text-secondary"
+                },
+                {
+                  "type": "text",
+                  "id": "fXQg8",
+                  "name": "Project Label",
+                  "fill": "$text-secondary",
+                  "content": "notes",
+                  "fontFamily": "$font",
+                  "fontSize": 12.5,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon",
+                  "id": "HTUwN",
+                  "name": "Chevron",
+                  "width": 11,
+                  "height": 11,
+                  "icon": "chevron-down",
+                  "library": "lucide",
+                  "fill": "$text-tertiary"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "m9N1dH",
+              "name": "Branch Chip",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "FFIj1",
+                  "name": "Branch Icon",
+                  "width": 13,
+                  "height": 13,
+                  "icon": "git-branch",
+                  "library": "lucide",
+                  "fill": "$text-secondary"
+                },
+                {
+                  "type": "text",
+                  "id": "tTNXj",
+                  "name": "Branch Label",
+                  "fill": "$text-secondary",
+                  "content": "fix/quick-switcher...",
+                  "fontFamily": "$font",
+                  "fontSize": 12.5,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "icon",
+                  "id": "SFNhS",
+                  "name": "Chevron",
+                  "width": 11,
+                  "height": 11,
+                  "icon": "chevron-down",
+                  "library": "lucide",
+                  "fill": "$text-tertiary"
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- Adopt the mockups.pen design system across Settings, chat, trace, PR sidebar, and Files/Diff panels
- Add responsive chat composer variants (full, inline, compact) with uniform 26px controls ? closes #173
- Redesign PR right-sidebar and Files/Diff tab chrome to match mockups

## Test plan
- [ ] pnpm typecheck and pnpm lint pass
- [ ] Resize chat panel: composer switches full ? inline (480px) ? compact (320px)
- [ ] Open worklog sidebar: composer stays usable at reduced chat width
- [ ] PR sidebar Files/Diff tabs match mockup styling
- [ ] Settings screens render correctly after design system adoption

Closes #173
