### PR TITLE
Refresh OpenCode Go model catalog

### DIFF
--- a/app/api/opencode-go/catalog/route.ts
+++ b/app/api/opencode-go/catalog/route.ts
@@ -1,0 +1,9 @@
+import { getOpenCodeGoCatalog } from "@/src/lib/opencode-go-catalog";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json({
+    catalog: await getOpenCodeGoCatalog(),
+  });
+}

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -12,7 +12,10 @@ import {
   type ModelId,
   type ProviderId,
 } from "@/src/lib/models";
-import type { OpenRouterCatalogSummary } from "@/src/lib/api-types";
+import type {
+  OpenCodeGoCatalogSummary,
+  OpenRouterCatalogSummary,
+} from "@/src/lib/api-types";
 import { getJson } from "@/src/lib/client-fetch";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,6 +39,12 @@ type PickerModel = {
   contextLength?: number | null;
   promptPrice?: string | null;
   completionPrice?: string | null;
+};
+
+type ProviderCatalog = OpenCodeGoCatalogSummary | OpenRouterCatalogSummary;
+type CatalogByProvider = {
+  "opencode-go": OpenCodeGoCatalogSummary | null;
+  openrouter: OpenRouterCatalogSummary | null;
 };
 
 type ModelFilter =
@@ -108,82 +117,81 @@ export function ModelPicker({
   );
   const [query, setQuery] = useState("");
   const [modelFilter, setModelFilter] = useState<ModelFilter>("recommended");
-  const [catalog, setCatalog] = useState<OpenRouterCatalogSummary | null>(null);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [catalogLoading, setCatalogLoading] = useState(false);
+  const [catalogs, setCatalogs] = useState<CatalogByProvider>({
+    "opencode-go": null,
+    openrouter: null,
+  });
+  const [catalogErrors, setCatalogErrors] = useState<Record<ProviderId, string | null>>({
+    "opencode-go": null,
+    openrouter: null,
+  });
+  const [catalogLoading, setCatalogLoading] = useState<ProviderId | null>(null);
 
-  const loadCatalog = useCallback(async ({ refresh = false } = {}) => {
-    if (!refresh && (catalog || catalogError)) return;
-    setCatalogLoading(true);
-    try {
-      const data = await getJson<{ catalog: OpenRouterCatalogSummary }>(
-        "/api/openrouter/catalog",
-      );
-      setCatalog(data.catalog);
-      setCatalogError(null);
-    } catch (err) {
-      setCatalogError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setCatalogLoading(false);
-    }
-  }, [catalog, catalogError]);
+  const loadCatalog = useCallback(
+    async (provider: ProviderId, { refresh = false } = {}) => {
+      if (!refresh && (catalogs[provider] || catalogErrors[provider])) return;
+      setCatalogLoading(provider);
+      try {
+        if (provider === "openrouter") {
+          const data = await getJson<{ catalog: OpenRouterCatalogSummary }>(
+            "/api/openrouter/catalog",
+          );
+          setCatalogs((current) => ({ ...current, openrouter: data.catalog }));
+        } else {
+          const data = await getJson<{ catalog: OpenCodeGoCatalogSummary }>(
+            "/api/opencode-go/catalog",
+          );
+          setCatalogs((current) => ({
+            ...current,
+            "opencode-go": data.catalog,
+          }));
+        }
+        setCatalogErrors((current) => ({ ...current, [provider]: null }));
+      } catch (err) {
+        setCatalogErrors((current) => ({
+          ...current,
+          [provider]: err instanceof Error ? err.message : String(err),
+        }));
+      } finally {
+        setCatalogLoading((current) => (current === provider ? null : current));
+      }
+    },
+    [catalogErrors, catalogs],
+  );
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
       const nextProvider = getProviderId(value);
       setActiveProvider(nextProvider);
-      if (nextProvider === "openrouter") void loadCatalog();
+      void loadCatalog(nextProvider);
     }
     setOpen(nextOpen);
   };
 
-  const openRouterModels = useMemo(() => {
-    const apiModels: PickerModel[] =
-      catalog?.models.map((model) => ({
-        id: `openrouter/${model.id}`,
-        label: model.name,
-        providerSlug: model.id.split("/")[0],
-        contextLength: model.contextLength,
-        promptPrice: model.promptPrice,
-        completionPrice: model.completionPrice,
-      })) ??
-      getModelsForProvider("openrouter").map((model) => ({
-        id: model.id,
-        label: model.label,
-        providerSlug: model.providerModelId.split("/")[0],
-        contextLength: null,
-        promptPrice: null,
-        completionPrice: null,
-      }));
-    const selectedProviderModelId =
-      getProviderId(value) === "openrouter" ? getProviderModelId(value) : null;
-    const withSelected =
-      selectedProviderModelId &&
-      !apiModels.some((model) => model.id === value)
-        ? [
-            {
-              id: value,
-              label: getModelLabel(value),
-              providerSlug: selectedProviderModelId.split("/")[0],
-            },
-            ...apiModels,
-          ]
-        : apiModels;
-    const needle = query.trim().toLowerCase();
-    const filtered = withSelected.filter(
-      (model) =>
-        matchesQuery(model.label, model.id, needle) &&
-        matchesModelFilter(model, modelFilter),
-    );
-    return sortModelResults(filtered, modelFilter).slice(0, 80);
-  }, [catalog, modelFilter, query, value]);
+  const modelsByProvider = useMemo(
+    () => ({
+      "opencode-go": buildCatalogModels({
+        catalog: catalogs["opencode-go"],
+        providerId: "opencode-go",
+        selectedValue: value,
+      }),
+      openrouter: buildCatalogModels({
+        catalog: catalogs.openrouter,
+        providerId: "openrouter",
+        selectedValue: value,
+      }),
+    }),
+    [catalogs, value],
+  );
 
+  const selectedProvider = getProviderId(value);
+  const selectedProviderModelId = getProviderModelId(value);
   const triggerLabel =
-    catalog?.models.find(
-      (model) =>
-        getProviderId(value) === "openrouter" &&
-        model.id === getProviderModelId(value),
+    catalogs[selectedProvider]?.models.find(
+      (model) => model.id === selectedProviderModelId,
     )?.name ?? getModelLabel(value);
+  const activeProviderLabel = providerLabel(activeProvider);
+  const activeCatalogLoading = catalogLoading === activeProvider;
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -209,8 +217,9 @@ export function ModelPicker({
         <Tabs
           value={activeProvider}
           onValueChange={(next) => {
-            setActiveProvider(next as ProviderId);
-            if (next === "openrouter") void loadCatalog();
+            const nextProvider = next as ProviderId;
+            setActiveProvider(nextProvider);
+            void loadCatalog(nextProvider);
           }}
           className="min-w-0 gap-0"
         >
@@ -237,39 +246,42 @@ export function ModelPicker({
                 className="min-w-0 flex-1 bg-transparent text-[12.5px] outline-none placeholder:text-muted-foreground/70"
                 aria-label="Search models"
               />
-              {activeProvider === "openrouter" ? (
-                <button
-                  type="button"
-                  onClick={() => void loadCatalog({ refresh: true })}
-                  disabled={catalogLoading}
-                  className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-                  aria-label="Refresh OpenRouter models"
-                  title="Refresh OpenRouter models"
-                >
-                  {catalogLoading ? (
-                    <Loader2 className="size-3 animate-spin" />
-                  ) : (
-                    <RefreshCw className="size-3" />
-                  )}
-                </button>
-              ) : null}
+              <button
+                type="button"
+                onClick={() => void loadCatalog(activeProvider, { refresh: true })}
+                disabled={activeCatalogLoading}
+                className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+                aria-label={`Refresh ${activeProviderLabel} models`}
+                title={`Refresh ${activeProviderLabel} models`}
+              >
+                {activeCatalogLoading ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-3" />
+                )}
+              </button>
             </div>
-            {activeProvider === "openrouter" && catalogError ? (
+            {catalogErrors[activeProvider] ? (
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Static fallback models shown.
               </p>
             ) : null}
           </div>
           {PROVIDERS.map((provider) => {
+            const providerModels = modelsByProvider[provider.id];
             const visibleModels: PickerModel[] =
               provider.id === "openrouter"
-                ? openRouterModels
-                : getModelsForProvider(provider.id).filter((model) =>
+                ? sortModelResults(
+                    providerModels.filter(
+                      (model) =>
+                        matchesQuery(model.label, model.id, query) &&
+                        matchesModelFilter(model, modelFilter),
+                    ),
+                    modelFilter,
+                  ).slice(0, 80)
+                : providerModels.filter((model) =>
                     matchesQuery(model.label, model.id, query),
-                  ).map((model) => ({
-                    id: model.id,
-                    label: model.label,
-                  }));
+                  );
             return (
               <TabsContent key={provider.id} value={provider.id} className="m-0">
                 <div className="max-h-96 overflow-y-auto p-1.5 pt-0">
@@ -289,7 +301,7 @@ export function ModelPicker({
                   />
                   {visibleModels.length === 0 ? (
                     <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
-                      {provider.id === "openrouter" && catalogLoading
+                      {catalogLoading === provider.id
                         ? "Loading models..."
                         : "No models found."}
                     </div>
@@ -352,6 +364,64 @@ export function ModelPicker({
         ) : null}
       </PopoverContent>
     </Popover>
+  );
+}
+
+function buildCatalogModels({
+  catalog,
+  providerId,
+  selectedValue,
+}: {
+  catalog: ProviderCatalog | null;
+  providerId: ProviderId;
+  selectedValue: ModelId;
+}): PickerModel[] {
+  const apiModels: PickerModel[] =
+    catalog?.models.map((model) => ({
+      id: `${providerId}/${model.id}`,
+      label: model.name,
+      providerSlug: providerId === "openrouter" ? model.id.split("/")[0] : undefined,
+      contextLength: model.contextLength,
+      promptPrice: model.promptPrice,
+      completionPrice: model.completionPrice,
+    })) ??
+    getModelsForProvider(providerId).map((model) => ({
+      id: model.id,
+      label: model.label,
+      providerSlug:
+        providerId === "openrouter" ? model.providerModelId.split("/")[0] : undefined,
+      contextLength: null,
+      promptPrice: null,
+      completionPrice: null,
+    }));
+
+  const selectedProviderModelId =
+    getProviderId(selectedValue) === providerId
+      ? getProviderModelId(selectedValue)
+      : null;
+  if (
+    !selectedProviderModelId ||
+    apiModels.some((model) => model.id === selectedValue)
+  ) {
+    return apiModels;
+  }
+
+  return [
+    {
+      id: selectedValue,
+      label: getModelLabel(selectedValue),
+      providerSlug:
+        providerId === "openrouter"
+          ? selectedProviderModelId.split("/")[0]
+          : undefined,
+    },
+    ...apiModels,
+  ];
+}
+
+function providerLabel(providerId: ProviderId): string {
+  return (
+    PROVIDERS.find((provider) => provider.id === providerId)?.label ?? providerId
   );
 }
 

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -394,6 +394,10 @@ function buildCatalogModels({
       promptPrice: null,
       completionPrice: null,
     }));
+  const orderedModels =
+    providerId === "opencode-go"
+      ? sortOpenCodeGoModels(apiModels)
+      : apiModels;
 
   const selectedProviderModelId =
     getProviderId(selectedValue) === providerId
@@ -401,9 +405,9 @@ function buildCatalogModels({
       : null;
   if (
     !selectedProviderModelId ||
-    apiModels.some((model) => model.id === selectedValue)
+    orderedModels.some((model) => model.id === selectedValue)
   ) {
-    return apiModels;
+    return orderedModels;
   }
 
   return [
@@ -415,7 +419,7 @@ function buildCatalogModels({
           ? selectedProviderModelId.split("/")[0]
           : undefined,
     },
-    ...apiModels,
+    ...orderedModels,
   ];
 }
 
@@ -423,6 +427,21 @@ function providerLabel(providerId: ProviderId): string {
   return (
     PROVIDERS.find((provider) => provider.id === providerId)?.label ?? providerId
   );
+}
+
+function sortOpenCodeGoModels(models: PickerModel[]): PickerModel[] {
+  const rankById = new Map(
+    getModelsForProvider("opencode-go").map((model, index) => [model.id, index]),
+  );
+  return models
+    .map((model, index) => ({ model, index }))
+    .sort(
+      (left, right) =>
+        (rankById.get(left.model.id) ?? Number.MAX_SAFE_INTEGER) -
+          (rankById.get(right.model.id) ?? Number.MAX_SAFE_INTEGER) ||
+        left.index - right.index,
+    )
+    .map((entry) => entry.model);
 }
 
 function isFreeModel(model: PickerModel): boolean {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -45,6 +45,23 @@ export type OpenRouterCatalogSummary = {
   error: string | null;
 };
 
+export type OpenCodeGoModelSummary = {
+  id: string;
+  name: string;
+  created: number | null;
+  ownedBy: string | null;
+  contextLength: number | null;
+  promptPrice: string | null;
+  completionPrice: string | null;
+};
+
+export type OpenCodeGoCatalogSummary = {
+  models: OpenCodeGoModelSummary[];
+  source: "api" | "fallback";
+  fetchedAt: number;
+  error: string | null;
+};
+
 export type OpenRouterModelEndpointSummary = {
   tag: string;
   providerName: string;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -11,16 +11,24 @@ export const DEFAULT_MODEL_ID = "opencode-go/deepseek-v4-flash";
 export const OPENCODE_GO_MODELS = [
   { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
   { slug: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { slug: "glm-5.2", label: "GLM 5.2" },
   { slug: "glm-5.1", label: "GLM 5.1" },
   { slug: "glm-5", label: "GLM 5" },
+  { slug: "kimi-k2.7-code", label: "Kimi K2.7 Code" },
   { slug: "kimi-k2.6", label: "Kimi K2.6" },
   { slug: "kimi-k2.5", label: "Kimi K2.5" },
+  { slug: "qwen3.7-max", label: "Qwen3.7 Max" },
+  { slug: "qwen3.7-plus", label: "Qwen3.7 Plus" },
   { slug: "qwen3.6-plus", label: "Qwen3.6 Plus" },
   { slug: "qwen3.5-plus", label: "Qwen3.5 Plus" },
+  { slug: "minimax-m3", label: "MiniMax M3" },
   { slug: "minimax-m2.7", label: "MiniMax M2.7" },
   { slug: "minimax-m2.5", label: "MiniMax M2.5" },
+  { slug: "mimo-v2-pro", label: "MiMo V2 Pro" },
+  { slug: "mimo-v2-omni", label: "MiMo V2 Omni" },
   { slug: "mimo-v2.5-pro", label: "MiMo V2.5 Pro" },
   { slug: "mimo-v2.5", label: "MiMo V2.5" },
+  { slug: "hy3-preview", label: "HY3 Preview" },
 ] as const;
 
 export const FALLBACK_OPENROUTER_MODELS = [
@@ -61,6 +69,13 @@ function normalizeModelId(modelId: string): ModelId | null {
     return opencodeId;
   }
 
+  if (modelId.startsWith("opencode-go/")) {
+    const providerModelId = modelId.slice("opencode-go/".length);
+    if (isOpenCodeGoModelSlug(providerModelId)) {
+      return modelId;
+    }
+  }
+
   if (modelId.startsWith("openrouter/")) {
     const providerModelId = modelId.slice("openrouter/".length);
     if (isOpenRouterModelSlug(providerModelId)) {
@@ -94,6 +109,7 @@ export function getProviderId(modelId: string): ProviderId {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
   if (entry) return entry.provider;
+  if (resolved.startsWith("opencode-go/")) return "opencode-go";
   if (resolved.startsWith("openrouter/")) return "openrouter";
   return DEFAULT_PROVIDER_ID;
 }
@@ -102,6 +118,9 @@ export function getProviderModelId(modelId: string): string {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
   if (entry) return entry.providerModelId;
+  if (resolved.startsWith("opencode-go/")) {
+    return resolved.slice("opencode-go/".length);
+  }
   if (resolved.startsWith("openrouter/")) {
     return resolved.slice("openrouter/".length);
   }
@@ -114,9 +133,12 @@ export function getModelsForProvider(provider: ProviderId): ModelCatalogEntry[] 
 
 export function getModelLabel(modelId: string): string {
   const resolved = resolveModelId(modelId);
-  return (
-    MODEL_CATALOG.find((model) => model.id === resolved)?.label ?? resolved
-  );
+  const catalogLabel = MODEL_CATALOG.find((model) => model.id === resolved)?.label;
+  if (catalogLabel) return catalogLabel;
+  if (resolved.startsWith("opencode-go/")) {
+    return labelFromSlug(resolved.slice("opencode-go/".length));
+  }
+  return resolved;
 }
 
 export function getDefaultModelForProvider(provider: ProviderId): ModelId {
@@ -143,4 +165,31 @@ function isOpenRouterModelSlug(value: string): boolean {
     !value.includes("..") &&
     !/\s/.test(value)
   );
+}
+
+export function isOpenCodeGoModelSlug(value: string): boolean {
+  return /^[a-z0-9][a-z0-9.-]*$/.test(value) && !value.includes("..");
+}
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (lower === "glm") return "GLM";
+      if (lower === "hy3") return "HY3";
+      if (lower === "mimo") return "MiMo";
+      if (lower === "minimax") return "MiniMax";
+      if (lower === "qwen3.7") return "Qwen3.7";
+      if (lower === "qwen3.6") return "Qwen3.6";
+      if (lower === "qwen3.5") return "Qwen3.5";
+      if (lower === "k2.7") return "K2.7";
+      if (lower === "k2.6") return "K2.6";
+      if (lower === "k2.5") return "K2.5";
+      if (lower === "v2.5") return "V2.5";
+      if (lower === "v2") return "V2";
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
 }

--- a/src/lib/opencode-go-catalog.ts
+++ b/src/lib/opencode-go-catalog.ts
@@ -1,0 +1,150 @@
+import type {
+  OpenCodeGoCatalogSummary,
+  OpenCodeGoModelSummary,
+} from "@/src/lib/api-types";
+import {
+  OPENCODE_GO_MODELS,
+  isOpenCodeGoModelSlug,
+  isStaticOpenCodeGoModelId,
+} from "@/src/lib/models";
+
+const OPENCODE_GO_API_BASE = "https://opencode.ai/zen/go";
+const CATALOG_TTL_MS = 10 * 60 * 1000;
+
+let catalogCache:
+  | {
+      expiresAt: number;
+      value: OpenCodeGoCatalogSummary;
+    }
+  | undefined;
+
+export async function getOpenCodeGoCatalog(): Promise<OpenCodeGoCatalogSummary> {
+  const now = Date.now();
+  if (catalogCache && catalogCache.expiresAt > now) return catalogCache.value;
+
+  try {
+    const models = await fetchOpenCodeGoJson("/v1/models");
+    const parsedModels = parseModels(models);
+    if (parsedModels.length === 0) {
+      throw new Error("OpenCode Go catalog response contained no models");
+    }
+    const value: OpenCodeGoCatalogSummary = {
+      models: parsedModels,
+      source: "api",
+      fetchedAt: now,
+      error: null,
+    };
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  } catch (err) {
+    const value = fallbackCatalog(errorMessage(err), now);
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  }
+}
+
+export async function isSupportedOpenCodeGoModelId(
+  modelId: string,
+): Promise<boolean> {
+  if (isStaticOpenCodeGoModelId(modelId)) return true;
+  const providerModelId = openCodeGoProviderModelId(modelId);
+  if (!providerModelId) return false;
+  const catalog = await getOpenCodeGoCatalog();
+  return catalog.models.some((model) => model.id === providerModelId);
+}
+
+function openCodeGoProviderModelId(modelId: string): string | null {
+  const trimmed = modelId.trim();
+  if (trimmed.startsWith("opencode-go/")) {
+    const providerModelId = trimmed.slice("opencode-go/".length);
+    return isOpenCodeGoModelSlug(providerModelId) ? providerModelId : null;
+  }
+  return null;
+}
+
+function fallbackCatalog(
+  error: string | null,
+  fetchedAt: number,
+): OpenCodeGoCatalogSummary {
+  return {
+    models: OPENCODE_GO_MODELS.map((model) => ({
+      id: model.slug,
+      name: model.label,
+      created: null,
+      ownedBy: null,
+      contextLength: null,
+      promptPrice: null,
+      completionPrice: null,
+    })),
+    source: "fallback",
+    fetchedAt,
+    error,
+  };
+}
+
+async function fetchOpenCodeGoJson(path: string): Promise<unknown> {
+  const headers: Record<string, string> = {};
+  if (process.env.OPENCODE_GO_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.OPENCODE_GO_API_KEY}`;
+  }
+  const response = await fetch(`${OPENCODE_GO_API_BASE}${path}`, {
+    headers,
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`OpenCode Go request failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function parseModels(payload: unknown): OpenCodeGoModelSummary[] {
+  return dataArray(payload).flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const id = stringValue(item.id);
+    if (!id || !isOpenCodeGoModelSlug(id)) return [];
+    return [
+      {
+        id,
+        name: labelFromModelId(id),
+        created: numberValue(item.created) ?? null,
+        ownedBy: stringValue(item.owned_by) ?? null,
+        contextLength: null,
+        promptPrice: null,
+        completionPrice: null,
+      },
+    ];
+  });
+}
+
+function labelFromModelId(modelId: string): string {
+  return (
+    OPENCODE_GO_MODELS.find((model) => model.slug === modelId)?.label ??
+    modelId
+      .split("-")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
+function dataArray(payload: unknown): unknown[] {
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  return Array.isArray(payload) ? payload : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/lib/openrouter-catalog.ts
+++ b/src/lib/openrouter-catalog.ts
@@ -7,8 +7,8 @@ import type {
 } from "@/src/lib/api-types";
 import {
   FALLBACK_OPENROUTER_MODELS,
-  isStaticOpenCodeGoModelId,
 } from "@/src/lib/models";
+import { isSupportedOpenCodeGoModelId } from "@/src/lib/opencode-go-catalog";
 
 const OPENROUTER_API_BASE = "https://openrouter.ai";
 const CATALOG_TTL_MS = 10 * 60 * 1000;
@@ -98,7 +98,8 @@ export async function getOpenRouterModelEndpoints(
 }
 
 export async function isSupportedAgentModelId(modelId: string): Promise<boolean> {
-  if (isStaticOpenCodeGoModelId(modelId)) return true;
+  if (await isSupportedOpenCodeGoModelId(modelId)) return true;
+  if (modelId.startsWith("opencode-go/")) return false;
   const providerModelId = modelId.startsWith("openrouter/")
     ? modelId.slice("openrouter/".length)
     : modelId.includes("/")

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -43,8 +43,11 @@ export const openrouter = createOpenRouter({
 });
 
 const ANTHROPIC_ENDPOINT_MODELS = new Set([
+  "minimax-m3",
   "minimax-m2.7",
   "minimax-m2.5",
+  "qwen3.7-max",
+  "qwen3.7-plus",
   "qwen3.6-plus",
   "qwen3.5-plus",
 ]);


### PR DESCRIPTION
## Summary
- Add an OpenCode Go catalog helper and `/api/opencode-go/catalog` route backed by `https://opencode.ai/zen/go/v1/models`.
- Update the model picker so OpenCode Go gets the same search-bar refresh affordance as OpenRouter, with per-provider loading/error/catalog state and static fallback models.
- Accept refreshed `opencode-go/<model-id>` selections in server validation and route newly listed Anthropic-endpoint Go models through the messages provider.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `git diff --cached --check`
- Focused catalog probe: OpenCode Go API catalog returned 20 models, included `qwen3.7-max` and `hy3-preview`, accepted `opencode-go/qwen3.7-max`, rejected `opencode-go/not-a-real-model`.
- Local route probe: `http://localhost:3000/api/opencode-go/catalog` returned API source with 20 models including `qwen3.7-max` and `hy3-preview`.

## Visual verification
- In-app browser at `http://localhost:3000`, default 1280x720 viewport: opened the composer model picker, verified the OpenCode Go tab shows `Refresh OpenCode Go models`, clicked refresh, searched `hy3`, and confirmed `HY3 Preview / hy3-preview` appears with no console errors or warnings.
- Screenshot capture timed out in the browser tool, so no screenshot is attached.

Closes #186
