### PR TITLE
[codex] Stage verification target execution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Synced file tree git status badges with local `git status`, including header dirty counts and refresh on focus.
 - [✔️] Replaced global active-project localStorage with session-scoped composer project picker that locks after the first message (#107).
 - [✔️] Kept chat, Worklog, and Status reasoning traces aligned across live and persisted run views.
-- [✔️] Made verification run independent targets in parallel with build-safe timeout reporting (#134).
+- [✔️] Made verification run independent targets in staged order with build-safe timeout reporting (#134, #175).
 - [✔️] Hardened verification classification and post-edit rollback for cache-safe agent recovery.
 - [✔️] Enriched prior-run context summaries with todos, verification, blockers, touched files, and failed tool details (#136).
 - [✔️] Reduced live trace rendering pressure with lazy-mounted disclosures and bounded running Worklog rows (#139).

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -167,6 +168,8 @@ function ChatSession({
   );
   const [mobileWorklogOpen, setMobileWorklogOpen] = useState(false);
   const layoutRef = useRef<HTMLDivElement>(null);
+  const chatColumnRef = useRef<HTMLElement>(null);
+  const [chatColumnWidth, setChatColumnWidth] = useState(0);
   const {
     width: worklogWidth,
     expanded: worklogExpanded,
@@ -175,6 +178,23 @@ function ChatSession({
     toggleExpanded: toggleWorklogExpanded,
     startResize: startWorklogResize,
   } = useWorklogWidth(layoutRef);
+
+  useLayoutEffect(() => {
+    const element = chatColumnRef.current;
+    if (!element) return;
+
+    const update = () => {
+      setChatColumnWidth(element.getBoundingClientRect().width);
+    };
+
+    update();
+    const observer = new ResizeObserver(() => {
+      update();
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
   const [restoreVersion, setRestoreVersion] = useState(0);
   const [messageDisplayOverride, setMessageDisplayOverride] = useState<
     AntonUIMessage[] | null
@@ -621,7 +641,10 @@ function ChatSession({
         ref={layoutRef}
         className="relative flex min-h-0 max-w-full flex-1 overflow-hidden"
       >
-        <section className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden">
+        <section
+          ref={chatColumnRef}
+          className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden"
+        >
           <MessageList
             messages={displayMessages}
             status={status}
@@ -669,6 +692,8 @@ function ChatSession({
             onSelectedMcpServerIdsChange={setSelectedMcpServerIds}
             runningCommandCount={projectCommands.runningCount}
             onOpenProjectStatus={openProjectStatus}
+            columnWidth={chatColumnWidth}
+            worklogOpen={worklogOpen}
           />
         </section>
 

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -80,6 +80,8 @@ interface ComposerProps {
   onSelectedMcpServerIdsChange: (ids: string[]) => void;
   runningCommandCount?: number;
   onOpenProjectStatus?: () => void;
+  columnWidth?: number;
+  worklogOpen?: boolean;
 }
 
 const MIN_HEIGHT = 24;
@@ -87,17 +89,18 @@ const MAX_HEIGHT = 44;
 
 type ComposerVariant = "full" | "compact" | "inline";
 
-const COMPOSER_CONTROL_H = "h-[26px]";
-const COMPOSER_ICON_BTN = "size-[26px] rounded-md";
+const COMPOSER_CONTROL_H =
+  "!h-[26px] !min-h-[26px] !max-h-[26px] shrink-0 py-0 leading-none";
+const COMPOSER_ICON_BTN = "size-[26px] shrink-0 rounded-md";
 
 const COMPOSER_CHIP = cn(
   COMPOSER_CONTROL_H,
-  "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium leading-4 text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
+  "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
 );
 
 const COMPOSER_CHIP_OUTLINE = cn(
   COMPOSER_CONTROL_H,
-  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium leading-4 text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
 );
 
 const MODEL_TRIGGER = cn(
@@ -105,33 +108,18 @@ const MODEL_TRIGGER = cn(
   "justify-between gap-2 rounded-md bg-input px-2 text-xs font-normal text-foreground shadow-none ring-1 ring-border hover:bg-input/80",
 );
 
-function resolveComposerVariant(width: number): ComposerVariant {
+function resolveComposerVariant(
+  width: number,
+  worklogOpen: boolean,
+): ComposerVariant {
+  if (width <= 0) return worklogOpen ? "inline" : "full";
   if (width < 320) return "compact";
+  if (worklogOpen) {
+    if (width < 400) return "compact";
+    return "inline";
+  }
   if (width < 480) return "inline";
   return "full";
-}
-
-function useComposerVariant() {
-  const ref = useRef<HTMLDivElement>(null);
-  const [variant, setVariant] = useState<ComposerVariant>("full");
-
-  useLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) return;
-
-    const update = (width: number) => {
-      setVariant(resolveComposerVariant(width));
-    };
-
-    update(element.getBoundingClientRect().width);
-    const observer = new ResizeObserver(([entry]) => {
-      update(entry.contentRect.width);
-    });
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
-
-  return { ref, variant };
 }
 
 export function Composer({
@@ -162,10 +150,12 @@ export function Composer({
   onSelectedMcpServerIdsChange,
   runningCommandCount = 0,
   onOpenProjectStatus,
+  columnWidth = 0,
+  worklogOpen = false,
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { ref: composerWidthRef, variant } = useComposerVariant();
+  const variant = resolveComposerVariant(columnWidth, worklogOpen);
   const sendDisabled = disabled || (mode !== "chat" && !project);
   const iconOnly = variant !== "full";
   const compactContext = variant !== "full";
@@ -250,7 +240,11 @@ export function Composer({
       disabled={streaming}
       triggerClassName={cn(
         MODEL_TRIGGER,
-        variant === "compact" ? "min-w-0 flex-1" : "w-40 sm:w-48",
+        variant === "compact"
+          ? "min-w-0 flex-1"
+          : variant === "inline"
+            ? "w-32 min-w-0 shrink"
+            : "w-40 sm:w-48",
       )}
     />
   );
@@ -286,10 +280,7 @@ export function Composer({
       }}
       className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background px-3 pb-2 pt-1 sm:px-4"
     >
-      <div
-        ref={composerWidthRef}
-        className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-[720px]"
-      >
+      <div className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-[720px]">
         <div className="rounded-xl bg-card p-3 ring-1 ring-border">
           <Textarea
             ref={textareaRef}
@@ -486,7 +477,6 @@ function McpSelector({
         <Button
           type="button"
           variant="secondary"
-          size="xs"
           className={cn(
             COMPOSER_CHIP_OUTLINE,
             selectedCount > 0 && "text-foreground",

--- a/components/features/chat/metrics-hover-card.tsx
+++ b/components/features/chat/metrics-hover-card.tsx
@@ -153,7 +153,7 @@ export function SessionMetricsHoverCard({
       trigger={
         <button
           type="button"
-          className="inline-flex h-[26px] items-center gap-1.5 rounded-md px-2 font-mono text-[11.5px] text-muted-foreground/80 ring-1 ring-border transition-colors hover:bg-secondary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-ring"
+          className="inline-flex !h-[26px] !min-h-[26px] !max-h-[26px] shrink-0 items-center gap-1.5 rounded-md px-2 py-0 font-mono text-[11.5px] leading-none text-muted-foreground/80 ring-1 ring-border transition-colors hover:bg-secondary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-ring"
           aria-label="Session token usage"
         >
           <Coins className="size-[11px]" aria-hidden />

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -191,7 +191,6 @@ export function ModelPicker({
         <Button
           type="button"
           variant="secondary"
-          size="xs"
           disabled={disabled}
           className={cn("min-w-0 justify-between", triggerClassName)}
         >

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -603,6 +603,7 @@ function failedTargetsFromVerifyResults(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((item): string[] => {
     if (!isRecord(item) || item.ok !== false) return [];
+    if (item.notRun === true || item.status === "not_run") return [];
     const target = compactLine(stringValue(item.target), 100);
     if (!target) return [];
     const exitCode = outputExitCode(item);

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -690,6 +690,7 @@ function buildVerifyApproval(
     target: targets.length > 0 ? targets.join(", ") : "typecheck, lint, build",
     details: [
       `Targets: ${targets.length > 0 ? targets.join(", ") : "typecheck, lint, build"}.`,
+      "Targets run in staged order and stop after the first failure.",
       `Commands: ${commands}.`,
       `Timeout per command: ${numberValue(input.timeoutMs) ?? 120_000}ms.`,
       "Runs package scripts directly through the detected package manager without shell interpolation.",

--- a/src/agent/tools/model-output.ts
+++ b/src/agent/tools/model-output.ts
@@ -267,17 +267,20 @@ export function compactVerifyForModel(output: unknown): unknown {
     ? output.results.map(compactVerifyResultForModel)
     : output.results;
   const failed = Array.isArray(results)
-    ? results.find((result) => isRecord(result) && result.ok === false)
+    ? results.find(isVerifyExecutionFailure)
     : undefined;
   const failureSummary = extractVerifyFailureSummary(output);
   const base = {
     ok: output.ok,
     status: output.status,
+    strategy: output.strategy,
+    stoppedOnFailure: output.stoppedOnFailure,
+    firstFailedTarget: output.firstFailedTarget,
+    notRunCount: output.notRunCount,
     failureScope: output.failureScope,
     recommendedNext: output.recommendedNext,
     summary: output.summary,
     packageManager: output.packageManager,
-    parallel: output.parallel,
     ranCount: output.ranCount,
     skippedCount: output.skippedCount,
     editedPaths: Array.isArray(output.editedPaths)
@@ -304,7 +307,7 @@ export function compactVerifyForModel(output: unknown): unknown {
       ...(parseIssues.length > 0 ? { parseIssues: parseIssues.slice(0, 5) } : {}),
       ...(failed && isRecord(failed)
         ? {
-            failedTarget: failed.target,
+            failedTarget: output.firstFailedTarget ?? failed.target,
             failedCommand: failed.command,
             timedOut: failed.timedOut,
             timeoutMs: failed.timeoutMs,
@@ -346,9 +349,7 @@ export function extractVerifyFailureSummary(output: unknown): string | undefined
   if (typeof output.summary === "string" && output.summary.trim().length > 0) {
     const base = output.summary.trim();
     if (!Array.isArray(output.results)) return base;
-    const failed = output.results.find(
-      (result) => isRecord(result) && result.ok === false && result.skipped !== true,
-    );
+    const failed = output.results.find(isVerifyExecutionFailure);
     if (!isRecord(failed)) return base;
     const text = [failed.stderr, failed.stdout, failed.error, failed.message]
       .filter((value): value is string => typeof value === "string")
@@ -408,11 +409,19 @@ export function extractParseIssuesFromText(
 
 function compactVerifyResultForModel(result: unknown): unknown {
   if (!isRecord(result)) return result;
+  const status = typeof result.status === "string" ? result.status : undefined;
+  const notRun = status === "not_run" || result.notRun === true;
   return {
     target: result.target,
+    ...(status ? { status } : {}),
     skipped: result.skipped,
     ok: result.ok,
-    ...(result.skipped
+    ...(notRun
+      ? {
+          notRun: true as const,
+          reason: result.reason,
+        }
+      : result.skipped
       ? { reason: result.reason }
       : {
           command: result.command,
@@ -424,6 +433,16 @@ function compactVerifyResultForModel(result: unknown): unknown {
           ...(result.ok === false ? { error: result.error } : {}),
         }),
   };
+}
+
+function isVerifyExecutionFailure(value: unknown): value is Record<string, unknown> {
+  return (
+    isRecord(value) &&
+    value.ok === false &&
+    value.skipped !== true &&
+    value.notRun !== true &&
+    value.status !== "not_run"
+  );
 }
 
 function tailText(value: unknown): string | undefined {

--- a/src/agent/tools/verify.ts
+++ b/src/agent/tools/verify.ts
@@ -72,12 +72,22 @@ export type VerificationStep = {
 type VerificationResult =
   | {
       target: VerificationTarget;
+      status: "skipped";
       skipped: true;
       ok: true;
       reason: string;
     }
   | {
       target: VerificationTarget;
+      status: "not_run";
+      skipped: false;
+      ok: false;
+      notRun: true;
+      reason: string;
+    }
+  | {
+      target: VerificationTarget;
+      status: "passed" | "failed" | "command_broken";
       skipped: false;
       ok: boolean;
       command?: string;
@@ -152,66 +162,36 @@ export function createVerifyTool(
         });
       }
 
-      const results = await Promise.all(
-        plan.steps.map(async (step): Promise<VerificationResult> => {
-          if (step.skipped || !step.command) {
-            return {
-              target: step.target,
-              skipped: true,
-              ok: true,
-              reason: step.reason ?? "No matching package script found.",
-            };
-          }
+      const results: VerificationResult[] = [];
+      let firstFailedTarget: VerificationTarget | undefined;
 
-          const [file, ...args] = step.command;
-          const stepTimeoutMs = timeoutForTarget(
-            step.target,
-            defaults.timeoutMs,
-            timeoutMs,
-          );
-          if (!file) {
-            return {
-              target: step.target,
-              skipped: false,
-              ok: false,
-              timeoutMs: stepTimeoutMs,
-              error: "Verification command is empty.",
-              commandBroken: true,
-            };
-          }
+      for (const step of plan.steps) {
+        if (!isRunnableStep(step)) {
+          results.push(skippedResultForStep(step));
+          continue;
+        }
 
-          const result = await runWorkspaceProcess(file, args, root, {
-            timeoutMs: stepTimeoutMs,
-          });
-          const ok = result.exitCode === 0;
-          return {
-            target: step.target,
-            skipped: false,
-            ok,
-            command: step.command.join(" "),
-            timeoutMs: stepTimeoutMs,
-            exitCode: result.exitCode ?? undefined,
-            timedOut: result.timedOut,
-            stdout: capOutput(result.stdout),
-            stderr: capOutput(result.stderr),
-            ...(result.failedToStart ? { commandBroken: true as const } : {}),
-            ...(ok
-              ? {}
-              : {
-                  error: result.timedOut
-                    ? `Verification command timed out after ${formatDuration(stepTimeoutMs)}.`
-                    : result.stderr ||
-                      result.stdout ||
-                      "Verification command failed.",
-                }),
-          };
-        }),
-      );
+        if (firstFailedTarget !== undefined) {
+          results.push(notRunResultForStep(step, firstFailedTarget));
+          continue;
+        }
+
+        const result = await runVerificationStep({
+          step,
+          workspaceRoot: root,
+          defaultTimeoutMs: defaults.timeoutMs,
+          requestedTimeoutMs: timeoutMs,
+        });
+        results.push(result);
+        if (isExecutedFailure(result)) {
+          firstFailedTarget = result.target;
+        }
+      }
 
       return buildVerificationOutput({
         editedPaths,
         packageManager: plan.packageManager,
-        parallel: true,
+        firstFailedTarget,
         results,
         workspaceRoot: root,
       });
@@ -222,18 +202,21 @@ export function createVerifyTool(
 function buildVerificationOutput(input: {
   editedPaths: readonly string[];
   packageManager: PackageManager | undefined;
-  parallel?: boolean;
+  firstFailedTarget?: VerificationTarget;
   results: readonly VerificationResult[];
   planError?: string;
   workspaceRoot: string;
 }) {
-  const ranCount = input.results.filter((result) => !result.skipped).length;
-  const failed = input.results.filter((result) => !result.ok);
+  const ran = input.results.filter(isExecutedResult);
+  const ranCount = ran.length;
+  const skippedCount = input.results.filter((result) => result.skipped).length;
+  const notRunCount = input.results.filter(isNotRunResult).length;
+  const failed = ran.filter((result) => !result.ok);
+  const firstFailed = failed[0];
+  const firstFailedTarget = input.firstFailedTarget ?? firstFailed?.target;
+  const stoppedOnFailure = firstFailedTarget !== undefined;
   const status = verificationStatus(input.results, input.planError);
-  const failedText = failed
-    .map((result) => failedResultText(result))
-    .filter((text) => text.length > 0)
-    .join("\n");
+  const failedText = firstFailed ? failedResultText(firstFailed) : "";
   const pathHints = extractPathHints(
     failedText,
     input.editedPaths,
@@ -243,7 +226,7 @@ function buildVerificationOutput(input: {
   const recommendedNext = recommendedNextForStatus(status, failureScope);
   const failureSummary = failureSummaryForStatus({
     status,
-    failed,
+    firstFailed,
     planError: input.planError,
     pathHints,
   });
@@ -251,15 +234,18 @@ function buildVerificationOutput(input: {
   return {
     ok: status === "passed" || status === "skipped",
     status,
+    strategy: "staged" as const,
+    stoppedOnFailure,
+    ...(firstFailedTarget ? { firstFailedTarget } : {}),
+    notRunCount,
     failureScope,
     recommendedNext,
     editedPaths: input.editedPaths,
     pathHints,
     ...(failureSummary ? { failureSummary } : {}),
     ...(input.packageManager ? { packageManager: input.packageManager } : {}),
-    ...(input.parallel ? { parallel: true as const } : {}),
     ranCount,
-    skippedCount: input.results.length - ranCount,
+    skippedCount,
     results: input.results,
     summary:
       status === "passed"
@@ -267,9 +253,118 @@ function buildVerificationOutput(input: {
         : status === "skipped"
           ? (input.planError ?? "No verification scripts were available.")
           : status === "command_broken"
-            ? "Verification command could not be executed."
-            : `Verification failed for ${failed.length} target${failed.length === 1 ? "" : "s"}.`,
+            ? `Verification command for ${firstFailedTarget ?? "a target"} could not be executed.`
+            : firstFailedTarget
+              ? `Verification failed on ${firstFailedTarget}.`
+              : `Verification failed for ${failed.length} target${failed.length === 1 ? "" : "s"}.`,
   };
+}
+
+async function runVerificationStep({
+  step,
+  workspaceRoot,
+  defaultTimeoutMs,
+  requestedTimeoutMs,
+}: {
+  step: VerificationStep & { skipped: false; command: string[] };
+  workspaceRoot: string;
+  defaultTimeoutMs: number;
+  requestedTimeoutMs: number | undefined;
+}): Promise<VerificationResult> {
+  const [file, ...args] = step.command;
+  const stepTimeoutMs = timeoutForTarget(
+    step.target,
+    defaultTimeoutMs,
+    requestedTimeoutMs,
+  );
+  if (!file) {
+    return {
+      target: step.target,
+      status: "command_broken",
+      skipped: false,
+      ok: false,
+      timeoutMs: stepTimeoutMs,
+      error: "Verification command is empty.",
+      commandBroken: true,
+    };
+  }
+
+  const result = await runWorkspaceProcess(file, args, workspaceRoot, {
+    timeoutMs: stepTimeoutMs,
+  });
+  const ok = result.exitCode === 0;
+  const commandBroken = result.failedToStart;
+  return {
+    target: step.target,
+    status: ok ? "passed" : commandBroken ? "command_broken" : "failed",
+    skipped: false,
+    ok,
+    command: step.command.join(" "),
+    timeoutMs: stepTimeoutMs,
+    exitCode: result.exitCode ?? undefined,
+    timedOut: result.timedOut,
+    stdout: capOutput(result.stdout),
+    stderr: capOutput(result.stderr),
+    ...(commandBroken ? { commandBroken: true as const } : {}),
+    ...(ok
+      ? {}
+      : {
+          error: result.timedOut
+            ? `Verification command timed out after ${formatDuration(stepTimeoutMs)}.`
+            : result.stderr ||
+              result.stdout ||
+              "Verification command failed.",
+        }),
+  };
+}
+
+function skippedResultForStep(step: VerificationStep): VerificationResult {
+  return {
+    target: step.target,
+    status: "skipped",
+    skipped: true,
+    ok: true,
+    reason: step.reason ?? "No matching package script found.",
+  };
+}
+
+function notRunResultForStep(
+  step: VerificationStep,
+  firstFailedTarget: VerificationTarget,
+): VerificationResult {
+  return {
+    target: step.target,
+    status: "not_run",
+    skipped: false,
+    ok: false,
+    notRun: true,
+    reason: `Not run because ${firstFailedTarget} failed earlier in the staged verification run.`,
+  };
+}
+
+function isRunnableStep(
+  step: VerificationStep,
+): step is VerificationStep & { skipped: false; command: string[] } {
+  return !step.skipped && step.command !== undefined;
+}
+
+function isNotRunResult(
+  result: VerificationResult,
+): result is Extract<VerificationResult, { status: "not_run" }> {
+  return result.status === "not_run";
+}
+
+function isExecutedResult(
+  result: VerificationResult,
+): result is Extract<
+  VerificationResult,
+  { status: "passed" | "failed" | "command_broken" }
+> {
+  return !result.skipped && !isNotRunResult(result);
+}
+
+function isExecutedFailure(result: VerificationResult): boolean {
+  return isExecutedResult(result) && !result.ok;
 }
 
 function timeoutForTarget(
@@ -292,7 +387,7 @@ function verificationStatus(
   planError: string | undefined,
 ): VerificationStatus {
   if (planError) return "skipped";
-  const ran = results.filter((result) => !result.skipped);
+  const ran = results.filter(isExecutedResult);
   if (ran.length === 0) return "skipped";
   if (ran.some((result) => !result.ok && result.commandBroken === true)) {
     return "command_broken";
@@ -326,7 +421,7 @@ function failureScopeForHints(
 
 function failureSummaryForStatus(input: {
   status: VerificationStatus;
-  failed: readonly VerificationResult[];
+  firstFailed?: VerificationResult;
   planError?: string;
   pathHints: readonly VerificationPathHint[];
 }): string | undefined {
@@ -334,8 +429,10 @@ function failureSummaryForStatus(input: {
   if (input.status === "skipped") {
     return input.planError ?? "No verification scripts were available.";
   }
-  const firstFailed = input.failed.find((result) => !result.skipped);
-  if (!firstFailed || firstFailed.skipped) return undefined;
+  const firstFailed = input.firstFailed;
+  if (!firstFailed || firstFailed.skipped || isNotRunResult(firstFailed)) {
+    return undefined;
+  }
   const text = failedResultText(firstFailed);
   const primaryLine = firstMeaningfulLine(text);
   const hint = input.pathHints[0];
@@ -355,6 +452,7 @@ function failureSummaryForStatus(input: {
 
 function failedResultText(result: VerificationResult): string {
   if (result.skipped) return result.reason;
+  if (isNotRunResult(result)) return result.reason;
   return [result.stderr, result.stdout, result.error]
     .filter((value): value is string => typeof value === "string" && value.length > 0)
     .join("\n");


### PR DESCRIPTION
## Summary

- Run `verify` targets sequentially in staged order and stop after the first executed failure.
- Add staged output metadata plus `not_run` results for later runnable targets.
- Keep recovery scoped to the first failed target and prevent compact context from treating `not_run` targets as failed.
- Update verify approval copy and the roadmap line for #175.

Closes #175.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (exit 0; CRLF warnings only on this Windows checkout)
- Focused VM source probe covering all-pass, skipped-only, skipped-then-run, typecheck failure stop, lint failure stop, command-broken stop, edited-file scope, and unrelated-failure reporting.
