### PR TITLE
Phase 6: run-scoped checkpointed revert

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -56,6 +56,7 @@ import {
   NATIVE_ANTON_TOOL_NAMES,
   type NativeAntonToolName,
 } from "./tools";
+import { createRunCheckpointManager } from "./tools/checkpoints";
 import { loadMcpTools, type LoadedMcpTools } from "./mcp";
 import {
   ensureWorkspaceRoot,
@@ -587,6 +588,7 @@ export async function runAgent({
   const finishedToolCallKeys = new Set<string>();
   const toolPolicy = new ToolPolicyEngine(profile, { targetPath: singleFileTargetPath });
   toolPolicy.seed(seedFromPriorToolRecords(priorToolHistory));
+  const checkpoints = createRunCheckpointManager(workspaceRoot);
   const tools = createAntonTools({
     model: selectedModel,
     mcpTools: mcpTools.tools,
@@ -597,6 +599,7 @@ export async function runAgent({
     executionCache,
     profile: isFastEditStart ? "localized-edit" : profile,
     toolPolicy,
+    checkpoints,
   });
   const initialActiveToolNames = initialActiveNativeToolNames.filter((name) =>
     Object.prototype.hasOwnProperty.call(tools, name),

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -459,7 +459,7 @@ function buildNativeToolApprovalMetadata(
         details: [
           pathsDetail(record.paths, workspaceRoot),
           `Staged: ${booleanValue(record.staged) ? "yes" : "no"}.`,
-          "Returns a patch and SHA-256 diff hash for scoped revert confirmation.",
+          "Returns a patch, SHA-256 diff hash, and active-run checkpoint hash when available.",
         ],
       });
     case "git_show":
@@ -517,7 +517,7 @@ function buildNativeToolApprovalMetadata(
         details: [
           pathsDetail(record.paths, workspaceRoot),
           `Expected diff hash: ${stringValue(record.expectedDiffHash) ?? "(missing)"}.`,
-          "The tool recomputes git_diff for the same scope before restoring files.",
+          "The tool recomputes current git and checkpoint hashes for the same scope before restoring files.",
           guardedDetail(record.allowGuarded),
         ],
       });

--- a/src/agent/tools/checkpoints.ts
+++ b/src/agent/tools/checkpoints.ts
@@ -1,0 +1,487 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  ensureWorkspaceRoot,
+  ensureWorkspaceRootAt,
+  resolveInWorkspace,
+} from "../sandbox";
+import { TEXT_FILE_MAX_BYTES, atomicWriteTextFile, isNotFound } from "./edit-utils";
+import { normalizeRelPath, pathGuardReasons } from "./file-guardrails";
+
+type TextCheckpointEntry = {
+  path: string;
+  state: "text";
+  content: string;
+  hash: string;
+};
+
+type AbsentCheckpointEntry = {
+  path: string;
+  state: "absent";
+};
+
+type UnsupportedCheckpointEntry = {
+  path: string;
+  state: "unsupported";
+  reasons: string[];
+};
+
+type CheckpointEntry =
+  | TextCheckpointEntry
+  | AbsentCheckpointEntry
+  | UnsupportedCheckpointEntry;
+
+type CurrentPathState =
+  | { state: "text"; hash: string }
+  | { state: "absent" }
+  | { state: "unsupported"; reasons: string[] };
+
+type CheckpointPathChange = {
+  path: string;
+  kind: "created" | "deleted" | "modified";
+  checkpointHash?: string;
+  currentHash?: string;
+};
+
+export type CheckpointCaptureResult = {
+  path: string;
+  status: "captured" | "already_captured";
+  state: CheckpointEntry["state"];
+  hash?: string;
+  reasons?: string[];
+};
+
+export type CheckpointPathDetail = {
+  path: string;
+  reasons: string[];
+};
+
+export type CheckpointComparison = {
+  hasEntries: boolean;
+  checkpointHash?: string;
+  checkpointedPaths: string[];
+  checkpointUnsupportedPaths: string[];
+  unsupportedPathDetails: CheckpointPathDetail[];
+  coveredPaths: string[];
+};
+
+export type CheckpointRestoreResult =
+  | {
+      ok: true;
+      checkpointRestoredPaths: string[];
+      unsupportedPaths: string[];
+      unsupportedPathDetails: CheckpointPathDetail[];
+      checkpointHash?: string;
+      coveredPaths: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+      checkpointRestoredPaths: string[];
+      unsupportedPaths: string[];
+      unsupportedPathDetails: CheckpointPathDetail[];
+      checkpointHash?: string;
+      coveredPaths: string[];
+    };
+
+export type RunCheckpointManager = {
+  capturePath(relPath: string): Promise<CheckpointCaptureResult>;
+  capturePaths(relPaths: readonly string[]): Promise<CheckpointCaptureResult[]>;
+  discardCaptures(captures: readonly CheckpointCaptureResult[]): void;
+  compare(scopes: readonly string[]): Promise<CheckpointComparison>;
+  restore(scopes: readonly string[]): Promise<CheckpointRestoreResult>;
+};
+
+export function createRunCheckpointManager(
+  workspaceRoot?: string,
+): RunCheckpointManager {
+  return new InMemoryRunCheckpointManager(workspaceRoot);
+}
+
+export function pathOverlapsCheckpointPath(
+  candidatePath: string,
+  checkpointPath: string,
+): boolean {
+  const candidate = normalizeComparablePath(candidatePath);
+  const checkpoint = normalizeComparablePath(checkpointPath);
+  return (
+    candidate === checkpoint ||
+    candidate.startsWith(`${checkpoint}/`) ||
+    checkpoint.startsWith(`${candidate}/`)
+  );
+}
+
+class InMemoryRunCheckpointManager implements RunCheckpointManager {
+  private readonly entries = new Map<string, CheckpointEntry>();
+
+  constructor(private readonly workspaceRoot?: string) {}
+
+  async capturePath(relPath: string): Promise<CheckpointCaptureResult> {
+    const normalized = this.normalizePath(relPath);
+    const existing = this.entries.get(normalized);
+    if (existing) {
+      return captureResult(existing, "already_captured");
+    }
+
+    const entry = await this.snapshotPath(normalized);
+    this.entries.set(normalized, entry);
+    return captureResult(entry, "captured");
+  }
+
+  async capturePaths(
+    relPaths: readonly string[],
+  ): Promise<CheckpointCaptureResult[]> {
+    const results: CheckpointCaptureResult[] = [];
+    for (const relPath of relPaths) {
+      results.push(await this.capturePath(relPath));
+    }
+    return results;
+  }
+
+  discardCaptures(captures: readonly CheckpointCaptureResult[]): void {
+    for (const capture of captures) {
+      if (capture.status === "captured") {
+        this.entries.delete(capture.path);
+      }
+    }
+  }
+
+  async compare(scopes: readonly string[]): Promise<CheckpointComparison> {
+    return this.compareEntries(scopes);
+  }
+
+  async restore(scopes: readonly string[]): Promise<CheckpointRestoreResult> {
+    const comparison = await this.compareEntries(scopes);
+    if (comparison.unsupportedPathDetails.length > 0) {
+      return {
+        ok: false,
+        error: unsupportedRestoreError(comparison.unsupportedPathDetails),
+        checkpointRestoredPaths: [],
+        unsupportedPaths: comparison.checkpointUnsupportedPaths,
+        unsupportedPathDetails: comparison.unsupportedPathDetails,
+        ...(comparison.checkpointHash
+          ? { checkpointHash: comparison.checkpointHash }
+          : {}),
+        coveredPaths: comparison.coveredPaths,
+      };
+    }
+
+    const restoredPaths: string[] = [];
+    const entries = this.entriesForScopes(scopes);
+    for (const entry of entries) {
+      if (entry.state === "unsupported") continue;
+      const current = await this.currentPathState(entry.path);
+      if (current.state === "unsupported") {
+        const details = [{ path: entry.path, reasons: current.reasons }];
+        return {
+          ok: false,
+          error: unsupportedRestoreError(details),
+          checkpointRestoredPaths: restoredPaths,
+          unsupportedPaths: details.map((detail) => detail.path),
+          unsupportedPathDetails: details,
+          ...(comparison.checkpointHash
+            ? { checkpointHash: comparison.checkpointHash }
+            : {}),
+          coveredPaths: comparison.coveredPaths,
+        };
+      }
+
+      if (entry.state === "absent") {
+        if (current.state === "absent") continue;
+        await fs.rm(this.absPath(entry.path), { force: false });
+        restoredPaths.push(entry.path);
+        continue;
+      }
+
+      if (current.state === "text" && current.hash === entry.hash) continue;
+      await atomicWriteTextFile(this.absPath(entry.path), entry.content);
+      restoredPaths.push(entry.path);
+    }
+
+    return {
+      ok: true,
+      checkpointRestoredPaths: uniqueSorted(restoredPaths),
+      unsupportedPaths: [],
+      unsupportedPathDetails: [],
+      ...(comparison.checkpointHash
+        ? { checkpointHash: comparison.checkpointHash }
+        : {}),
+      coveredPaths: comparison.coveredPaths,
+    };
+  }
+
+  private async compareEntries(
+    scopes: readonly string[],
+  ): Promise<CheckpointComparison> {
+    const entries = this.entriesForScopes(scopes);
+    const changes: CheckpointPathChange[] = [];
+    const unsupportedDetails: CheckpointPathDetail[] = [];
+
+    for (const entry of entries) {
+      if (entry.state === "unsupported") {
+        unsupportedDetails.push({ path: entry.path, reasons: entry.reasons });
+        continue;
+      }
+
+      const current = await this.currentPathState(entry.path);
+      if (current.state === "unsupported") {
+        unsupportedDetails.push({ path: entry.path, reasons: current.reasons });
+        continue;
+      }
+
+      if (entry.state === "absent") {
+        if (current.state === "text") {
+          changes.push({
+            path: entry.path,
+            kind: "created",
+            currentHash: current.hash,
+          });
+        }
+        continue;
+      }
+
+      if (current.state === "absent") {
+        changes.push({
+          path: entry.path,
+          kind: "deleted",
+          checkpointHash: entry.hash,
+        });
+      } else if (current.hash !== entry.hash) {
+        changes.push({
+          path: entry.path,
+          kind: "modified",
+          checkpointHash: entry.hash,
+          currentHash: current.hash,
+        });
+      }
+    }
+
+    const checkpointHash = hashComparison(changes, unsupportedDetails);
+    return {
+      hasEntries: entries.length > 0,
+      ...(checkpointHash ? { checkpointHash } : {}),
+      checkpointedPaths: uniqueSorted(changes.map((change) => change.path)),
+      checkpointUnsupportedPaths: uniqueSorted(
+        unsupportedDetails.map((detail) => detail.path),
+      ),
+      unsupportedPathDetails: unsupportedDetails.sort((left, right) =>
+        left.path.localeCompare(right.path),
+      ),
+      coveredPaths: uniqueSorted(entries.map((entry) => entry.path)),
+    };
+  }
+
+  private entriesForScopes(scopes: readonly string[]): CheckpointEntry[] {
+    const normalizedScopes = scopes.map((scope) => normalizeComparablePath(scope));
+    return [...this.entries.values()]
+      .filter(
+        (entry) =>
+          normalizedScopes.length === 0 ||
+          normalizedScopes.some((scope) =>
+            pathOverlapsCheckpointPath(entry.path, scope),
+          ),
+      )
+      .sort((left, right) => left.path.localeCompare(right.path));
+  }
+
+  private async snapshotPath(normalized: string): Promise<CheckpointEntry> {
+    const guardReasons = pathGuardReasons(normalized);
+    if (guardReasons.length > 0) {
+      return {
+        path: normalized,
+        state: "unsupported",
+        reasons: guardReasons,
+      };
+    }
+
+    const abs = this.absPath(normalized);
+    let stat: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stat = await fs.lstat(abs);
+    } catch (err) {
+      if (isNotFound(err)) return { path: normalized, state: "absent" };
+      throw err;
+    }
+
+    if (stat.isSymbolicLink()) {
+      return unsupportedEntry(normalized, "symbolic links are not checkpoint-restorable");
+    }
+    if (stat.isDirectory()) {
+      return unsupportedEntry(normalized, "directories are not checkpoint-restorable");
+    }
+    if (!stat.isFile()) {
+      return unsupportedEntry(normalized, "non-file paths are not checkpoint-restorable");
+    }
+    if (stat.size > TEXT_FILE_MAX_BYTES) {
+      return unsupportedEntry(
+        normalized,
+        `large file exceeds ${TEXT_FILE_MAX_BYTES} bytes`,
+      );
+    }
+
+    const bytes = await fs.readFile(abs);
+    const decoded = decodeUtf8Text(bytes);
+    if (!decoded.ok) {
+      return unsupportedEntry(normalized, decoded.reason);
+    }
+    return {
+      path: normalized,
+      state: "text",
+      content: decoded.content,
+      hash: sha256(bytes),
+    };
+  }
+
+  private async currentPathState(relPath: string): Promise<CurrentPathState> {
+    const guardReasons = pathGuardReasons(relPath);
+    if (guardReasons.length > 0) {
+      return { state: "unsupported", reasons: guardReasons };
+    }
+
+    const abs = this.absPath(relPath);
+    let stat: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stat = await fs.lstat(abs);
+    } catch (err) {
+      if (isNotFound(err)) return { state: "absent" };
+      throw err;
+    }
+
+    if (stat.isSymbolicLink()) {
+      return {
+        state: "unsupported",
+        reasons: ["symbolic links are not checkpoint-restorable"],
+      };
+    }
+    if (stat.isDirectory()) {
+      return {
+        state: "unsupported",
+        reasons: ["directories are not checkpoint-restorable"],
+      };
+    }
+    if (!stat.isFile()) {
+      return {
+        state: "unsupported",
+        reasons: ["non-file paths are not checkpoint-restorable"],
+      };
+    }
+    if (stat.size > TEXT_FILE_MAX_BYTES) {
+      return {
+        state: "unsupported",
+        reasons: [`large file exceeds ${TEXT_FILE_MAX_BYTES} bytes`],
+      };
+    }
+
+    const bytes = await fs.readFile(abs);
+    const decoded = decodeUtf8Text(bytes);
+    if (!decoded.ok) {
+      return { state: "unsupported", reasons: [decoded.reason] };
+    }
+    return { state: "text", hash: sha256(bytes) };
+  }
+
+  private normalizePath(relPath: string): string {
+    const root = this.root();
+    const abs = resolveInWorkspace(relPath, root);
+    const normalized = normalizeRelPath(path.relative(root, abs));
+    if (!normalized || normalized === ".") {
+      throw new Error("checkpoint paths must name a file or directory");
+    }
+    return normalized;
+  }
+
+  private absPath(relPath: string): string {
+    return resolveInWorkspace(relPath, this.root());
+  }
+
+  private root(): string {
+    return this.workspaceRoot
+      ? ensureWorkspaceRootAt(this.workspaceRoot)
+      : ensureWorkspaceRoot();
+  }
+}
+
+function captureResult(
+  entry: CheckpointEntry,
+  status: CheckpointCaptureResult["status"],
+): CheckpointCaptureResult {
+  return {
+    path: entry.path,
+    status,
+    state: entry.state,
+    ...(entry.state === "text" ? { hash: entry.hash } : {}),
+    ...(entry.state === "unsupported" ? { reasons: entry.reasons } : {}),
+  };
+}
+
+function unsupportedEntry(
+  relPath: string,
+  reason: string,
+): UnsupportedCheckpointEntry {
+  return {
+    path: relPath,
+    state: "unsupported",
+    reasons: [reason],
+  };
+}
+
+function decodeUtf8Text(
+  bytes: Buffer,
+): { ok: true; content: string } | { ok: false; reason: string } {
+  let content: string;
+  try {
+    content = new TextDecoder("utf-8", {
+      fatal: true,
+      ignoreBOM: true,
+    }).decode(bytes);
+  } catch {
+    return { ok: false, reason: "file is not valid UTF-8 text" };
+  }
+  if (content.includes("\0")) {
+    return { ok: false, reason: "binary file content is not supported" };
+  }
+  return { ok: true, content };
+}
+
+function hashComparison(
+  changes: readonly CheckpointPathChange[],
+  unsupportedDetails: readonly CheckpointPathDetail[],
+): string | undefined {
+  const lines = [
+    ...changes.map((change) =>
+      [
+        "change",
+        change.kind,
+        change.path,
+        change.checkpointHash ?? "",
+        change.currentHash ?? "",
+      ].join("\0"),
+    ),
+    ...unsupportedDetails.map((detail) =>
+      ["unsupported", detail.path, ...detail.reasons].join("\0"),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+  if (lines.length === 0) return undefined;
+  return sha256(Buffer.from(lines.join("\n"), "utf8"));
+}
+
+function unsupportedRestoreError(details: readonly CheckpointPathDetail[]): string {
+  const summary = details
+    .map((detail) => `${detail.path}: ${detail.reasons.join("; ")}`)
+    .join("; ");
+  return `checkpoint restore refused unsupported path${details.length === 1 ? "" : "s"}: ${summary}`;
+}
+
+function normalizeComparablePath(relPath: string): string {
+  return normalizeRelPath(relPath).replace(/\/+$/, "");
+}
+
+function uniqueSorted(paths: readonly string[]): string[] {
+  return [...new Set(paths)].sort((left, right) => left.localeCompare(right));
+}
+
+function sha256(input: string | Buffer): string {
+  return createHash("sha256").update(input).digest("hex");
+}

--- a/src/agent/tools/edit-file.ts
+++ b/src/agent/tools/edit-file.ts
@@ -10,6 +10,7 @@ import {
   sha256,
 } from "./edit-utils";
 import { assertGuardAllowed } from "./file-guardrails";
+import type { RunCheckpointManager } from "./checkpoints";
 
 export type EditFileErrorCode =
   | "HASH_MISMATCH"
@@ -18,7 +19,10 @@ export type EditFileErrorCode =
   | "GUARD_REJECTED"
   | "WRITE_FAILED";
 
-export function createEditFileTool(workspaceRoot?: string) {
+export function createEditFileTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
   description:
     "Apply a single-file unified diff patch to an existing UTF-8 text file when expectedHash matches. Prefer this for multi-line structural edits. Requires user approval.",
@@ -97,7 +101,13 @@ export function createEditFileTool(workspaceRoot?: string) {
         });
       }
 
-      await atomicWriteTextFile(abs, nextContent);
+      const checkpoint = await checkpoints?.capturePath(relPath);
+      try {
+        await atomicWriteTextFile(abs, nextContent);
+      } catch (err) {
+        if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+        throw err;
+      }
       return {
         ok: true as const,
         alreadyApplied: false,
@@ -107,6 +117,7 @@ export function createEditFileTool(workspaceRoot?: string) {
         previousHash: previous.sha256,
         nextHash: sha256(nextContent),
         bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+        ...(checkpoint ? { checkpoint } : {}),
       };
     } catch (err) {
       if (err instanceof SandboxError && err.message.includes("guard")) {

--- a/src/agent/tools/edit-text.ts
+++ b/src/agent/tools/edit-text.ts
@@ -13,6 +13,7 @@ import { findPreview, nearMatchesForFind } from "./edit-diagnostics";
 import { applyTextEditsToContent, buildDisplayDiff } from "./text-edits";
 import { lintEditedFile } from "./post-edit-lint";
 import { modelVisibleToolOutput } from "./model-output";
+import type { RunCheckpointManager } from "./checkpoints";
 
 const editSchema = z.object({
   oldText: z.string().describe("Text to find in the current file on disk (LF or CRLF both work)."),
@@ -25,7 +26,10 @@ const editSchema = z.object({
     ),
 });
 
-export function createEditTextTool(workspaceRoot?: string) {
+export function createEditTextTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Apply one or more oldText/newText edits to an existing UTF-8 file. Reads the current file from disk (no read_file hash required). Line-ending differences (CRLF vs LF) are normalized before matching. Returns a compact diff so you can continue editing without re-reading the whole file. Requires user approval.",
@@ -80,7 +84,13 @@ export function createEditTextTool(workspaceRoot?: string) {
           });
         }
 
-        await atomicWriteTextFile(abs, result.content);
+        const checkpoint = await checkpoints?.capturePath(relPath);
+        try {
+          await atomicWriteTextFile(abs, result.content);
+        } catch (err) {
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+          throw err;
+        }
         const diff = buildDisplayDiff(previous.content, result.content);
         const patch = createPatch(relPath, previous.content, result.content);
         const patchPreview =
@@ -88,6 +98,7 @@ export function createEditTextTool(workspaceRoot?: string) {
         const lint = await lintEditedFile(relPath, workspaceRoot);
         if (!lint.ok && !lint.skipped && lint.blocking) {
           await atomicWriteTextFile(abs, previous.content);
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
           return structuredError({
             code: "SYNTAX_OR_LINT_FAILED",
             path: relPath,
@@ -111,6 +122,7 @@ export function createEditTextTool(workspaceRoot?: string) {
           bytesWritten: Buffer.byteLength(result.content, "utf8"),
           diff,
           patchPreview,
+          ...(checkpoint ? { checkpoint } : {}),
           priorReadStale: true as const,
           ...(result.recoveredEditCount > 0
             ? {

--- a/src/agent/tools/file-ops.ts
+++ b/src/agent/tools/file-ops.ts
@@ -17,6 +17,7 @@ import {
   pathGuardReasons,
   verifyExpectedHash,
 } from "./file-guardrails";
+import type { RunCheckpointManager } from "./checkpoints";
 
 const allowGuardedSchema = z
   .boolean()
@@ -119,7 +120,10 @@ export function createMkdirTool(workspaceRoot?: string) {
   });
 }
 
-export function createDeleteTool(workspaceRoot?: string) {
+export function createDeleteTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Delete a file or directory inside the workspace. Regular files require expectedHash. Recursive directory deletes require recursive: true. Requires approval.",
@@ -154,11 +158,18 @@ export function createDeleteTool(workspaceRoot?: string) {
         if (metadata.kind === "directory") {
           await assertNoGuardedDescendants({ absPath: abs, relPath, allowGuarded });
         }
-        await fs.rm(abs, { recursive, force: false });
+        const checkpoint = await checkpoints?.capturePath(relPath);
+        try {
+          await fs.rm(abs, { recursive, force: false });
+        } catch (err) {
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+          throw err;
+        }
         return {
           ok: true as const,
           path: normalizeInputPath(relPath),
           kind: metadata.kind,
+          ...(checkpoint ? { checkpoint } : {}),
         };
       } catch (err) {
         return { ok: false as const, error: errorMessage(err) };
@@ -167,7 +178,10 @@ export function createDeleteTool(workspaceRoot?: string) {
   });
 }
 
-export function createRenameTool(workspaceRoot?: string) {
+export function createRenameTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Rename or move a workspace path without overwriting the destination. Regular source files require expectedSourceHash. Requires approval.",
@@ -212,13 +226,23 @@ export function createRenameTool(workspaceRoot?: string) {
             allowGuarded,
           });
         }
-        await fs.mkdir(path.dirname(destinationAbs), { recursive: true });
-        await fs.rename(sourceAbs, destinationAbs);
+        const checkpointResults = await checkpoints?.capturePaths([
+          sourcePath,
+          destinationPath,
+        ]);
+        try {
+          await fs.mkdir(path.dirname(destinationAbs), { recursive: true });
+          await fs.rename(sourceAbs, destinationAbs);
+        } catch (err) {
+          if (checkpointResults) checkpoints?.discardCaptures(checkpointResults);
+          throw err;
+        }
         return {
           ok: true as const,
           sourcePath: normalizeInputPath(sourcePath),
           destinationPath: normalizeInputPath(destinationPath),
           kind: metadata.kind,
+          ...(checkpointResults ? { checkpoints: checkpointResults } : {}),
         };
       } catch (err) {
         return { ok: false as const, error: errorMessage(err) };
@@ -227,7 +251,10 @@ export function createRenameTool(workspaceRoot?: string) {
   });
 }
 
-export function createCopyTool(workspaceRoot?: string) {
+export function createCopyTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Copy a workspace file or directory without overwriting the destination. Regular source files require expectedSourceHash. Requires approval.",
@@ -269,8 +296,21 @@ export function createCopyTool(workspaceRoot?: string) {
             actualHash: metadata.sha256,
             expectedHash: expectedSourceHash,
           });
-          await fs.mkdir(path.dirname(destinationAbs), { recursive: true });
-          await fs.copyFile(sourceAbs, destinationAbs, fsConstants.COPYFILE_EXCL);
+          const checkpoint = await checkpoints?.capturePath(destinationPath);
+          try {
+            await fs.mkdir(path.dirname(destinationAbs), { recursive: true });
+            await fs.copyFile(sourceAbs, destinationAbs, fsConstants.COPYFILE_EXCL);
+          } catch (err) {
+            if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+            throw err;
+          }
+          return {
+            ok: true as const,
+            sourcePath: normalizeInputPath(sourcePath),
+            destinationPath: normalizeInputPath(destinationPath),
+            kind: metadata.kind,
+            ...(checkpoint ? { checkpoint } : {}),
+          };
         } else if (metadata.kind === "directory") {
           if (!recursive) {
             throw new Error("recursive: true is required to copy directories");
@@ -280,20 +320,27 @@ export function createCopyTool(workspaceRoot?: string) {
             relPath: sourcePath,
             allowGuarded,
           });
-          await fs.cp(sourceAbs, destinationAbs, {
-            recursive: true,
-            errorOnExist: true,
-            force: false,
-          });
+          const checkpoint = await checkpoints?.capturePath(destinationPath);
+          try {
+            await fs.cp(sourceAbs, destinationAbs, {
+              recursive: true,
+              errorOnExist: true,
+              force: false,
+            });
+          } catch (err) {
+            if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+            throw err;
+          }
+          return {
+            ok: true as const,
+            sourcePath: normalizeInputPath(sourcePath),
+            destinationPath: normalizeInputPath(destinationPath),
+            kind: metadata.kind,
+            ...(checkpoint ? { checkpoint } : {}),
+          };
         } else {
           throw new Error(`copy is not supported for ${metadata.kind} paths`);
         }
-        return {
-          ok: true as const,
-          sourcePath: normalizeInputPath(sourcePath),
-          destinationPath: normalizeInputPath(destinationPath),
-          kind: metadata.kind,
-        };
       } catch (err) {
         return { ok: false as const, error: errorMessage(err) };
       }

--- a/src/agent/tools/git.ts
+++ b/src/agent/tools/git.ts
@@ -5,6 +5,10 @@ import { tool } from "ai";
 import { ensureWorkspaceRoot, ensureWorkspaceRootAt, resolveInWorkspace, SandboxError } from "../sandbox";
 import { assertPathGuardAllowed, normalizeRelPath } from "./file-guardrails";
 import { runWorkspaceProcess } from "@/src/workspace/process-runner";
+import {
+  pathOverlapsCheckpointPath,
+  type RunCheckpointManager,
+} from "./checkpoints";
 
 const pathListSchema = z
   .array(z.string())
@@ -34,7 +38,10 @@ export function createGitStatusTool(workspaceRoot?: string) {
   });
 }
 
-export function createGitDiffTool(workspaceRoot?: string) {
+export function createGitDiffTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Show a scoped git diff and return a SHA-256 hash of the patch for later revert confirmation. Read-only.",
@@ -47,14 +54,23 @@ export function createGitDiffTool(workspaceRoot?: string) {
         const root = workspace(workspaceRoot);
         const scopedPaths = validatePaths(paths, root, true);
         const args = ["diff", ...(staged ? ["--cached"] : []), ...pathspecArgs(scopedPaths)];
+        const checkpoint = staged
+          ? undefined
+          : await checkpointMetadata(checkpoints, scopedPaths);
         const result = await git(root, args);
-        if (result.exitCode !== 0) return gitError(result);
+        if (result.exitCode !== 0) {
+          return {
+            ...gitError(result),
+            ...checkpoint,
+          };
+        }
         return {
           ok: true as const,
           staged,
           paths: scopedPaths,
           patch: result.stdout,
           diffHash: sha256(result.stdout),
+          ...checkpoint,
         };
       } catch (err) {
         return { ok: false as const, error: errorMessage(err) };
@@ -240,7 +256,10 @@ export function createGitRestoreTool(workspaceRoot?: string) {
   });
 }
 
-export function createRevertChangesTool(workspaceRoot?: string) {
+export function createRevertChangesTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Revert scoped working-tree changes only when the current git diff hash matches the expected hash from git_diff. Requires approval.",
@@ -253,19 +272,77 @@ export function createRevertChangesTool(workspaceRoot?: string) {
       try {
         const root = workspace(workspaceRoot);
         const scopedPaths = validatePaths(paths, root, allowGuarded);
+        const checkpoint = checkpoints
+          ? await checkpoints.compare(scopedPaths)
+          : undefined;
+        const checkpointHash = checkpoint?.checkpointHash;
         const diff = await git(root, ["diff", ...pathspecArgs(scopedPaths)]);
-        if (diff.exitCode !== 0) return gitError(diff);
-        const actualHash = sha256(diff.stdout);
-        if (actualHash !== expectedDiffHash) {
+        const diffHash =
+          diff.exitCode === 0 ? sha256(diff.stdout) : undefined;
+        if (diff.exitCode !== 0 && checkpointHash !== expectedDiffHash) {
           return {
-            ok: false as const,
-            error: `diff hash mismatch: expected ${expectedDiffHash}, found ${actualHash}`,
-            actualDiffHash: actualHash,
+            ...gitError(diff),
+            ...(checkpointHash ? { checkpointHash } : {}),
           };
         }
-        const restore = await git(root, ["restore", "--", ...scopedPaths]);
-        if (restore.exitCode !== 0) return gitError(restore);
-        return { ok: true as const, restoredPaths: scopedPaths, diffHash: actualHash };
+        if (diffHash !== expectedDiffHash && checkpointHash !== expectedDiffHash) {
+          return {
+            ok: false as const,
+            error: hashMismatchError(expectedDiffHash, diffHash, checkpointHash),
+            ...(diffHash ? { actualDiffHash: diffHash, diffHash } : {}),
+            ...(checkpointHash ? { checkpointHash } : {}),
+          };
+        }
+
+        const checkpointRestore =
+          checkpoints && checkpoint?.hasEntries
+            ? await checkpoints.restore(scopedPaths)
+            : undefined;
+        if (checkpointRestore && !checkpointRestore.ok) {
+          return {
+            ok: false as const,
+            error: checkpointRestore.error,
+            checkpointRestoredPaths: checkpointRestore.checkpointRestoredPaths,
+            gitRestoredPaths: [],
+            unsupportedPaths: checkpointRestore.unsupportedPaths,
+            unsupportedPathDetails: checkpointRestore.unsupportedPathDetails,
+            ...(checkpointRestore.checkpointHash
+              ? { checkpointHash: checkpointRestore.checkpointHash }
+              : checkpointHash
+                ? { checkpointHash }
+                : {}),
+            ...(diffHash ? { diffHash } : {}),
+          };
+        }
+
+        const checkpointRestoredPaths =
+          checkpointRestore?.checkpointRestoredPaths ?? [];
+        const coveredPaths = checkpointRestore?.coveredPaths ?? [];
+        const gitRestorePaths =
+          coveredPaths.length > 0
+            ? await gitRestoreFallbackPaths(root, scopedPaths, coveredPaths)
+            : scopedPaths;
+        if (gitRestorePaths.length > 0) {
+          const restore = await git(root, ["restore", "--", ...gitRestorePaths]);
+          if (restore.exitCode !== 0) return gitError(restore);
+        }
+        const gitRestoredPaths = gitRestorePaths;
+        return {
+          ok: true as const,
+          restoredPaths: uniqueSorted([
+            ...checkpointRestoredPaths,
+            ...gitRestoredPaths,
+          ]),
+          checkpointRestoredPaths,
+          gitRestoredPaths,
+          unsupportedPaths: [] as string[],
+          ...(checkpointRestore?.checkpointHash
+            ? { checkpointHash: checkpointRestore.checkpointHash }
+            : checkpointHash
+              ? { checkpointHash }
+              : {}),
+          ...(diffHash ? { diffHash } : {}),
+        };
       } catch (err) {
         return { ok: false as const, error: errorMessage(err) };
       }
@@ -307,6 +384,68 @@ function validatePaths(
 
 function pathspecArgs(paths: readonly string[]): string[] {
   return paths.length > 0 ? ["--", ...paths] : [];
+}
+
+async function checkpointMetadata(
+  checkpoints: RunCheckpointManager | undefined,
+  scopedPaths: readonly string[],
+): Promise<
+  | {
+      checkpointHash: string;
+      checkpointedPaths: string[];
+      checkpointUnsupportedPaths: string[];
+    }
+  | Record<string, never>
+> {
+  const comparison = await checkpoints?.compare(scopedPaths);
+  if (!comparison?.checkpointHash) return {};
+  return {
+    checkpointHash: comparison.checkpointHash,
+    checkpointedPaths: comparison.checkpointedPaths,
+    checkpointUnsupportedPaths: comparison.checkpointUnsupportedPaths,
+  };
+}
+
+async function gitRestoreFallbackPaths(
+  root: string,
+  scopedPaths: readonly string[],
+  coveredPaths: readonly string[],
+): Promise<string[]> {
+  const result = await git(root, [
+    "diff",
+    "--name-only",
+    "-z",
+    ...pathspecArgs(scopedPaths),
+  ]);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || "git diff --name-only failed");
+  }
+  const paths = result.stdout
+    .split("\0")
+    .map((item) => normalizeRelPath(item))
+    .filter(Boolean);
+  return uniqueSorted(
+    paths.filter(
+      (changedPath) =>
+        !coveredPaths.some((coveredPath) =>
+          pathOverlapsCheckpointPath(changedPath, coveredPath),
+        ),
+    ),
+  );
+}
+
+function hashMismatchError(
+  expected: string,
+  diffHash: string | undefined,
+  checkpointHash: string | undefined,
+): string {
+  const diff = diffHash ? `diffHash ${diffHash}` : "no current diffHash";
+  const checkpoint = checkpointHash ? `, checkpointHash ${checkpointHash}` : "";
+  return `diff hash mismatch: expected ${expected}, found ${diff}${checkpoint}`;
+}
+
+function uniqueSorted(paths: readonly string[]): string[] {
+  return [...new Set(paths)].sort((left, right) => left.localeCompare(right));
 }
 
 function parseStatus(output: string): Array<{

--- a/src/agent/tools/index.ts
+++ b/src/agent/tools/index.ts
@@ -69,6 +69,7 @@ import { createUpdateTodosTool, updateTodosTool } from "./todos";
 import { createVerifyTool, verifyTool } from "./verify";
 import type { AgentRunProfile } from "../loop";
 import type { ToolPolicyEngine } from "../tool-policy";
+import type { RunCheckpointManager } from "./checkpoints";
 
 export const nativeAntonTools = applyNativeToolPermissionPolicy({
   read_file: readFileTool,
@@ -126,6 +127,7 @@ export function createAntonTools({
   executionCache,
   profile = "general-chat",
   toolPolicy,
+  checkpoints,
 }: {
   model?: string;
   mcpTools?: ToolSet;
@@ -136,6 +138,7 @@ export function createAntonTools({
   executionCache?: ToolExecutionCache;
   profile?: AgentRunProfile;
   toolPolicy?: ToolPolicyEngine;
+  checkpoints?: RunCheckpointManager;
 }) {
   const selectedNativeToolNames = new Set(
     nativeToolNames ?? NATIVE_ANTON_TOOL_NAMES,
@@ -143,26 +146,26 @@ export function createAntonTools({
   const allNativeTools = {
     ...nativeAntonTools,
     read_file: createReadFileTool(workspaceRoot, profile),
-    edit_file: createEditFileTool(workspaceRoot),
-    replace_text: createReplaceTextTool(workspaceRoot),
-    replace_lines: createReplaceLinesTool(workspaceRoot),
-    edit_text: createEditTextTool(workspaceRoot),
-    multi_replace_text: createMultiReplaceTextTool(workspaceRoot),
-    write_file: createWriteFileTool(workspaceRoot),
+    edit_file: createEditFileTool(workspaceRoot, checkpoints),
+    replace_text: createReplaceTextTool(workspaceRoot, checkpoints),
+    replace_lines: createReplaceLinesTool(workspaceRoot, checkpoints),
+    edit_text: createEditTextTool(workspaceRoot, checkpoints),
+    multi_replace_text: createMultiReplaceTextTool(workspaceRoot, checkpoints),
+    write_file: createWriteFileTool(workspaceRoot, checkpoints),
     read_dir: createReadDirTool(workspaceRoot),
     stat: createStatTool(workspaceRoot),
     mkdir: createMkdirTool(workspaceRoot),
-    delete: createDeleteTool(workspaceRoot),
-    rename: createRenameTool(workspaceRoot),
-    copy: createCopyTool(workspaceRoot),
+    delete: createDeleteTool(workspaceRoot, checkpoints),
+    rename: createRenameTool(workspaceRoot, checkpoints),
+    copy: createCopyTool(workspaceRoot, checkpoints),
     format: createFormatTool(workspaceRoot),
     git_status: createGitStatusTool(workspaceRoot),
-    git_diff: createGitDiffTool(workspaceRoot),
+    git_diff: createGitDiffTool(workspaceRoot, checkpoints),
     git_show: createGitShowTool(workspaceRoot),
     git_branch: createGitBranchTool(workspaceRoot),
     git_commit: createGitCommitTool(workspaceRoot),
     git_restore: createGitRestoreTool(workspaceRoot),
-    revert_changes: createRevertChangesTool(workspaceRoot),
+    revert_changes: createRevertChangesTool(workspaceRoot, checkpoints),
     bash: createBashTool(workspaceRoot, permissionMode),
     inspect_project: createInspectProjectTool(workspaceRoot),
     verify: createVerifyTool(workspaceRoot, profile, {

--- a/src/agent/tools/multi-replace-text.ts
+++ b/src/agent/tools/multi-replace-text.ts
@@ -16,13 +16,17 @@ import {
   restoreLineEndings,
   type MatchedLineRange,
 } from "./text-edits";
+import type { RunCheckpointManager } from "./checkpoints";
 
 const replacementSchema = z.object({
   find: z.string().min(1).describe("Exact text to find in the file."),
   replace: z.string().describe("Replacement text."),
 });
 
-export function createMultiReplaceTextTool(workspaceRoot?: string) {
+export function createMultiReplaceTextTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Apply ordered exact-text replacements to one existing UTF-8 file when expectedHash matches. All replacements run atomically. Requires user approval.",
@@ -109,7 +113,13 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
           });
         }
 
-        await atomicWriteTextFile(abs, restoredContent);
+        const checkpoint = await checkpoints?.capturePath(relPath);
+        try {
+          await atomicWriteTextFile(abs, restoredContent);
+        } catch (err) {
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+          throw err;
+        }
         return {
           ok: true as const,
           path: relPath,
@@ -117,6 +127,7 @@ export function createMultiReplaceTextTool(workspaceRoot?: string) {
           previousHash: previous.sha256,
           nextHash: sha256(restoredContent),
           bytesWritten: Buffer.byteLength(restoredContent, "utf8"),
+          ...(checkpoint ? { checkpoint } : {}),
           ...(recoveredEditCount > 0
             ? {
                 matchStrategy:

--- a/src/agent/tools/replace-lines.ts
+++ b/src/agent/tools/replace-lines.ts
@@ -8,6 +8,7 @@ import {
   sha256,
 } from "./edit-utils";
 import { assertGuardAllowed } from "./file-guardrails";
+import type { RunCheckpointManager } from "./checkpoints";
 
 const editSchema = z.object({
   startLine: z.number().int().min(1).describe("1-indexed first line to replace (inclusive)."),
@@ -19,7 +20,10 @@ const editSchema = z.object({
   replacement: z.string().describe("Replacement text for the line range."),
 });
 
-export function createReplaceLinesTool(workspaceRoot?: string) {
+export function createReplaceLinesTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Replace ordered, non-overlapping line ranges in an existing UTF-8 file when expectedHash matches. Prefer this when exact find strings are brittle. Requires user approval.",
@@ -85,7 +89,13 @@ export function createReplaceLinesTool(workspaceRoot?: string) {
           });
         }
 
-        await atomicWriteTextFile(abs, nextContent);
+        const checkpoint = await checkpoints?.capturePath(relPath);
+        try {
+          await atomicWriteTextFile(abs, nextContent);
+        } catch (err) {
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+          throw err;
+        }
         return {
           ok: true as const,
           path: relPath,
@@ -93,6 +103,7 @@ export function createReplaceLinesTool(workspaceRoot?: string) {
           previousHash: previous.sha256,
           nextHash: sha256(nextContent),
           bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+          ...(checkpoint ? { checkpoint } : {}),
           changedRanges: validation.normalizedEdits.map((edit) => ({
             startLine: edit.startLine,
             endLine: edit.endLine,

--- a/src/agent/tools/replace-text.ts
+++ b/src/agent/tools/replace-text.ts
@@ -15,8 +15,12 @@ import {
   planTextReplacement,
   restoreLineEndings,
 } from "./text-edits";
+import type { RunCheckpointManager } from "./checkpoints";
 
-export function createReplaceTextTool(workspaceRoot?: string) {
+export function createReplaceTextTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
     description:
       "Replace one exact text span in an existing UTF-8 file when expectedHash matches. Prefer this for small targeted edits. Requires user approval.",
@@ -102,7 +106,13 @@ export function createReplaceTextTool(workspaceRoot?: string) {
           });
         }
 
-        await atomicWriteTextFile(abs, nextContent);
+        const checkpoint = await checkpoints?.capturePath(relPath);
+        try {
+          await atomicWriteTextFile(abs, nextContent);
+        } catch (err) {
+          if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+          throw err;
+        }
         return {
           ok: true as const,
           path: relPath,
@@ -110,6 +120,7 @@ export function createReplaceTextTool(workspaceRoot?: string) {
           previousHash: previous.sha256,
           nextHash: sha256(nextContent),
           bytesWritten: Buffer.byteLength(nextContent, "utf8"),
+          ...(checkpoint ? { checkpoint } : {}),
           ...(plan.strategy === "indentation"
             ? {
                 matchStrategy: "indentation",

--- a/src/agent/tools/write-file.ts
+++ b/src/agent/tools/write-file.ts
@@ -11,8 +11,12 @@ import {
   assertPathGuardAllowed,
 } from "./file-guardrails";
 import { modelVisibleToolOutput } from "./model-output";
+import type { RunCheckpointManager } from "./checkpoints";
 
-export function createWriteFileTool(workspaceRoot?: string) {
+export function createWriteFileTool(
+  workspaceRoot?: string,
+  checkpoints?: RunCheckpointManager,
+) {
   return tool({
   description:
     "Create a new small UTF-8 text file. Existing files are rejected; use edit_text for surgical edits or edit_file for large structural rewrites. Requires user approval.",
@@ -56,7 +60,13 @@ export function createWriteFileTool(workspaceRoot?: string) {
             "Use edit_text for surgical edits, or edit_file for large structural rewrites.",
         };
       }
-      await createTextFileExclusive(abs, content);
+      const checkpoint = await checkpoints?.capturePath(relPath);
+      try {
+        await createTextFileExclusive(abs, content);
+      } catch (err) {
+        if (checkpoint) checkpoints?.discardCaptures([checkpoint]);
+        throw err;
+      }
       return {
         ok: true as const,
         path: relPath,
@@ -66,6 +76,7 @@ export function createWriteFileTool(workspaceRoot?: string) {
         previousHash: previous.previousHash,
         previousTruncated: previous.previousTruncated,
         nextHash: sha256(content),
+        ...(checkpoint ? { checkpoint } : {}),
       };
     } catch (err) {
       const message = errorMessage(err);


### PR DESCRIPTION
## Summary
- Add an internal run-scoped checkpoint manager for native tool mutations.
- Capture first pre-change state for explicit edit/create/delete/rename/copy paths, including absent markers and unsupported markers for guarded, large, binary, directory, symlink, or non-file paths.
- Extend `git_diff` with checkpoint metadata when active-run checkpoint changes exist.
- Extend `revert_changes` to accept either the current git diff hash or checkpoint hash, restore checkpointed text/created files first, fall back to git restore for uncovered tracked paths, and refuse unsupported checkpoint restores.

## Protected surfaces
- No new model-visible tool.
- No `revert_changes` input schema change.
- No system prompt, profile tool list, native tool name list, or activeTools change.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (exit 0; Windows CRLF warnings only)
- `git diff --cached --check`
- VM-transpiled probe over throwaway git repos:
  - dirty tracked content restored to pre-agent state
  - `write_file` created file removed by checkpoint restore
  - normal tracked-file revert still works through git restore
  - stale `expectedDiffHash` rejected
  - large, binary, guarded, and directory paths reported unsupported
  - mixed scoped restore uses checkpoint and git restore paths

Refs #179
