### PR TITLE
Add composer context picker and attachments

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 ## Phase 6: Developer Experience
 
 - [✔️] Add file tree and file search panel for the active project.
+- [✔️] Add composer slash commands, workspace `@` references, and attachment previews (#183).
 - [✔️] Add project status panel showing root path, git branch, dirty files, package manager, scripts, and last run.
 - [✔️] Add expandable run details for project last run.
 - [✔️] Add live terminal output streaming for long-running commands.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -9,10 +9,12 @@ import {
   type ModelMessage,
   type ProviderMetadata,
   type TextStreamPart,
+  type TextPart,
   type ToolSet,
   type UIMessageStreamWriter,
 } from "ai";
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import { z } from "zod";
 
 import {
@@ -55,6 +57,8 @@ import { buildWorkspaceContextDigest } from "@/src/agent/workspace-context";
 import { budgetForProfile } from "@/src/agent/run-budget";
 import { compactReadFileForModel } from "@/src/agent/tools/model-output";
 import type { ProfilePromotionEvent } from "@/src/agent/profile-promotion";
+import { readComposerSkill } from "@/src/agent/skills";
+import { resolveInWorkspace } from "@/src/agent/sandbox";
 import {
   buildToolApprovalMetadata,
   commandPolicyModeForPermission,
@@ -125,12 +129,47 @@ import type {
   AntonRunStatus,
   AntonTodoItem,
   AntonTodoSnapshot,
+  AntonWorkspaceReferencePartData,
   AntonUIMessage,
 } from "@/src/lib/trace";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
 const ACTIVE_RUN_STALE_AFTER_MS = 5 * 60 * 1000;
+const MAX_ATTACHMENT_COUNT = 10;
+const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+const MAX_ATTACHMENT_TOTAL_BYTES = 24 * 1024 * 1024;
+const MAX_WORKSPACE_REFERENCES = 50;
+const SUPPORTED_ATTACHMENT_MEDIA_TYPES = new Set([
+  "application/json",
+  "application/pdf",
+  "application/typescript",
+  "application/xml",
+  "application/yaml",
+  "application/x-yaml",
+  "application/x-javascript",
+  "application/javascript",
+  "text/css",
+  "text/csv",
+  "text/html",
+  "text/javascript",
+  "text/jsx",
+  "text/markdown",
+  "text/plain",
+  "text/tsx",
+  "text/typescript",
+  "text/x-markdown",
+  "text/x-yaml",
+  "text/xml",
+  "text/yaml",
+]);
+const SUPPORTED_ATTACHMENT_IMAGE_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
 
 const bodySchema = z.object({
   sessionId: z.string().min(1),
@@ -288,6 +327,14 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
+  const workspaceReferenceError = validateWorkspaceReferences(uiMessages, project);
+  if (workspaceReferenceError) {
+    return Response.json({ error: workspaceReferenceError }, { status: 400 });
+  }
+  const attachmentError = validateAttachments(uiMessages);
+  if (attachmentError) {
+    return Response.json({ error: attachmentError }, { status: 400 });
+  }
 
   if (!existing) {
     createSession({
@@ -360,6 +407,10 @@ export async function POST(req: Request) {
 
   const isSegmentContinuation = isProfileHandoffContinuation;
   const userText = latestUserText(uiMessages);
+  const slashSkillContext = slashSkillContextFromUserText(
+    userText,
+    project?.localPath,
+  );
   const inheritedSingleFileTargetResolution =
     profile === "single-file-edit"
       ? singleFileTargetResolutionFromCostMetadata(
@@ -429,15 +480,24 @@ export async function POST(req: Request) {
         })
       : undefined;
   const baseModelContextText = isProfileHandoffContinuation
-    ? continuationContextMessageText(continuationNote)
+    ? combineModelContextText(
+        continuationContextMessageText(continuationNote),
+        slashSkillContext,
+      )
     : profile === "single-file-edit" &&
         singleFileTargetResolution &&
         "targetPath" in singleFileTargetResolution
-      ? singleFileTargetContext(singleFileTargetResolution)
-      : modelOnlyContextMessageText({
-          sessionContextDigest,
-          workspaceContextDigest,
-        });
+      ? combineModelContextText(
+          singleFileTargetContext(singleFileTargetResolution),
+          slashSkillContext,
+        )
+      : combineModelContextText(
+          modelOnlyContextMessageText({
+            sessionContextDigest,
+            workspaceContextDigest,
+          }),
+          slashSkillContext,
+        );
   let modelContextText = baseModelContextText;
   let contextDigestBytes = byteLength(modelContextText ?? "");
   const preservation = modelContextPreservation(
@@ -854,6 +914,196 @@ function isLikelyRepoPath(value: string): boolean {
   );
 }
 
+function validateWorkspaceReferences(
+  messages: AntonUIMessage[],
+  project: ReturnType<typeof getProject> | undefined,
+): string | undefined {
+  const parts = messages.flatMap((message) =>
+    message.parts.filter(isWorkspaceReferencePart),
+  );
+  if (parts.length === 0) return undefined;
+  if (!project || project.status !== "ready") {
+    return "workspace references require a ready project";
+  }
+
+  let referenceCount = 0;
+  for (const part of parts) {
+    if (!isWorkspaceReferenceData(part.data)) {
+      return "workspace reference part is invalid";
+    }
+    if (part.data.projectId !== project.id) {
+      return "workspace reference project does not match the active session project";
+    }
+    referenceCount += part.data.references.length;
+    if (referenceCount > MAX_WORKSPACE_REFERENCES) {
+      return `too many workspace references; maximum is ${MAX_WORKSPACE_REFERENCES}`;
+    }
+
+    for (const reference of part.data.references) {
+      let absolutePath: string;
+      try {
+        absolutePath = resolveInWorkspace(reference.path, project.localPath);
+      } catch (err) {
+        return errorMessage(err);
+      }
+
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(absolutePath);
+      } catch {
+        return `workspace reference does not exist: ${reference.path}`;
+      }
+      if (reference.kind === "file" && !stat.isFile()) {
+        return `workspace reference is not a file: ${reference.path}`;
+      }
+      if (reference.kind === "directory" && !stat.isDirectory()) {
+        return `workspace reference is not a directory: ${reference.path}`;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function validateAttachments(messages: AntonUIMessage[]): string | undefined {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    const fileParts = message.parts.filter((part) => part.type === "file");
+    if (fileParts.length > MAX_ATTACHMENT_COUNT) {
+      return `too many attachments; maximum is ${MAX_ATTACHMENT_COUNT}`;
+    }
+
+    let totalBytes = 0;
+    for (const part of fileParts) {
+      const record = part as Record<string, unknown>;
+      const mediaType = typeof record.mediaType === "string"
+        ? record.mediaType.toLowerCase()
+        : "";
+      const url = typeof record.url === "string" ? record.url : "";
+      if (!isSupportedAttachmentMediaType(mediaType)) {
+        return `unsupported attachment type: ${mediaType || "unknown"}`;
+      }
+      const bytes = attachmentDataUrlBytes(url);
+      if (bytes === undefined) {
+        return "attachments must be submitted as data URLs";
+      }
+      if (bytes > MAX_ATTACHMENT_BYTES) {
+        return `attachment is too large; maximum is ${formatBytes(MAX_ATTACHMENT_BYTES)}`;
+      }
+      totalBytes += bytes;
+      if (totalBytes > MAX_ATTACHMENT_TOTAL_BYTES) {
+        return `attachments are too large; total maximum is ${formatBytes(MAX_ATTACHMENT_TOTAL_BYTES)}`;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function formatBytes(bytes: number): string {
+  const mib = bytes / (1024 * 1024);
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MiB`;
+}
+
+function isSupportedAttachmentMediaType(mediaType: string): boolean {
+  return (
+    SUPPORTED_ATTACHMENT_IMAGE_TYPES.has(mediaType) ||
+    SUPPORTED_ATTACHMENT_MEDIA_TYPES.has(mediaType)
+  );
+}
+
+function attachmentDataUrlBytes(url: string): number | undefined {
+  const match = /^data:([^;,]+)?(;base64)?,(.*)$/i.exec(url);
+  if (!match) return undefined;
+  const isBase64 = match[2] !== undefined;
+  const payload = match[3] ?? "";
+  if (isBase64) {
+    const normalized = payload.replace(/\s/g, "");
+    const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+    return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
+  }
+  try {
+    return Buffer.byteLength(decodeURIComponent(payload), "utf8");
+  } catch {
+    return Buffer.byteLength(payload, "utf8");
+  }
+}
+
+function workspaceReferenceModelPart(
+  part: { type: string; data: unknown },
+): TextPart | undefined {
+  if (part.type !== "data-workspace-reference") return undefined;
+  if (!isWorkspaceReferenceData(part.data)) return undefined;
+  const lines = part.data.references.map((reference) =>
+    `- ${reference.kind}: ${reference.path}`,
+  );
+  if (lines.length === 0) return undefined;
+  return {
+    type: "text",
+    text: [
+      "User-selected workspace references (path-only; read them with tools if needed):",
+      ...lines,
+    ].join("\n"),
+  };
+}
+
+function isWorkspaceReferencePart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-workspace-reference" }> {
+  return part.type === "data-workspace-reference";
+}
+
+function isWorkspaceReferenceData(
+  data: unknown,
+): data is AntonWorkspaceReferencePartData {
+  if (!isRecord(data)) return false;
+  if (typeof data.projectId !== "string" || data.projectId.length === 0) {
+    return false;
+  }
+  if (!Array.isArray(data.references) || data.references.length === 0) {
+    return false;
+  }
+  return data.references.every((reference) => {
+    if (!isRecord(reference)) return false;
+    return (
+      (reference.kind === "file" || reference.kind === "directory") &&
+      typeof reference.path === "string" &&
+      reference.path.length > 0 &&
+      !reference.path.includes("\\") &&
+      typeof reference.label === "string" &&
+      reference.label.length > 0
+    );
+  });
+}
+
+function slashSkillContextFromUserText(
+  text: string,
+  workspaceRoot: string | undefined,
+): string | undefined {
+  const command = leadingSlashCommand(text);
+  if (!command) return undefined;
+  try {
+    const skill = readComposerSkill(command, workspaceRoot);
+    return [
+      "Slash-selected skill context for this run:",
+      `Command: ${skill.command}`,
+      `Source: ${skill.source}`,
+      `Name: ${skill.name}`,
+      skill.description ? `Description: ${skill.description}` : undefined,
+      "",
+      "SKILL.md:",
+      skill.body,
+    ].filter((line): line is string => line !== undefined).join("\n");
+  } catch {
+    return undefined;
+  }
+}
+
+function leadingSlashCommand(text: string): string | undefined {
+  const match = /^\/([a-z0-9_-]+)(?:\s|$)/.exec(text.trimStart());
+  return match ? `/${match[1]}` : undefined;
+}
+
 async function convertMessagesForRun(
   messages: AntonUIMessage[],
   runId: string,
@@ -861,7 +1111,7 @@ async function convertMessagesForRun(
 ) {
   try {
     return await convertToModelMessages(messages, {
-      convertDataPart: () => undefined,
+      convertDataPart: (part) => workspaceReferenceModelPart(part),
     });
   } catch (err) {
     updateRun(runId, {

--- a/app/api/projects/[id]/files/route.ts
+++ b/app/api/projects/[id]/files/route.ts
@@ -21,6 +21,7 @@ const IGNORED_DIRECTORIES = [
   ".git",
   ".next",
   ".turbo",
+  ".vercel",
   "build",
   "coverage",
   "dist",

--- a/app/api/projects/[id]/files/route.ts
+++ b/app/api/projects/[id]/files/route.ts
@@ -66,10 +66,12 @@ export async function GET(_req: Request, { params }: Ctx) {
 
 async function listProjectFiles(root: string): Promise<{
   paths: string[];
+  directories: string[];
   totalCount: number;
   truncated: boolean;
 }> {
   const paths: string[] = [];
+  const directories = new Set<string>();
   let totalCount = 0;
   let truncated = false;
 
@@ -94,6 +96,11 @@ async function listProjectFiles(root: string): Promise<{
 
       if (entry.isDirectory()) {
         if (ignoredDirectorySet.has(entry.name)) continue;
+        const relativeDirectory = path
+          .relative(root, absolutePath)
+          .split(path.sep)
+          .join("/");
+        if (relativeDirectory) directories.add(relativeDirectory);
         await walk(absolutePath);
         continue;
       }
@@ -109,7 +116,7 @@ async function listProjectFiles(root: string): Promise<{
   }
 
   await walk(root);
-  return { paths, totalCount, truncated };
+  return { paths, directories: [...directories].sort(), totalCount, truncated };
 }
 
 function readDirectoryEntries(directory: string) {

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,8 +1,24 @@
-import { listSkills } from "@/src/agent/skills";
+import { listComposerSkills, listSkills } from "@/src/agent/skills";
+import { getProject } from "@/src/db/queries";
 
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  if (url.searchParams.get("scope") === "composer") {
+    const projectId = url.searchParams.get("projectId");
+    const project = projectId ? getProject(projectId) : undefined;
+    if (projectId && !project) {
+      return Response.json({ error: "project not found" }, { status: 404 });
+    }
+    if (project && project.status !== "ready") {
+      return Response.json({ error: "project is not ready" }, { status: 400 });
+    }
+    return Response.json(
+      listComposerSkills(project?.localPath),
+    );
+  }
+
   try {
     return Response.json(listSkills());
   } catch (err) {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -49,6 +49,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { MessageList } from "./message-list";
 import { Composer } from "./composer";
+import type { ComposerSendPayload } from "./composer-context";
 import { sessionTokenUsage } from "./message-metrics";
 import { generateChatId } from "./chat-utils";
 import { Worklog } from "@/components/features/run-trace/worklog";
@@ -220,7 +221,7 @@ function ChatSession({
     initialControls?.selectedMcpServerIds ?? [],
   );
   const [pendingMcpSend, setPendingMcpSend] = useState<{
-    text: string;
+    payload: ComposerSendPayload;
     mode: ChatMode;
     untrusted: McpPreflightServer[];
   } | null>(null);
@@ -504,11 +505,13 @@ function ChatSession({
   }, [messages, requestBodyForMode, sendMessage, sessionId, status]);
 
   const sendWithMcp = async (
-    text: string,
+    payload: ComposerSendPayload,
     requestedMode: ChatMode = mode,
   ): Promise<boolean> => {
     if (requestedMode !== "chat" && !effectiveProjectId) return false;
-    const includeMcp = requestedMode === "agent" && !isAcceptedPlanRequest(text);
+    if (payload.references.length > 0 && !effectiveProjectId) return false;
+    const includeMcp =
+      requestedMode === "agent" && !isAcceptedPlanRequest(payload.text);
     const selectedIds = includeMcp
       ? selectedEnabledMcpServerIds()
       : [];
@@ -522,7 +525,11 @@ function ChatSession({
         body: JSON.stringify({ serverIds: selectedIds }),
       });
       if (!preflight.ok) {
-        setPendingMcpSend({ text, mode: requestedMode, untrusted: preflight.untrusted });
+        setPendingMcpSend({
+          payload,
+          mode: requestedMode,
+          untrusted: preflight.untrusted,
+        });
         return false;
       }
     }
@@ -531,7 +538,7 @@ function ChatSession({
     }
     setStreamingResponseMode(requestedMode);
     void sendMessage(
-      { text },
+      composerPayloadToMessage(payload, effectiveProjectId),
       {
         body: {
           ...requestBodyForMode(requestedMode),
@@ -557,7 +564,7 @@ function ChatSession({
       });
     }
     setPendingMcpSend(null);
-    await sendWithMcp(pending.text, pending.mode);
+    await sendWithMcp(pending.payload, pending.mode);
   };
 
   const streaming = status === "streaming" || status === "submitted";
@@ -653,7 +660,10 @@ function ChatSession({
             onApproval={approveTool}
             onAcceptPlan={() => {
               setMode("agent");
-              void sendWithMcp("Implement plan", "agent");
+              void sendWithMcp(
+                { text: "Implement plan", references: [], files: [] },
+                "agent",
+              );
             }}
             acceptPlanDisabled={streaming || !effectiveProjectId}
           />
@@ -771,6 +781,28 @@ function ChatSession({
 
 function isAcceptedPlanRequest(text: string): boolean {
   return text.trim().toLowerCase() === "implement plan";
+}
+
+function composerPayloadToMessage(
+  payload: ComposerSendPayload,
+  projectId: string | null,
+): { role: "user"; parts: AntonUIMessage["parts"] } {
+  const parts: AntonUIMessage["parts"] = [];
+  if (payload.text.trim().length > 0) {
+    parts.push({ type: "text", text: payload.text.trim() });
+  }
+  if (payload.references.length > 0 && projectId) {
+    parts.push({
+      type: "data-workspace-reference",
+      id: `workspace-reference-${generateChatId()}`,
+      data: {
+        projectId,
+        references: payload.references,
+      },
+    });
+  }
+  parts.push(...payload.files);
+  return { role: "user", parts };
 }
 
 function composerControlsStorageKey(sessionId: string): string {
@@ -903,7 +935,11 @@ function McpTrustDialog({
   onClose,
   onApprove,
 }: {
-  pending: { text: string; mode: ChatMode; untrusted: McpPreflightServer[] } | null;
+  pending: {
+    payload: ComposerSendPayload;
+    mode: ChatMode;
+    untrusted: McpPreflightServer[];
+  } | null;
   onClose: () => void;
   onApprove: () => void;
 }) {

--- a/components/features/chat/composer-context.ts
+++ b/components/features/chat/composer-context.ts
@@ -1,0 +1,329 @@
+"use client";
+
+import type { FileUIPart } from "ai";
+
+import type {
+  ComposerSkillSummary,
+  ProjectFileTreeSummary,
+} from "@/src/lib/api-types";
+import type { AntonWorkspaceReference } from "@/src/lib/trace";
+
+export type ComposerSendPayload = {
+  text: string;
+  references: AntonWorkspaceReference[];
+  files: FileUIPart[];
+};
+
+export type ComposerTrigger = {
+  kind: "slash" | "workspace";
+  start: number;
+  end: number;
+  query: string;
+};
+
+export type ComposerSuggestion =
+  | {
+      kind: "slash";
+      id: string;
+      primary: string;
+      secondary: string;
+      source: ComposerSkillSummary["source"];
+      command: string;
+    }
+  | {
+      kind: "workspace";
+      id: string;
+      primary: string;
+      secondary: string;
+      reference: AntonWorkspaceReference;
+    };
+
+export const MAX_ATTACHMENT_COUNT = 10;
+export const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+export const MAX_ATTACHMENT_TOTAL_BYTES = 24 * 1024 * 1024;
+
+const SUGGESTION_LIMIT = 12;
+const IMAGE_MEDIA_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const MEDIA_TYPES = new Set([
+  "application/json",
+  "application/pdf",
+  "application/typescript",
+  "application/x-javascript",
+  "application/javascript",
+  "application/xml",
+  "text/css",
+  "text/csv",
+  "text/html",
+  "text/javascript",
+  "text/jsx",
+  "text/markdown",
+  "text/plain",
+  "text/tsx",
+  "text/typescript",
+  "text/x-markdown",
+  "text/xml",
+  "text/yaml",
+  "text/x-yaml",
+  "application/yaml",
+  "application/x-yaml",
+]);
+const MIME_BY_EXTENSION: Record<string, string> = {
+  ".avif": "image/avif",
+  ".c": "text/plain",
+  ".cpp": "text/plain",
+  ".cs": "text/plain",
+  ".css": "text/css",
+  ".csv": "text/csv",
+  ".go": "text/plain",
+  ".gif": "image/gif",
+  ".h": "text/plain",
+  ".hpp": "text/plain",
+  ".html": "text/html",
+  ".java": "text/plain",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".jsx": "text/jsx",
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
+  ".mjs": "text/javascript",
+  ".pdf": "application/pdf",
+  ".php": "text/plain",
+  ".png": "image/png",
+  ".ps1": "text/plain",
+  ".py": "text/plain",
+  ".rb": "text/plain",
+  ".rs": "text/plain",
+  ".scss": "text/css",
+  ".sh": "text/plain",
+  ".sql": "text/plain",
+  ".toml": "text/plain",
+  ".ts": "text/typescript",
+  ".tsx": "text/tsx",
+  ".txt": "text/plain",
+  ".webp": "image/webp",
+  ".xml": "text/xml",
+  ".yaml": "text/yaml",
+  ".yml": "text/yaml",
+};
+
+export const ATTACHMENT_ACCEPT = [
+  ...IMAGE_MEDIA_TYPES,
+  ...MEDIA_TYPES,
+  ...Object.keys(MIME_BY_EXTENSION),
+].join(",");
+
+export function findComposerTrigger(
+  text: string,
+  caret: number | null | undefined,
+): ComposerTrigger | null {
+  if (caret === null || caret === undefined) return null;
+  if (caret < 0 || caret > text.length) return null;
+
+  let start = caret;
+  while (start > 0 && !/\s/.test(text[start - 1] ?? "")) start -= 1;
+
+  const token = text.slice(start, caret);
+  if (token.length === 0) return null;
+  const marker = token[0];
+  if (marker !== "/" && marker !== "@") return null;
+  if (start > 0 && !/\s/.test(text[start - 1] ?? "")) return null;
+
+  return {
+    kind: marker === "/" ? "slash" : "workspace",
+    start,
+    end: caret,
+    query: token.slice(1).toLowerCase(),
+  };
+}
+
+export function skillSuggestions(
+  skills: ComposerSkillSummary[],
+  query: string,
+): ComposerSuggestion[] {
+  const normalizedQuery = query.toLowerCase();
+  return skills
+    .filter((skill) => {
+      if (!normalizedQuery) return true;
+      return [
+        skill.command,
+        skill.name,
+        skill.description,
+      ].some((value) => value.toLowerCase().includes(normalizedQuery));
+    })
+    .slice(0, SUGGESTION_LIMIT)
+    .map((skill) => ({
+      kind: "slash",
+      id: `slash:${skill.command}`,
+      primary: skill.command,
+      secondary: skill.description || skill.name,
+      source: skill.source,
+      command: skill.command,
+    }));
+}
+
+export function workspaceSuggestions(
+  fileTree: ProjectFileTreeSummary | null,
+  query: string,
+  selected: AntonWorkspaceReference[],
+): ComposerSuggestion[] {
+  if (!fileTree) return [];
+
+  const normalizedQuery = query.toLowerCase();
+  const selectedKeys = new Set(
+    selected.map((reference) => `${reference.kind}:${reference.path}`),
+  );
+  const directories = fileTree.directories.map((directory) => ({
+    kind: "directory" as const,
+    path: directory,
+    label: directoryName(directory),
+  }));
+  const files = fileTree.paths.map((filePath) => ({
+    kind: "file" as const,
+    path: filePath,
+    label: fileName(filePath),
+  }));
+
+  return [...directories, ...files]
+    .filter((reference) => {
+      if (selectedKeys.has(`${reference.kind}:${reference.path}`)) return false;
+      if (!normalizedQuery) return true;
+      return reference.path.toLowerCase().includes(normalizedQuery);
+    })
+    .slice(0, SUGGESTION_LIMIT)
+    .map((reference) => ({
+      kind: "workspace",
+      id: `workspace:${reference.kind}:${reference.path}`,
+      primary:
+        reference.kind === "directory"
+          ? `${reference.label}/`
+          : reference.label,
+      secondary: reference.path,
+      reference,
+    }));
+}
+
+export async function appendAttachmentFiles(
+  current: FileUIPart[],
+  incoming: FileList | File[],
+): Promise<{ files: FileUIPart[]; error: string | null }> {
+  const source = Array.from(incoming);
+  if (source.length === 0) return { files: current, error: null };
+  if (current.length + source.length > MAX_ATTACHMENT_COUNT) {
+    return {
+      files: current,
+      error: `Maximum ${MAX_ATTACHMENT_COUNT} attachments per message.`,
+    };
+  }
+
+  let totalBytes = current.reduce(
+    (sum, file) => sum + (attachmentDataUrlBytes(file.url) ?? 0),
+    0,
+  );
+  const next = [...current];
+
+  for (const file of source) {
+    const mediaType = mediaTypeForFile(file);
+    if (!mediaType) {
+      return {
+        files: current,
+        error: `Unsupported file type: ${file.name || "unnamed file"}.`,
+      };
+    }
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      return {
+        files: current,
+        error: `${file.name || "Attachment"} is larger than ${formatBytes(MAX_ATTACHMENT_BYTES)}.`,
+      };
+    }
+    totalBytes += file.size;
+    if (totalBytes > MAX_ATTACHMENT_TOTAL_BYTES) {
+      return {
+        files: current,
+        error: `Attachments exceed the ${formatBytes(MAX_ATTACHMENT_TOTAL_BYTES)} total limit.`,
+      };
+    }
+    next.push({
+      type: "file",
+      mediaType,
+      filename: file.name || "attachment",
+      url: await readFileAsDataUrl(file),
+    });
+  }
+
+  return { files: next, error: null };
+}
+
+export function isImageFilePart(file: FileUIPart): boolean {
+  return IMAGE_MEDIA_TYPES.has(file.mediaType.toLowerCase());
+}
+
+export function attachmentDisplayName(file: FileUIPart): string {
+  return file.filename?.trim() || "Attachment";
+}
+
+export function formatBytes(bytes: number): string {
+  const mib = bytes / (1024 * 1024);
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MiB`;
+}
+
+function mediaTypeForFile(file: File): string | undefined {
+  const extension = extensionForFile(file.name);
+  const byExtension = extension ? MIME_BY_EXTENSION[extension] : undefined;
+  if (byExtension) return byExtension;
+
+  const mediaType = file.type.toLowerCase();
+  if (IMAGE_MEDIA_TYPES.has(mediaType) || MEDIA_TYPES.has(mediaType)) {
+    return mediaType;
+  }
+  return undefined;
+}
+
+function extensionForFile(name: string): string | undefined {
+  const lastDot = name.lastIndexOf(".");
+  if (lastDot === -1) return undefined;
+  return name.slice(lastDot).toLowerCase();
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("Failed to read attachment"));
+    reader.onload = () => {
+      resolve(typeof reader.result === "string" ? reader.result : "");
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function attachmentDataUrlBytes(url: string): number | undefined {
+  const match = /^data:([^;,]+)?(;base64)?,(.*)$/i.exec(url);
+  if (!match) return undefined;
+  const isBase64 = match[2] !== undefined;
+  const payload = match[3] ?? "";
+  if (isBase64) {
+    const normalized = payload.replace(/\s/g, "");
+    const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
+    return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
+  }
+  try {
+    return new TextEncoder().encode(decodeURIComponent(payload)).length;
+  } catch {
+    return new TextEncoder().encode(payload).length;
+  }
+}
+
+function fileName(filePath: string): string {
+  return filePath.split("/").at(-1) ?? filePath;
+}
+
+function directoryName(directory: string): string {
+  return directory.split("/").at(-1) ?? directory;
+}

--- a/components/features/chat/composer-parts.tsx
+++ b/components/features/chat/composer-parts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { FileUIPart } from "ai";
 import {
   Code2,
@@ -40,6 +40,14 @@ export function ComposerSuggestionPopover({
   onSelect: (suggestion: ComposerSuggestion) => void;
   className?: string;
 }) {
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  useEffect(() => {
+    optionRefs.current[activeIndex]?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [activeIndex]);
+
   if (suggestions.length === 0) return null;
 
   return (
@@ -58,12 +66,15 @@ export function ComposerSuggestionPopover({
           const active = index === activeIndex;
           return (
             <button
+              ref={(element) => {
+                optionRefs.current[index] = element;
+              }}
               key={suggestion.id}
               type="button"
               role="option"
               aria-selected={active}
               className={cn(
-                "flex w-full min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none",
+                "flex w-full min-w-0 items-start gap-2 rounded-md px-2.5 py-2 text-left outline-none",
                 active
                   ? "bg-secondary text-foreground"
                   : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
@@ -83,7 +94,7 @@ export function ComposerSuggestionPopover({
                 </span>
               </span>
               {suggestion.kind === "slash" ? (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
+                <span className="mt-px shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
                   {suggestion.source}
                 </span>
               ) : null}
@@ -119,7 +130,7 @@ export function WorkspaceReferencePill({
         <FileText className="size-3 shrink-0 text-muted-foreground" />
       )}
       <span className="min-w-0 truncate font-mono">
-        {reference.kind === "directory" ? `${reference.path}/` : reference.path}
+        {reference.kind === "directory" ? `${reference.label}/` : reference.label}
       </span>
       {removable ? (
         <button
@@ -212,7 +223,7 @@ export function AttachmentPreview({
     <span
       className={cn(
         "group/attachment relative inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-[11.5px] font-medium text-secondary-foreground ring-1 ring-border/70",
-        image && "pl-1",
+        image && "gap-0 p-1",
         className,
       )}
     >
@@ -233,14 +244,14 @@ export function AttachmentPreview({
       ) : (
         <AttachmentIcon file={file} />
       )}
-      <span className="grid min-w-0">
-        <span className="truncate">{name}</span>
-        {!image ? (
+      {!image ? (
+        <span className="grid min-w-0">
+          <span className="truncate">{name}</span>
           <span className="truncate text-[10.5px] font-normal text-muted-foreground">
             {file.mediaType}
           </span>
-        ) : null}
-      </span>
+        </span>
+      ) : null}
       {removable ? (
         <button
           type="button"
@@ -267,7 +278,7 @@ function ImageLightbox({
     <AlertDialog open={file !== null} onOpenChange={(open) => {
       if (!open) onOpenChange(null);
     }}>
-      <AlertDialogContent className="!max-w-[min(94vw,960px)] gap-0 bg-popover p-2">
+      <AlertDialogContent className="!w-auto !max-w-[min(94vw,960px)] gap-0 bg-popover p-1">
         <AlertDialogTitle className="sr-only">{name}</AlertDialogTitle>
         <AlertDialogDescription className="sr-only">
           Attached image preview.
@@ -278,7 +289,7 @@ function ImageLightbox({
             <img
               src={file.url}
               alt={name}
-              className="max-h-[82vh] w-auto max-w-full rounded-lg object-contain"
+              className="max-h-[86vh] max-w-[92vw] rounded-lg object-contain"
             />
             <AlertDialogCancel
               size="icon-sm"
@@ -296,12 +307,12 @@ function ImageLightbox({
 
 function SuggestionIcon({ suggestion }: { suggestion: ComposerSuggestion }) {
   if (suggestion.kind === "slash") {
-    return <Sparkles className="size-3.5 shrink-0 text-primary" />;
+    return <Sparkles className="mt-px size-3.5 shrink-0 text-primary" />;
   }
   return suggestion.reference.kind === "directory" ? (
-    <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+    <Folder className="mt-px size-3.5 shrink-0 text-muted-foreground" />
   ) : (
-    <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+    <FileText className="mt-px size-3.5 shrink-0 text-muted-foreground" />
   );
 }
 
@@ -322,7 +333,7 @@ function AttachmentIcon({ file }: { file: FileUIPart }) {
     return <ImageIcon className="size-3.5 shrink-0 text-muted-foreground" />;
   }
   if (mediaType.includes("text") || mediaType.includes("pdf")) {
-    return <FileText className="size-3.5 shrink-0 text-muted-foreground" />;
+    return <FileText className="mt-px size-3.5 shrink-0 text-muted-foreground" />;
   }
   if (mediaType.includes("csv")) {
     return <Paperclip className="size-3.5 shrink-0 text-muted-foreground" />;

--- a/components/features/chat/composer-parts.tsx
+++ b/components/features/chat/composer-parts.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useState } from "react";
+import type { FileUIPart } from "ai";
+import {
+  Code2,
+  File,
+  FileJson,
+  FileText,
+  Folder,
+  Image as ImageIcon,
+  Paperclip,
+  Sparkles,
+  X,
+} from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import type { AntonWorkspaceReference } from "@/src/lib/trace";
+import {
+  attachmentDisplayName,
+  isImageFilePart,
+  type ComposerSuggestion,
+} from "./composer-context";
+
+export function ComposerSuggestionPopover({
+  suggestions,
+  activeIndex,
+  onSelect,
+  className,
+}: {
+  suggestions: ComposerSuggestion[];
+  activeIndex: number;
+  onSelect: (suggestion: ComposerSuggestion) => void;
+  className?: string;
+}) {
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-full left-0 z-50 mb-2 w-full max-w-[min(560px,calc(100vw-2rem))] overflow-hidden rounded-[10px] bg-popover text-popover-foreground shadow-[0_12px_32px_rgba(0,0,0,0.35)] ring-1 ring-border",
+        className,
+      )}
+    >
+      <div
+        role="listbox"
+        aria-label="Composer suggestions"
+        className="max-h-64 overflow-y-auto p-1.5"
+      >
+        {suggestions.map((suggestion, index) => {
+          const active = index === activeIndex;
+          return (
+            <button
+              key={suggestion.id}
+              type="button"
+              role="option"
+              aria-selected={active}
+              className={cn(
+                "flex w-full min-w-0 items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none",
+                active
+                  ? "bg-secondary text-foreground"
+                  : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
+              )}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onSelect(suggestion);
+              }}
+            >
+              <SuggestionIcon suggestion={suggestion} />
+              <span className="grid min-w-0 flex-1 gap-px">
+                <span className="truncate font-mono text-[12.5px] leading-4 text-foreground">
+                  {suggestion.primary}
+                </span>
+                <span className="truncate text-[11.5px] leading-4 text-muted-foreground">
+                  {suggestion.secondary}
+                </span>
+              </span>
+              {suggestion.kind === "slash" ? (
+                <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
+                  {suggestion.source}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceReferencePill({
+  reference,
+  removable = false,
+  onRemove,
+  className,
+}: {
+  reference: AntonWorkspaceReference;
+  removable?: boolean;
+  onRemove?: () => void;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "group/ref inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-[11.5px] font-medium text-secondary-foreground ring-1 ring-border/70",
+        className,
+      )}
+    >
+      {reference.kind === "directory" ? (
+        <Folder className="size-3 shrink-0 text-muted-foreground" />
+      ) : (
+        <FileText className="size-3 shrink-0 text-muted-foreground" />
+      )}
+      <span className="min-w-0 truncate font-mono">
+        {reference.kind === "directory" ? `${reference.path}/` : reference.path}
+      </span>
+      {removable ? (
+        <button
+          type="button"
+          className="grid size-4 shrink-0 place-items-center rounded-sm text-muted-foreground opacity-0 outline-none transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/30 group-hover/ref:opacity-100"
+          aria-label={`Remove ${reference.path}`}
+          onClick={onRemove}
+        >
+          <X className="size-3" />
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+export function WorkspaceReferenceTray({
+  references,
+  removable,
+  onRemove,
+  className,
+}: {
+  references: AntonWorkspaceReference[];
+  removable?: boolean;
+  onRemove?: (reference: AntonWorkspaceReference) => void;
+  className?: string;
+}) {
+  if (references.length === 0) return null;
+  return (
+    <div className={cn("flex min-w-0 flex-wrap gap-1.5", className)}>
+      {references.map((reference) => (
+        <WorkspaceReferencePill
+          key={`${reference.kind}:${reference.path}`}
+          reference={reference}
+          removable={removable}
+          onRemove={() => onRemove?.(reference)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function AttachmentTray({
+  files,
+  removable,
+  onRemove,
+  className,
+}: {
+  files: FileUIPart[];
+  removable?: boolean;
+  onRemove?: (file: FileUIPart, index: number) => void;
+  className?: string;
+}) {
+  const [preview, setPreview] = useState<FileUIPart | null>(null);
+  if (files.length === 0) return null;
+
+  return (
+    <>
+      <div className={cn("flex min-w-0 flex-wrap gap-1.5", className)}>
+        {files.map((file, index) => (
+          <AttachmentPreview
+            key={`${file.url.slice(0, 80)}:${index}`}
+            file={file}
+            removable={removable}
+            onRemove={() => onRemove?.(file, index)}
+            onOpenImage={() => setPreview(file)}
+          />
+        ))}
+      </div>
+      <ImageLightbox file={preview} onOpenChange={setPreview} />
+    </>
+  );
+}
+
+export function AttachmentPreview({
+  file,
+  removable = false,
+  onRemove,
+  onOpenImage,
+  className,
+}: {
+  file: FileUIPart;
+  removable?: boolean;
+  onRemove?: () => void;
+  onOpenImage?: () => void;
+  className?: string;
+}) {
+  const image = isImageFilePart(file);
+  const name = attachmentDisplayName(file);
+  return (
+    <span
+      className={cn(
+        "group/attachment relative inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md bg-secondary px-2 py-1 text-[11.5px] font-medium text-secondary-foreground ring-1 ring-border/70",
+        image && "pl-1",
+        className,
+      )}
+    >
+      {image ? (
+        <button
+          type="button"
+          className="relative size-8 shrink-0 overflow-hidden rounded bg-muted outline-none ring-1 ring-border/70 focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={onOpenImage}
+          aria-label={`Preview ${name}`}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={file.url}
+            alt={name}
+            className="h-full w-full object-cover"
+          />
+        </button>
+      ) : (
+        <AttachmentIcon file={file} />
+      )}
+      <span className="grid min-w-0">
+        <span className="truncate">{name}</span>
+        {!image ? (
+          <span className="truncate text-[10.5px] font-normal text-muted-foreground">
+            {file.mediaType}
+          </span>
+        ) : null}
+      </span>
+      {removable ? (
+        <button
+          type="button"
+          className="absolute -right-1.5 -top-1.5 grid size-5 place-items-center rounded-full bg-popover text-muted-foreground opacity-0 shadow-sm ring-1 ring-border outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/30 group-hover/attachment:opacity-100"
+          aria-label={`Remove ${name}`}
+          onClick={onRemove}
+        >
+          <X className="size-3" />
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+function ImageLightbox({
+  file,
+  onOpenChange,
+}: {
+  file: FileUIPart | null;
+  onOpenChange: (file: FileUIPart | null) => void;
+}) {
+  const name = file ? attachmentDisplayName(file) : "Image preview";
+  return (
+    <AlertDialog open={file !== null} onOpenChange={(open) => {
+      if (!open) onOpenChange(null);
+    }}>
+      <AlertDialogContent className="!max-w-[min(94vw,960px)] gap-0 bg-popover p-2">
+        <AlertDialogTitle className="sr-only">{name}</AlertDialogTitle>
+        <AlertDialogDescription className="sr-only">
+          Attached image preview.
+        </AlertDialogDescription>
+        {file ? (
+          <div className="relative">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={file.url}
+              alt={name}
+              className="max-h-[82vh] w-auto max-w-full rounded-lg object-contain"
+            />
+            <AlertDialogCancel
+              size="icon-sm"
+              className="absolute right-2 top-2 bg-popover/85 text-foreground backdrop-blur-sm"
+              aria-label="Close preview"
+            >
+              <X className="size-3.5" />
+            </AlertDialogCancel>
+          </div>
+        ) : null}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function SuggestionIcon({ suggestion }: { suggestion: ComposerSuggestion }) {
+  if (suggestion.kind === "slash") {
+    return <Sparkles className="size-3.5 shrink-0 text-primary" />;
+  }
+  return suggestion.reference.kind === "directory" ? (
+    <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+  ) : (
+    <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+  );
+}
+
+function AttachmentIcon({ file }: { file: FileUIPart }) {
+  const mediaType = file.mediaType.toLowerCase();
+  if (mediaType.includes("json")) {
+    return <FileJson className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  if (
+    mediaType.includes("javascript") ||
+    mediaType.includes("typescript") ||
+    mediaType.includes("css") ||
+    mediaType.includes("html")
+  ) {
+    return <Code2 className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  if (mediaType.includes("image")) {
+    return <ImageIcon className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  if (mediaType.includes("text") || mediaType.includes("pdf")) {
+    return <FileText className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  if (mediaType.includes("csv")) {
+    return <Paperclip className="size-3.5 shrink-0 text-muted-foreground" />;
+  }
+  return <File className="size-3.5 shrink-0 text-muted-foreground" />;
+}

--- a/components/features/chat/composer.tsx
+++ b/components/features/chat/composer.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import {
+  useCallback,
+  useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
+  type ChangeEvent,
+  type ClipboardEvent,
   type ComponentType,
+  type DragEvent,
   type KeyboardEvent,
 } from "react";
 import {
@@ -45,15 +51,36 @@ import {
 import type { ModelId } from "@/src/lib/models";
 import type { ChatMode } from "@/src/lib/chat-modes";
 import type { PermissionMode } from "@/src/agent/permissions";
-import type { McpServerSummary, ProjectSummary } from "@/src/lib/api-types";
+import type {
+  ComposerSkillSummary,
+  McpServerSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
 import type { SessionTokenUsage } from "@/src/lib/token-usage";
+import type { AntonWorkspaceReference } from "@/src/lib/trace";
+import { errorMessage, getJson } from "@/src/lib/client-fetch";
 import { BranchSwitcher } from "@/components/features/projects/branch-switcher";
 import { ProjectPicker } from "@/components/features/projects/project-picker";
+import { useProjectFileTree } from "@/components/features/projects/hooks";
 import { ModelPicker } from "./model-picker";
 import { SessionMetricsHoverCard } from "./metrics-hover-card";
+import {
+  appendAttachmentFiles,
+  ATTACHMENT_ACCEPT,
+  findComposerTrigger,
+  skillSuggestions,
+  workspaceSuggestions,
+  type ComposerSendPayload,
+  type ComposerSuggestion,
+} from "./composer-context";
+import {
+  AttachmentTray,
+  ComposerSuggestionPopover,
+  WorkspaceReferenceTray,
+} from "./composer-parts";
 
 interface ComposerProps {
-  onSend: (text: string) => boolean | Promise<boolean>;
+  onSend: (payload: ComposerSendPayload) => boolean | Promise<boolean>;
   onStop: () => void;
   disabled: boolean;
   streaming: boolean;
@@ -153,12 +180,87 @@ export function Composer({
   worklogOpen = false,
 }: ComposerProps) {
   const [input, setInput] = useState("");
+  const [workspaceReferences, setWorkspaceReferences] = useState<
+    AntonWorkspaceReference[]
+  >([]);
+  const [attachments, setAttachments] = useState<ComposerSendPayload["files"]>(
+    [],
+  );
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [skills, setSkills] = useState<ComposerSkillSummary[]>([]);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
+  const [caret, setCaret] = useState(0);
+  const [suggestionIndex, setSuggestionIndex] = useState(0);
+  const [dragActive, setDragActive] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const hasSessionMetrics = tokenUsage.effectiveTokens > 0 || streaming;
   const variant = resolveComposerVariant(columnWidth, worklogOpen, hasSessionMetrics);
   const sendDisabled = disabled || (mode !== "chat" && !project);
+  const hasSendContent =
+    input.trim().length > 0 ||
+    workspaceReferences.length > 0 ||
+    attachments.length > 0;
   const iconOnly = variant !== "full";
   const compactContext = variant !== "full";
+  const readyProjectId = project?.status === "ready" ? project.id : null;
+  const fileTreeState = useProjectFileTree(readyProjectId);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadSkills = async () => {
+      const params = new URLSearchParams({ scope: "composer" });
+      if (readyProjectId) params.set("projectId", readyProjectId);
+      try {
+        const data = await getJson<{
+          skills: ComposerSkillSummary[];
+          warnings: string[];
+        }>(`/api/skills?${params.toString()}`);
+        if (cancelled) return;
+        setSkills(data.skills);
+        setSkillsError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setSkills([]);
+        setSkillsError(errorMessage(err, "Failed to load skills"));
+      }
+    };
+    void loadSkills();
+    return () => {
+      cancelled = true;
+    };
+  }, [readyProjectId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setWorkspaceReferences([]);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [readyProjectId]);
+
+  const trigger = useMemo(
+    () => findComposerTrigger(input, caret),
+    [caret, input],
+  );
+  const suggestions = useMemo(() => {
+    if (!trigger) return [];
+    if (trigger.kind === "slash") {
+      return skillSuggestions(skills, trigger.query);
+    }
+    return workspaceSuggestions(
+      fileTreeState.fileTree,
+      trigger.query,
+      workspaceReferences,
+    );
+  }, [fileTreeState.fileTree, skills, trigger, workspaceReferences]);
+  const suggestionsOpen = trigger !== null && suggestions.length > 0;
+  const activeSuggestionIndex =
+    suggestions.length === 0
+      ? 0
+      : Math.min(suggestionIndex, suggestions.length - 1);
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -169,21 +271,156 @@ export function Composer({
     el.style.overflowY = el.scrollHeight > MAX_HEIGHT ? "auto" : "hidden";
   }, [input]);
 
+  const focusTextareaAt = useCallback((position: number) => {
+    window.requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(position, position);
+      setCaret(position);
+    });
+  }, []);
+
+  const addAttachments = useCallback(
+    async (files: FileList | File[]) => {
+      setAttachmentError(null);
+      try {
+        const result = await appendAttachmentFiles(attachments, files);
+        setAttachments(result.files);
+        setAttachmentError(result.error);
+      } catch (err) {
+        setAttachmentError(errorMessage(err, "Failed to add attachment"));
+      }
+    },
+    [attachments],
+  );
+
+  const selectSuggestion = useCallback(
+    (suggestion: ComposerSuggestion) => {
+      if (!trigger) return;
+      if (suggestion.kind === "slash") {
+        const replacement = `${suggestion.command} `;
+        const next =
+          input.slice(0, trigger.start) + replacement + input.slice(trigger.end);
+        setInput(next);
+        focusTextareaAt(trigger.start + replacement.length);
+        return;
+      }
+
+      const next = input.slice(0, trigger.start) + input.slice(trigger.end);
+      setInput(next);
+      setWorkspaceReferences((current) => {
+        if (
+          current.some(
+            (reference) =>
+              reference.kind === suggestion.reference.kind &&
+              reference.path === suggestion.reference.path,
+          )
+        ) {
+          return current;
+        }
+        return [...current, suggestion.reference];
+      });
+      focusTextareaAt(trigger.start);
+    },
+    [focusTextareaAt, input, trigger],
+  );
+
   const submit = () => {
-    const trimmed = input.trim();
-    if (!trimmed || sendDisabled) return;
-    void Promise.resolve(onSend(trimmed)).then((sent) => {
+    if (!hasSendContent || sendDisabled) return;
+    const payload: ComposerSendPayload = {
+      text: input.trim(),
+      references: workspaceReferences,
+      files: attachments,
+    };
+    void Promise.resolve(onSend(payload)).then((sent) => {
       if (sent) {
         setInput("");
+        setWorkspaceReferences([]);
+        setAttachments([]);
+        setAttachmentError(null);
+        setCaret(0);
       }
     });
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (suggestionsOpen) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSuggestionIndex((index) => (index + 1) % suggestions.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSuggestionIndex((index) =>
+          (index - 1 + suggestions.length) % suggestions.length,
+        );
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        selectSuggestion(suggestions[activeSuggestionIndex] ?? suggestions[0]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setCaret(-1);
+        return;
+      }
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submit();
     }
+  };
+
+  const onInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(event.target.value);
+    setCaret(event.target.selectionStart);
+    setSuggestionIndex(0);
+  };
+
+  const onFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.currentTarget.files;
+    if (files) void addAttachments(files);
+    event.currentTarget.value = "";
+  };
+
+  const onPaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (event.clipboardData.files.length === 0) return;
+    event.preventDefault();
+    void addAttachments(event.clipboardData.files);
+  };
+
+  const onDragEnter = (event: DragEvent<HTMLFormElement>) => {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    setDragActive(true);
+  };
+
+  const onDragOver = (event: DragEvent<HTMLFormElement>) => {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    setDragActive(true);
+  };
+
+  const onDragLeave = (event: DragEvent<HTMLFormElement>) => {
+    if (
+      event.relatedTarget instanceof Node &&
+      event.currentTarget.contains(event.relatedTarget)
+    ) {
+      return;
+    }
+    setDragActive(false);
+  };
+
+  const onDrop = (event: DragEvent<HTMLFormElement>) => {
+    if (!hasDraggedFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    setDragActive(false);
+    void addAttachments(event.dataTransfer.files);
   };
 
   const attachButton = (
@@ -193,7 +430,8 @@ export function Composer({
       size="icon-xs"
       className={cn(COMPOSER_ICON_BTN, "text-muted-foreground hover:text-foreground")}
       disabled={disabled}
-      aria-label="Add context"
+      aria-label="Attach files"
+      onClick={() => fileInputRef.current?.click()}
     >
       <Plus className="size-3.5" />
     </Button>
@@ -258,7 +496,7 @@ export function Composer({
     <Button
       type="submit"
       size="icon-xs"
-      disabled={sendDisabled || !input.trim()}
+      disabled={sendDisabled || !hasSendContent}
       className={COMPOSER_ICON_BTN}
       aria-label="Send message"
     >
@@ -272,21 +510,77 @@ export function Composer({
         e.preventDefault();
         submit();
       }}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
       className="relative z-40 w-full max-w-full shrink-0 overflow-visible bg-background px-3 pb-2 pt-1 sm:px-4"
     >
       <div className="mx-auto w-full max-w-[calc(100vw-1.5rem)] min-w-0 sm:max-w-[720px]">
-        <div className="rounded-xl bg-card p-3 ring-1 ring-border">
-          <Textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onInput={(e) => setInput(e.currentTarget.value)}
-            onKeyDown={onKeyDown}
-            placeholder={placeholderForMode(mode)}
-            rows={1}
-            className="field-sizing-fixed min-h-0 min-w-0 resize-none rounded-none border-0 bg-transparent p-0 font-mono text-[13px] leading-5 shadow-none ring-0 placeholder:font-mono placeholder:text-(--accent-muted) focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-[13px]"
-            style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
+        <div
+          className={cn(
+            "rounded-xl bg-card p-3 ring-1 ring-border",
+            dragActive && "ring-primary/60",
+          )}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={ATTACHMENT_ACCEPT}
+            className="hidden"
+            tabIndex={-1}
+            onChange={onFileInputChange}
           />
+          <div className="relative min-w-0">
+            <ComposerSuggestionPopover
+              suggestions={suggestions}
+              activeIndex={activeSuggestionIndex}
+              onSelect={selectSuggestion}
+            />
+            <WorkspaceReferenceTray
+              references={workspaceReferences}
+              removable
+              onRemove={(reference) => {
+                setWorkspaceReferences((current) =>
+                  current.filter(
+                    (item) =>
+                      item.kind !== reference.kind || item.path !== reference.path,
+                  ),
+                );
+              }}
+              className="mb-2"
+            />
+            <AttachmentTray
+              files={attachments}
+              removable
+              onRemove={(_file, index) => {
+                setAttachments((current) =>
+                  current.filter((_item, itemIndex) => itemIndex !== index),
+                );
+                setAttachmentError(null);
+              }}
+              className={workspaceReferences.length > 0 ? "mb-2" : "mb-2"}
+            />
+            {attachmentError || skillsError || fileTreeState.error ? (
+              <div className="mb-2 rounded-md bg-destructive/10 px-2 py-1.5 text-[11.5px] text-destructive ring-1 ring-destructive/20">
+                {attachmentError ?? skillsError ?? fileTreeState.error}
+              </div>
+            ) : null}
+            <Textarea
+              ref={textareaRef}
+              value={input}
+              onChange={onInputChange}
+              onClick={(event) => setCaret(event.currentTarget.selectionStart)}
+              onKeyUp={(event) => setCaret(event.currentTarget.selectionStart)}
+              onKeyDown={onKeyDown}
+              onPaste={onPaste}
+              placeholder={placeholderForMode(mode)}
+              rows={1}
+              className="field-sizing-fixed min-h-0 min-w-0 resize-none rounded-none border-0 bg-transparent p-0 font-mono text-[13px] leading-5 shadow-none ring-0 placeholder:font-mono placeholder:text-(--accent-muted) focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent md:text-[13px]"
+              style={{ minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
+            />
+          </div>
           {variant === "compact" ? (
             <div className="mt-3 flex flex-col gap-2">
               <div className="flex min-w-0 items-center gap-1.5">
@@ -440,6 +734,10 @@ function placeholderForMode(mode: ChatMode): string {
     case "agent":
       return "Ask Anton to change the code";
   }
+}
+
+function hasDraggedFiles(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types).includes("Files");
 }
 
 function McpSelector({

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { ChatAddToolApproveResponseFunction } from "ai";
+import type { ChatAddToolApproveResponseFunction, FileUIPart } from "ai";
 import {
   Check,
   Copy,
@@ -21,6 +21,8 @@ import {
   messageIsUnverifiedEdit,
   messageIsVerificationFailed,
   type AntonUIMessage,
+  type AntonWorkspaceReference,
+  type AntonWorkspaceReferencePartData,
 } from "@/src/lib/trace";
 import type { ChatMode } from "@/src/lib/chat-modes";
 import { cn } from "@/lib/utils";
@@ -36,6 +38,10 @@ import { ResponseMetricsHoverCard } from "./metrics-hover-card";
 import { RunTraceAccordion } from "@/components/features/run-trace/run-trace";
 import { isFailedToolOutput } from "@/components/features/run-trace/tool-display";
 import { getTodoTraceDisplay } from "@/components/features/run-trace/trace-data";
+import {
+  AttachmentTray,
+  WorkspaceReferenceTray,
+} from "./composer-parts";
 
 interface MessageListProps {
   messages: AntonUIMessage[];
@@ -234,14 +240,7 @@ function MessageEvent({
       >
         {isUser ? (
           <div className="rounded-[10px] border border-border bg-secondary px-3.5 py-[9px] text-[13px]">
-            {message.parts.map((part, i) => {
-              if (part.type !== "text") return null;
-              return (
-                <div key={i} className="whitespace-pre-wrap leading-normal">
-                  {part.text}
-                </div>
-              );
-            })}
+            <UserMessageContent message={message} />
           </div>
         ) : (
           <div>
@@ -301,6 +300,66 @@ function MessageEvent({
       )}
     </div>
   );
+}
+
+function UserMessageContent({ message }: { message: AntonUIMessage }) {
+  const textParts = message.parts.filter((part) => part.type === "text");
+  const references = message.parts.flatMap((part) =>
+    isWorkspaceReferencePart(part) ? part.data.references : [],
+  );
+  const files = message.parts.filter(isMessageFilePart);
+
+  return (
+    <div className="grid min-w-0 gap-2">
+      {textParts.map((part, index) => (
+        <div key={index} className="whitespace-pre-wrap leading-normal">
+          {part.text}
+        </div>
+      ))}
+      <WorkspaceReferenceTray
+        references={references}
+        className={textParts.length > 0 ? "pt-0.5" : undefined}
+      />
+      <AttachmentTray files={files} />
+    </div>
+  );
+}
+
+function isMessageFilePart(
+  part: AntonUIMessage["parts"][number],
+): part is FileUIPart {
+  return part.type === "file";
+}
+
+function isWorkspaceReferencePart(
+  part: AntonUIMessage["parts"][number],
+): part is Extract<AntonUIMessage["parts"][number], { type: "data-workspace-reference" }> {
+  return (
+    part.type === "data-workspace-reference" &&
+    isWorkspaceReferenceData(part.data)
+  );
+}
+
+function isWorkspaceReferenceData(
+  data: unknown,
+): data is AntonWorkspaceReferencePartData {
+  if (!isRecord(data)) return false;
+  if (typeof data.projectId !== "string") return false;
+  if (!Array.isArray(data.references)) return false;
+  return data.references.every(isWorkspaceReference);
+}
+
+function isWorkspaceReference(value: unknown): value is AntonWorkspaceReference {
+  if (!isRecord(value)) return false;
+  return (
+    (value.kind === "file" || value.kind === "directory") &&
+    typeof value.path === "string" &&
+    typeof value.label === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function PlanMessageCard({

--- a/src/agent/skills.ts
+++ b/src/agent/skills.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { resolveInWorkspace, SandboxError, workspaceRelative } from "./sandbox";
+import {
+  resolveInWorkspace,
+  SandboxError,
+  workspaceRelative,
+  workspaceRelativeTo,
+} from "./sandbox";
 
 const SKILLS_DIR = "skills";
 const SKILL_FILE = "SKILL.md";
@@ -21,6 +27,28 @@ export type SkillDocument = SkillSummary & {
 
 export type SkillList = {
   skills: SkillSummary[];
+  warnings: string[];
+};
+
+export type ComposerSkillSource = "local" | "global";
+
+export type ComposerSkillSummary = {
+  source: ComposerSkillSource;
+  slug: string;
+  name: string;
+  description: string;
+  command: string;
+  path: string;
+  updatedAt: string;
+};
+
+export type ComposerSkillDocument = SkillDocument & {
+  source: ComposerSkillSource;
+  command: string;
+};
+
+export type ComposerSkillList = {
+  skills: ComposerSkillSummary[];
   warnings: string[];
 };
 
@@ -61,6 +89,73 @@ export function listSkills(workspaceRoot?: string): SkillList {
   return { skills, warnings };
 }
 
+export function listComposerSkills(workspaceRoot?: string): ComposerSkillList {
+  const warnings: string[] = [];
+  const byCommand = new Map<string, ComposerSkillSummary>();
+
+  if (workspaceRoot) {
+    try {
+      const local = listSkills(workspaceRoot);
+      warnings.push(...local.warnings);
+      for (const skill of local.skills) {
+        const command = commandForSkillSlug(skill.slug);
+        byCommand.set(command, {
+          source: "local",
+          slug: skill.slug,
+          name: skill.name,
+          description: skill.description,
+          command,
+          path: skill.path,
+          updatedAt: skill.updatedAt,
+        });
+      }
+    } catch (err) {
+      warnings.push(errorMessage(err));
+    }
+  }
+
+  for (const root of globalSkillRoots()) {
+    const global = listGlobalSkills(root);
+    warnings.push(...global.warnings);
+    for (const skill of global.skills) {
+      if (byCommand.has(skill.command)) continue;
+      byCommand.set(skill.command, skill);
+    }
+  }
+
+  return {
+    skills: [...byCommand.values()].sort((left, right) => {
+      if (left.source !== right.source) {
+        return left.source === "local" ? -1 : 1;
+      }
+      return left.command.localeCompare(right.command);
+    }),
+    warnings,
+  };
+}
+
+export function readComposerSkill(
+  command: string,
+  workspaceRoot?: string,
+): ComposerSkillDocument {
+  const slug = normalizeCommandSlug(command);
+  if (workspaceRoot) {
+    try {
+      const local = readSkill(slug, workspaceRoot);
+      return { ...local, source: "local", command: commandForSkillSlug(local.slug) };
+    } catch {
+      // Fall through to installed global skills.
+    }
+  }
+
+  for (const root of globalSkillRoots()) {
+    const skill = readGlobalSkill(root, slug);
+    if (skill) return skill;
+  }
+
+  throw new SkillError(`composer skill not found: ${command}`);
+}
+
 export function readSkill(slug: string, workspaceRoot?: string): SkillDocument {
   validateSkillSlug(slug);
   const relPath = path.posix.join(SKILLS_DIR, slug, SKILL_FILE);
@@ -77,10 +172,118 @@ export function readSkill(slug: string, workspaceRoot?: string): SkillDocument {
 
   return parseSkill({
     slug,
-    path: workspaceRelative(abs).split(path.sep).join("/"),
+    path: skillDisplayPath(abs, workspaceRoot),
     raw: fs.readFileSync(abs, "utf8"),
     updatedAt: stat.mtime.toISOString(),
   });
+}
+
+function listGlobalSkills(root: GlobalSkillRoot): ComposerSkillList {
+  if (!fs.existsSync(root.path)) return { skills: [], warnings: [] };
+  let entries: fs.Dirent[];
+  try {
+    entries = fs
+      .readdirSync(root.path, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (err) {
+    return { skills: [], warnings: [errorMessage(err)] };
+  }
+
+  const skills: ComposerSkillSummary[] = [];
+  const warnings: string[] = [];
+  for (const entry of entries) {
+    if (!isValidSkillSlug(entry.name)) {
+      warnings.push(`skipping invalid installed skill slug: ${entry.name}`);
+      continue;
+    }
+
+    const skillPath = path.join(root.path, entry.name, SKILL_FILE);
+    try {
+      const stat = fs.statSync(skillPath);
+      if (!stat.isFile()) continue;
+      if (stat.size > MAX_SKILL_BYTES) {
+        warnings.push(
+          `installed skill too large: ${root.label}/${entry.name}/${SKILL_FILE}`,
+        );
+        continue;
+      }
+      const skill = parseSkill({
+        slug: entry.name,
+        path: `${root.label}/${entry.name}/${SKILL_FILE}`,
+        raw: fs.readFileSync(skillPath, "utf8"),
+        updatedAt: stat.mtime.toISOString(),
+      });
+      skills.push({
+        source: "global",
+        slug: skill.slug,
+        name: skill.name,
+        description: skill.description,
+        command: commandForSkillSlug(skill.slug),
+        path: skill.path,
+        updatedAt: skill.updatedAt,
+      });
+    } catch (err) {
+      warnings.push(errorMessage(err));
+    }
+  }
+
+  return { skills, warnings };
+}
+
+function readGlobalSkill(
+  root: GlobalSkillRoot,
+  slug: string,
+): ComposerSkillDocument | undefined {
+  if (!isValidSkillSlug(slug)) return undefined;
+  const skillPath = path.join(root.path, slug, SKILL_FILE);
+  if (!fs.existsSync(skillPath)) return undefined;
+  const stat = fs.statSync(skillPath);
+  if (!stat.isFile()) return undefined;
+  if (stat.size > MAX_SKILL_BYTES) {
+    throw new SkillError(
+      `installed skill too large (${stat.size} bytes, cap ${MAX_SKILL_BYTES})`,
+    );
+  }
+  const skill = parseSkill({
+    slug,
+    path: `${root.label}/${slug}/${SKILL_FILE}`,
+    raw: fs.readFileSync(skillPath, "utf8"),
+    updatedAt: stat.mtime.toISOString(),
+  });
+  return {
+    ...skill,
+    source: "global",
+    command: commandForSkillSlug(skill.slug),
+  };
+}
+
+type GlobalSkillRoot = {
+  path: string;
+  label: string;
+};
+
+function globalSkillRoots(): GlobalSkillRoot[] {
+  const home = os.homedir();
+  return [
+    {
+      path: path.join(home, ".agents", "skills"),
+      label: "~/.agents/skills",
+    },
+    {
+      path: path.join(home, ".codex", "skills", ".system"),
+      label: "~/.codex/skills/.system",
+    },
+  ];
+}
+
+function commandForSkillSlug(slug: string): string {
+  return `/${slug}`;
+}
+
+function normalizeCommandSlug(command: string): string {
+  const trimmed = command.trim();
+  return trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
 }
 
 function parseSkill({
@@ -164,6 +367,13 @@ function validateSkillSlug(slug: string): void {
       "skill slug must contain only lowercase letters, numbers, underscores, and hyphens",
     );
   }
+}
+
+function skillDisplayPath(absPath: string, workspaceRoot?: string): string {
+  const relativePath = workspaceRoot
+    ? workspaceRelativeTo(workspaceRoot, absPath)
+    : workspaceRelative(absPath);
+  return relativePath.split(path.sep).join("/");
 }
 
 function isValidSkillSlug(slug: string): boolean {

--- a/src/lib/anton-message-validation.ts
+++ b/src/lib/anton-message-validation.ts
@@ -97,6 +97,31 @@ const antonUIPartSchema = z
       return;
     }
 
+    if (type === "file") {
+      if (typeof part.mediaType !== "string" || part.mediaType.length === 0) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["mediaType"],
+          message: "file part requires string mediaType",
+        });
+      }
+      if (typeof part.url !== "string" || part.url.length === 0) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["url"],
+          message: "file part requires string url",
+        });
+      }
+      if (part.filename !== undefined && typeof part.filename !== "string") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["filename"],
+          message: "file part filename must be a string when present",
+        });
+      }
+      return;
+    }
+
     if (KNOWN_STRUCTURAL_PARTS.has(type)) return;
 
     ctx.addIssue({

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -331,6 +331,7 @@ export type ProjectBranchesSummary = {
 export type ProjectFileTreeSummary = {
   projectId: string;
   paths: string[];
+  directories: string[];
   gitStatus: ProjectFileGitStatusEntry[];
   totalCount: number;
   truncated: boolean;
@@ -531,6 +532,16 @@ export type SkillSummary = {
 
 export type SkillDocument = SkillSummary & {
   body: string;
+};
+
+export type ComposerSkillSummary = {
+  source: "local" | "global";
+  slug: string;
+  name: string;
+  description: string;
+  command: string;
+  path: string;
+  updatedAt: string;
 };
 
 export type McpTransport = "stdio" | "http" | "sse";

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -146,10 +146,22 @@ export type AntonTodoSnapshot = {
   updatedAt: number;
 };
 
+export type AntonWorkspaceReference = {
+  kind: "file" | "directory";
+  path: string;
+  label: string;
+};
+
+export type AntonWorkspaceReferencePartData = {
+  projectId: string;
+  references: AntonWorkspaceReference[];
+};
+
 export type AntonDataParts = {
   run: AntonRunData;
   activity: AntonActivityEvent;
   todos: AntonTodoSnapshot;
+  "workspace-reference": AntonWorkspaceReferencePartData;
 };
 
 export type AntonUIMessage = UIMessage<


### PR DESCRIPTION
﻿## Summary
- Adds composer slash-skill suggestions and active-project/global composer skill listing.
- Adds workspace `@` reference suggestions, removable path pills, and model-only path reference conversion.
- Adds attachment validation/previews/lightbox for AI SDK file parts and renders sent refs/uploads after reload.
- Marks the focused Phase 6 roadmap item complete for #183.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passes; existing Turbopack NFT warning remains through `next.config.ts` -> `src/workspace/project-inspect.ts` -> `app/api/projects/[id]/status/route.ts`)
- `git diff --check` and `git diff --cached --check` (only Windows LF/CRLF warnings in unstaged check)

## Browser Verification
- Checked slash popup, ArrowDown/Enter insertion, and Escape behavior.
- Checked `@` popup, ArrowDown/Enter pill insertion, pill removal, and project switch clearing refs.
- Checked paste image preview, remove preview, composer image lightbox, sent-message image lightbox, and reload persistence for text + workspace ref + image.
- Checked responsive overflow at 320px, 768px, 1024px, and 1440px with a reference pill and image preview present.
- Checked browser console warnings/errors: none observed.

## Notes
- The in-app browser does not expose an OS file chooser or DataTransfer APIs, so direct `+` file picker and physical drag/drop file selection were not fully automatable there. The code path is wired through the hidden multi-file input and shared attachment validation/preview logic; paste-image and preview/removal/lightbox flows were verified in-browser.
