### PR TITLE
fix: composer follow-ups and status tab command card

### DIFF
--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -98,11 +98,6 @@ const COMPOSER_CHIP = cn(
   "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium leading-4 text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
 );
 
-const COMPOSER_CHIP_OUTLINE = cn(
-  COMPOSER_CONTROL_H,
-  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium leading-4 text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
-);
-
 const MODEL_TRIGGER = cn(
   COMPOSER_CONTROL_H,
   "justify-between gap-2 rounded-md bg-input px-2 text-xs font-normal text-foreground shadow-none ring-1 ring-border hover:bg-input/80",
@@ -472,10 +467,10 @@ function McpSelector({
         <Button
           type="button"
           variant="secondary"
-          size="xs"
           className={cn(
-            COMPOSER_CHIP_OUTLINE,
+            COMPOSER_CHIP,
             selectedCount > 0 && "text-foreground",
+            iconOnly && "px-2",
           )}
           disabled={disabled}
           aria-label={`MCP servers, ${selectedCount} enabled`}

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -111,14 +111,18 @@ const MODEL_TRIGGER = cn(
 function resolveComposerVariant(
   width: number,
   worklogOpen: boolean,
+  hasSessionMetrics: boolean,
 ): ComposerVariant {
-  if (width <= 0) return worklogOpen ? "inline" : "full";
-  if (width < 320) return "compact";
-  if (worklogOpen) {
-    if (width < 400) return "compact";
-    return "inline";
+  if (width <= 0) {
+    return worklogOpen || hasSessionMetrics ? "inline" : "full";
   }
-  if (width < 480) return "inline";
+  if (width < 320) return "compact";
+  if (width < 400) return "compact";
+  if (worklogOpen) return "inline";
+
+  const inlineThreshold = hasSessionMetrics ? 720 : 480;
+  if (width < inlineThreshold) return "inline";
+
   return "full";
 }
 
@@ -155,7 +159,8 @@ export function Composer({
 }: ComposerProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const variant = resolveComposerVariant(columnWidth, worklogOpen);
+  const hasSessionMetrics = tokenUsage.effectiveTokens > 0 || streaming;
+  const variant = resolveComposerVariant(columnWidth, worklogOpen, hasSessionMetrics);
   const sendDisabled = disabled || (mode !== "chat" && !project);
   const iconOnly = variant !== "full";
   const compactContext = variant !== "full";
@@ -244,7 +249,7 @@ export function Composer({
           ? "min-w-0 flex-1"
           : variant === "inline"
             ? "w-32 min-w-0 shrink"
-            : "w-40 sm:w-48",
+            : "w-40 min-w-0 max-w-48 shrink",
       )}
     />
   );
@@ -309,14 +314,14 @@ export function Composer({
               </div>
             </div>
           ) : (
-            <div className="mt-3 flex items-center justify-between gap-2">
-              <div className="flex min-w-0 items-center gap-1.5">
+            <div className="mt-3 flex min-w-0 items-center gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
                 {attachButton}
                 {modeSelector}
                 {permissionsDropdown}
                 {mcpSelector}
               </div>
-              <div className="flex min-w-0 items-center gap-1.5">
+              <div className="flex shrink-0 items-center gap-1.5">
                 {variant === "inline" ? tokenCounter : null}
                 {modelPicker}
                 {variant === "full" ? tokenCounter : null}

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -95,12 +95,12 @@ const COMPOSER_ICON_BTN = "size-[26px] shrink-0 rounded-md";
 
 const COMPOSER_CHIP = cn(
   COMPOSER_CONTROL_H,
-  "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
+  "gap-1.5 rounded-md bg-secondary px-2 text-xs font-medium leading-4 text-foreground shadow-none ring-0 hover:bg-secondary/80 focus-visible:ring-0",
 );
 
 const COMPOSER_CHIP_OUTLINE = cn(
   COMPOSER_CONTROL_H,
-  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+  "gap-1.5 rounded-md bg-transparent px-2 text-xs font-medium leading-4 text-muted-foreground/80 shadow-none ring-1 ring-border hover:bg-secondary/40 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
 );
 
 const MODEL_TRIGGER = cn(
@@ -227,13 +227,7 @@ export function Composer({
   );
 
   const tokenCounter = (
-    <TokenCounter
-      tokenUsage={tokenUsage}
-      pending={streaming}
-      display={
-        variant === "full" ? "full" : variant === "compact" ? "compact" : "minimal"
-      }
-    />
+    <TokenCounter tokenUsage={tokenUsage} pending={streaming} />
   );
 
   const modelPicker = (
@@ -309,8 +303,8 @@ export function Composer({
                 {sendButton}
               </div>
               <div className="flex min-w-0 items-center gap-1.5">
-                {modelPicker}
                 {tokenCounter}
+                {modelPicker}
               </div>
             </div>
           ) : (
@@ -322,9 +316,8 @@ export function Composer({
                 {mcpSelector}
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
-                {variant === "inline" ? tokenCounter : null}
+                {tokenCounter}
                 {modelPicker}
-                {variant === "full" ? tokenCounter : null}
                 {sendButton}
               </div>
             </div>
@@ -403,10 +396,7 @@ function ModeSelector({
       disabled={disabled}
     >
       <SelectTrigger
-        className={cn(
-          iconOnly ? COMPOSER_CHIP_OUTLINE : COMPOSER_CHIP,
-          iconOnly && "px-2",
-        )}
+        className={cn(COMPOSER_CHIP, iconOnly && "px-2")}
         hideChevron={iconOnly}
         aria-label={`Mode: ${selected.label}`}
       >
@@ -482,6 +472,7 @@ function McpSelector({
         <Button
           type="button"
           variant="secondary"
+          size="xs"
           className={cn(
             COMPOSER_CHIP_OUTLINE,
             selectedCount > 0 && "text-foreground",
@@ -627,12 +618,10 @@ function PermissionsDropdown({
 function TokenCounter({
   tokenUsage,
   pending,
-  display = "full",
 }: {
   tokenUsage: SessionTokenUsage;
   pending: boolean;
-  display?: "full" | "compact" | "minimal";
 }) {
   if (tokenUsage.effectiveTokens <= 0 && !pending) return null;
-  return <SessionMetricsHoverCard tokenUsage={tokenUsage} display={display} />;
+  return <SessionMetricsHoverCard tokenUsage={tokenUsage} />;
 }

--- a/components/features/chat/metrics-hover-card.tsx
+++ b/components/features/chat/metrics-hover-card.tsx
@@ -130,22 +130,12 @@ export function ResponseMetricsHoverCard({
   );
 }
 
-export type SessionMetricsDisplay = "full" | "compact" | "minimal";
-
 export function SessionMetricsHoverCard({
   tokenUsage,
-  display = "full",
 }: {
   tokenUsage: SessionTokenUsage;
-  display?: SessionMetricsDisplay;
 }) {
   const tokens = formatCompactSessionTokens(tokenUsage.effectiveTokens);
-  const label =
-    display === "full"
-      ? `session · ${tokens} tok`
-      : display === "compact"
-        ? `${tokens} tok`
-        : tokens;
 
   return (
     <MetricsHoverCardShell
@@ -154,10 +144,10 @@ export function SessionMetricsHoverCard({
         <button
           type="button"
           className="inline-flex !h-[26px] !min-h-[26px] !max-h-[26px] shrink-0 items-center gap-1.5 rounded-md px-2 py-0 font-mono text-[11.5px] leading-none text-muted-foreground/80 ring-1 ring-border transition-colors hover:bg-secondary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-ring"
-          aria-label="Session token usage"
+          aria-label={`Session token usage: ${tokens}`}
         >
           <Coins className="size-[11px]" aria-hidden />
-          {label}
+          {tokens}
         </button>
       }
       footer={

--- a/components/features/projects/background-commands-panel.tsx
+++ b/components/features/projects/background-commands-panel.tsx
@@ -591,14 +591,11 @@ function RecentCommandCard({
         <div className="min-w-0 flex-1">
           <div className="flex min-h-5 items-center gap-2">
             <StatusBadge status={session.status} />
-            <code className="truncate font-mono text-[10px] leading-none text-foreground">
-              {session.command}
-            </code>
-          </div>
-          <div className="mt-1 text-[10px] text-muted-foreground">
-            {formatDuration(session.startedAt, session.finishedAt)}
-            {session.exitCode !== null ? ` · exit ${session.exitCode}` : null}
-            {session.signal ? ` · ${session.signal}` : null}
+            <span className="text-[10px] text-muted-foreground">
+              {formatDuration(session.startedAt, session.finishedAt)}
+              {session.exitCode !== null ? ` · exit ${session.exitCode}` : null}
+              {session.signal ? ` · ${session.signal}` : null}
+            </span>
           </div>
         </div>
         <div className="flex h-5 shrink-0 items-center gap-0.5">


### PR DESCRIPTION
## Summary
- Finish composer responsive fixes that did not land with #176: session-aware inline layout, unified token chip (icon + count, left of model picker), and consistent MCP/mode chip styling
- Simplify the Status tab recent command card header: show `0s · exit 0` beside the status badge instead of repeating the command above the bash log viewer

## Test plan
- [ ] New chat at 100% zoom, worklog closed: full composer labels, no overlap
- [ ] Existing session at 100% zoom, worklog closed: inline/icon chips, token chip before model picker
- [ ] Worklog or file tree open: inline composer layout
- [ ] MCP button matches mode/permission filled chip style
- [ ] Status tab → Recent command card: header shows `[Exited] 0s · exit 0`, command only inside expanded bash card
- [ ] `pnpm typecheck` and `pnpm lint` pass
