### PR TITLE
[codex] Add OpenCode Go model refresh

### DIFF
--- a/app/api/opencode-go/catalog/route.ts
+++ b/app/api/opencode-go/catalog/route.ts
@@ -1,10 +1,10 @@
-import { getOpenRouterCatalog } from "@/src/lib/openrouter-catalog";
+import { getOpenCodeGoCatalog } from "@/src/lib/opencode-go-catalog";
 
 export const runtime = "nodejs";
 
 export async function GET(req: Request) {
   const refresh = new URL(req.url).searchParams.get("refresh") === "1";
   return Response.json({
-    catalog: await getOpenRouterCatalog({ refresh }),
+    catalog: await getOpenCodeGoCatalog({ refresh }),
   });
 }

--- a/components/features/chat/model-picker.tsx
+++ b/components/features/chat/model-picker.tsx
@@ -12,7 +12,10 @@ import {
   type ModelId,
   type ProviderId,
 } from "@/src/lib/models";
-import type { OpenRouterCatalogSummary } from "@/src/lib/api-types";
+import type {
+  OpenCodeGoCatalogSummary,
+  OpenRouterCatalogSummary,
+} from "@/src/lib/api-types";
 import { getJson } from "@/src/lib/client-fetch";
 import { Button } from "@/components/ui/button";
 import {
@@ -111,13 +114,18 @@ export function ModelPicker({
   const [catalog, setCatalog] = useState<OpenRouterCatalogSummary | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [catalogLoading, setCatalogLoading] = useState(false);
+  const [openCodeGoCatalog, setOpenCodeGoCatalog] =
+    useState<OpenCodeGoCatalogSummary | null>(null);
+  const [openCodeGoCatalogError, setOpenCodeGoCatalogError] =
+    useState<string | null>(null);
+  const [openCodeGoCatalogLoading, setOpenCodeGoCatalogLoading] = useState(false);
 
   const loadCatalog = useCallback(async ({ refresh = false } = {}) => {
     if (!refresh && (catalog || catalogError)) return;
     setCatalogLoading(true);
     try {
       const data = await getJson<{ catalog: OpenRouterCatalogSummary }>(
-        "/api/openrouter/catalog",
+        refresh ? "/api/openrouter/catalog?refresh=1" : "/api/openrouter/catalog",
       );
       setCatalog(data.catalog);
       setCatalogError(null);
@@ -128,14 +136,69 @@ export function ModelPicker({
     }
   }, [catalog, catalogError]);
 
+  const loadOpenCodeGoCatalog = useCallback(async ({ refresh = false } = {}) => {
+    if (!refresh && (openCodeGoCatalog || openCodeGoCatalogError)) return;
+    setOpenCodeGoCatalogLoading(true);
+    try {
+      const data = await getJson<{ catalog: OpenCodeGoCatalogSummary }>(
+        refresh
+          ? "/api/opencode-go/catalog?refresh=1"
+          : "/api/opencode-go/catalog",
+      );
+      setOpenCodeGoCatalog(data.catalog);
+      setOpenCodeGoCatalogError(null);
+    } catch (err) {
+      setOpenCodeGoCatalogError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setOpenCodeGoCatalogLoading(false);
+    }
+  }, [openCodeGoCatalog, openCodeGoCatalogError]);
+
+  const loadProviderCatalog = useCallback(
+    (provider: ProviderId, options?: { refresh?: boolean }) => {
+      if (provider === "openrouter") return loadCatalog(options);
+      if (provider === "opencode-go") return loadOpenCodeGoCatalog(options);
+      return Promise.resolve();
+    },
+    [loadCatalog, loadOpenCodeGoCatalog],
+  );
+
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
       const nextProvider = getProviderId(value);
       setActiveProvider(nextProvider);
-      if (nextProvider === "openrouter") void loadCatalog();
+      void loadProviderCatalog(nextProvider);
     }
     setOpen(nextOpen);
   };
+
+  const openCodeGoModels = useMemo(() => {
+    const apiModels: PickerModel[] =
+      openCodeGoCatalog?.models.map((model) => ({
+        id: `opencode-go/${model.id}`,
+        label: model.name,
+      })) ??
+      getModelsForProvider("opencode-go").map((model) => ({
+        id: model.id,
+        label: model.label,
+      }));
+    const selectedProviderModelId =
+      getProviderId(value) === "opencode-go" ? getProviderModelId(value) : null;
+    const withSelected =
+      selectedProviderModelId &&
+      !apiModels.some((model) => model.id === value)
+        ? [
+            {
+              id: value,
+              label: getModelLabel(value),
+            },
+            ...apiModels,
+          ]
+        : apiModels;
+    return withSelected
+      .filter((model) => matchesQuery(model.label, model.id, query))
+      .slice(0, 80);
+  }, [openCodeGoCatalog, query, value]);
 
   const openRouterModels = useMemo(() => {
     const apiModels: PickerModel[] =
@@ -183,7 +246,29 @@ export function ModelPicker({
       (model) =>
         getProviderId(value) === "openrouter" &&
         model.id === getProviderModelId(value),
-    )?.name ?? getModelLabel(value);
+    )?.name ??
+    openCodeGoCatalog?.models.find(
+      (model) =>
+        getProviderId(value) === "opencode-go" &&
+        model.id === getProviderModelId(value),
+    )?.name ??
+    getModelLabel(value);
+
+  const activeCatalogLoading =
+    activeProvider === "openrouter"
+      ? catalogLoading
+      : activeProvider === "opencode-go"
+        ? openCodeGoCatalogLoading
+        : false;
+  const activeCatalogError =
+    activeProvider === "openrouter"
+      ? catalogError
+      : activeProvider === "opencode-go"
+        ? openCodeGoCatalogError
+        : null;
+  const activeProviderLabel =
+    PROVIDERS.find((provider) => provider.id === activeProvider)?.label ??
+    activeProvider;
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -209,8 +294,9 @@ export function ModelPicker({
         <Tabs
           value={activeProvider}
           onValueChange={(next) => {
-            setActiveProvider(next as ProviderId);
-            if (next === "openrouter") void loadCatalog();
+            const provider = next as ProviderId;
+            setActiveProvider(provider);
+            void loadProviderCatalog(provider);
           }}
           className="min-w-0 gap-0"
         >
@@ -237,16 +323,19 @@ export function ModelPicker({
                 className="min-w-0 flex-1 bg-transparent text-[12.5px] outline-none placeholder:text-muted-foreground/70"
                 aria-label="Search models"
               />
-              {activeProvider === "openrouter" ? (
+              {activeProvider === "openrouter" ||
+              activeProvider === "opencode-go" ? (
                 <button
                   type="button"
-                  onClick={() => void loadCatalog({ refresh: true })}
-                  disabled={catalogLoading}
+                  onClick={() =>
+                    void loadProviderCatalog(activeProvider, { refresh: true })
+                  }
+                  disabled={activeCatalogLoading}
                   className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-                  aria-label="Refresh OpenRouter models"
-                  title="Refresh OpenRouter models"
+                  aria-label={`Refresh ${activeProviderLabel} models`}
+                  title={`Refresh ${activeProviderLabel} models`}
                 >
-                  {catalogLoading ? (
+                  {activeCatalogLoading ? (
                     <Loader2 className="size-3 animate-spin" />
                   ) : (
                     <RefreshCw className="size-3" />
@@ -254,22 +343,21 @@ export function ModelPicker({
                 </button>
               ) : null}
             </div>
-            {activeProvider === "openrouter" && catalogError ? (
+            {activeCatalogError ? (
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Static fallback models shown.
               </p>
             ) : null}
           </div>
           {PROVIDERS.map((provider) => {
+            const providerCatalogLoading =
+              provider.id === "openrouter"
+                ? catalogLoading
+                : openCodeGoCatalogLoading;
             const visibleModels: PickerModel[] =
               provider.id === "openrouter"
                 ? openRouterModels
-                : getModelsForProvider(provider.id).filter((model) =>
-                    matchesQuery(model.label, model.id, query),
-                  ).map((model) => ({
-                    id: model.id,
-                    label: model.label,
-                  }));
+                : openCodeGoModels;
             return (
               <TabsContent key={provider.id} value={provider.id} className="m-0">
                 <div className="max-h-96 overflow-y-auto p-1.5 pt-0">
@@ -289,7 +377,7 @@ export function ModelPicker({
                   />
                   {visibleModels.length === 0 ? (
                     <div className="px-2 py-3 text-center text-[11px] text-muted-foreground">
-                      {provider.id === "openrouter" && catalogLoading
+                      {providerCatalogLoading
                         ? "Loading models..."
                         : "No models found."}
                     </div>

--- a/components/features/settings/agent-settings-panel.tsx
+++ b/components/features/settings/agent-settings-panel.tsx
@@ -131,6 +131,9 @@ export function AgentSettingsPanel() {
     () => new Set(routingForSelectedModel.order),
     [routingForSelectedModel.order],
   );
+  const selectedPermissionMode =
+    PERMISSION_MODE_ITEMS.find((item) => item.value === permissionMode) ??
+    PERMISSION_MODE_ITEMS[1];
 
   useEffect(() => {
     if (!openRouterModelId) return;
@@ -406,7 +409,10 @@ export function AgentSettingsPanel() {
                 className={ROW_SELECT_TRIGGER_CLASS}
                 aria-label="Approval strictness"
               >
-                <SelectValue />
+                <span className="inline-flex min-w-0 items-center gap-1.5 leading-none">
+                  <selectedPermissionMode.Icon className="size-3.5 shrink-0 text-muted-foreground/80" />
+                  <SelectValue>{selectedPermissionMode.label}</SelectValue>
+                </span>
               </SelectTrigger>
               <SelectContent>
                 <SelectViewport>

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -45,6 +45,18 @@ export type OpenRouterCatalogSummary = {
   error: string | null;
 };
 
+export type OpenCodeGoModelSummary = {
+  id: string;
+  name: string;
+};
+
+export type OpenCodeGoCatalogSummary = {
+  models: OpenCodeGoModelSummary[];
+  source: "api" | "fallback";
+  fetchedAt: number;
+  error: string | null;
+};
+
 export type OpenRouterModelEndpointSummary = {
   tag: string;
   providerName: string;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -9,18 +9,26 @@ export const DEFAULT_PROVIDER_ID: ProviderId = "opencode-go";
 export const DEFAULT_MODEL_ID = "opencode-go/deepseek-v4-flash";
 
 export const OPENCODE_GO_MODELS = [
-  { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
-  { slug: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
-  { slug: "glm-5.1", label: "GLM 5.1" },
-  { slug: "glm-5", label: "GLM 5" },
-  { slug: "kimi-k2.6", label: "Kimi K2.6" },
-  { slug: "kimi-k2.5", label: "Kimi K2.5" },
-  { slug: "qwen3.6-plus", label: "Qwen3.6 Plus" },
-  { slug: "qwen3.5-plus", label: "Qwen3.5 Plus" },
+  { slug: "minimax-m3", label: "MiniMax M3" },
   { slug: "minimax-m2.7", label: "MiniMax M2.7" },
   { slug: "minimax-m2.5", label: "MiniMax M2.5" },
+  { slug: "kimi-k2.7-code", label: "Kimi K2.7 Code" },
+  { slug: "kimi-k2.6", label: "Kimi K2.6" },
+  { slug: "kimi-k2.5", label: "Kimi K2.5" },
+  { slug: "glm-5.2", label: "GLM 5.2" },
+  { slug: "glm-5.1", label: "GLM 5.1" },
+  { slug: "glm-5", label: "GLM 5" },
+  { slug: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+  { slug: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { slug: "qwen3.7-max", label: "Qwen3.7 Max" },
+  { slug: "qwen3.7-plus", label: "Qwen3.7 Plus" },
+  { slug: "qwen3.6-plus", label: "Qwen3.6 Plus" },
+  { slug: "qwen3.5-plus", label: "Qwen3.5 Plus" },
+  { slug: "mimo-v2-pro", label: "MiMo V2 Pro" },
+  { slug: "mimo-v2-omni", label: "MiMo V2 Omni" },
   { slug: "mimo-v2.5-pro", label: "MiMo V2.5 Pro" },
   { slug: "mimo-v2.5", label: "MiMo V2.5" },
+  { slug: "hy3-preview", label: "HY3 Preview" },
 ] as const;
 
 export const FALLBACK_OPENROUTER_MODELS = [
@@ -61,6 +69,13 @@ function normalizeModelId(modelId: string): ModelId | null {
     return opencodeId;
   }
 
+  if (modelId.startsWith("opencode-go/")) {
+    const providerModelId = modelId.slice("opencode-go/".length);
+    if (isOpenCodeGoModelSlug(providerModelId)) {
+      return modelId;
+    }
+  }
+
   if (modelId.startsWith("openrouter/")) {
     const providerModelId = modelId.slice("openrouter/".length);
     if (isOpenRouterModelSlug(providerModelId)) {
@@ -94,6 +109,7 @@ export function getProviderId(modelId: string): ProviderId {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
   if (entry) return entry.provider;
+  if (resolved.startsWith("opencode-go/")) return "opencode-go";
   if (resolved.startsWith("openrouter/")) return "openrouter";
   return DEFAULT_PROVIDER_ID;
 }
@@ -102,6 +118,9 @@ export function getProviderModelId(modelId: string): string {
   const resolved = resolveModelId(modelId);
   const entry = MODEL_CATALOG.find((model) => model.id === resolved);
   if (entry) return entry.providerModelId;
+  if (resolved.startsWith("opencode-go/")) {
+    return resolved.slice("opencode-go/".length);
+  }
   if (resolved.startsWith("openrouter/")) {
     return resolved.slice("openrouter/".length);
   }
@@ -115,7 +134,10 @@ export function getModelsForProvider(provider: ProviderId): ModelCatalogEntry[] 
 export function getModelLabel(modelId: string): string {
   const resolved = resolveModelId(modelId);
   return (
-    MODEL_CATALOG.find((model) => model.id === resolved)?.label ?? resolved
+    MODEL_CATALOG.find((model) => model.id === resolved)?.label ??
+    (resolved.startsWith("opencode-go/")
+      ? getOpenCodeGoModelLabel(resolved.slice("opencode-go/".length))
+      : resolved)
   );
 }
 
@@ -134,6 +156,28 @@ export function isStaticOpenCodeGoModelId(modelId: string): boolean {
   );
 }
 
+export function isOpenCodeGoModelId(modelId: string): boolean {
+  return normalizeModelId(modelId)?.startsWith("opencode-go/") ?? false;
+}
+
+export function getOpenCodeGoModelLabel(providerModelId: string): string {
+  return (
+    OPENCODE_GO_MODELS.find((model) => model.slug === providerModelId)?.label ??
+    labelFromSlug(providerModelId)
+  );
+}
+
+export function isOpenCodeGoModelSlug(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 100 &&
+    /^[a-z0-9][a-z0-9.-]*$/.test(value) &&
+    !value.includes("..") &&
+    !value.endsWith(".") &&
+    !value.endsWith("-")
+  );
+}
+
 function isOpenRouterModelSlug(value: string): boolean {
   return (
     value.length > 0 &&
@@ -143,4 +187,18 @@ function isOpenRouterModelSlug(value: string): boolean {
     !value.includes("..") &&
     !/\s/.test(value)
   );
+}
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) =>
+      part
+        .split(".")
+        .filter(Boolean)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join("."),
+    )
+    .join(" ");
 }

--- a/src/lib/opencode-go-catalog.ts
+++ b/src/lib/opencode-go-catalog.ts
@@ -1,0 +1,125 @@
+import type {
+  OpenCodeGoCatalogSummary,
+  OpenCodeGoModelSummary,
+} from "@/src/lib/api-types";
+import {
+  getOpenCodeGoModelLabel,
+  getProviderModelId,
+  isOpenCodeGoModelId,
+  isOpenCodeGoModelSlug,
+  OPENCODE_GO_MODELS,
+} from "@/src/lib/models";
+
+const OPENCODE_GO_MODELS_URL = "https://opencode.ai/zen/go/v1/models";
+const CATALOG_TTL_MS = 10 * 60 * 1000;
+
+let catalogCache:
+  | {
+      expiresAt: number;
+      value: OpenCodeGoCatalogSummary;
+    }
+  | undefined;
+
+export async function getOpenCodeGoCatalog(
+  { refresh = false }: { refresh?: boolean } = {},
+): Promise<OpenCodeGoCatalogSummary> {
+  const now = Date.now();
+  if (!refresh && catalogCache && catalogCache.expiresAt > now) {
+    return catalogCache.value;
+  }
+
+  try {
+    const payload = await fetchOpenCodeGoJson();
+    const value: OpenCodeGoCatalogSummary = {
+      models: parseModels(payload),
+      source: "api",
+      fetchedAt: now,
+      error: null,
+    };
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  } catch (err) {
+    const value = fallbackCatalog(errorMessage(err), now);
+    catalogCache = { expiresAt: now + CATALOG_TTL_MS, value };
+    return value;
+  }
+}
+
+export async function isSupportedOpenCodeGoModelId(
+  modelId: string,
+): Promise<boolean> {
+  if (!isOpenCodeGoModelId(modelId)) return false;
+
+  const providerModelId = getProviderModelId(modelId);
+  if (OPENCODE_GO_MODELS.some((model) => model.slug === providerModelId)) {
+    return true;
+  }
+
+  const catalog = await getOpenCodeGoCatalog();
+  return catalog.models.some((model) => model.id === providerModelId);
+}
+
+function fallbackCatalog(
+  error: string | null,
+  fetchedAt: number,
+): OpenCodeGoCatalogSummary {
+  return {
+    models: OPENCODE_GO_MODELS.map((model) => ({
+      id: model.slug,
+      name: model.label,
+    })),
+    source: "fallback",
+    fetchedAt,
+    error,
+  };
+}
+
+async function fetchOpenCodeGoJson(): Promise<unknown> {
+  const headers: Record<string, string> = {};
+  if (process.env.OPENCODE_GO_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.OPENCODE_GO_API_KEY}`;
+  }
+  const response = await fetch(OPENCODE_GO_MODELS_URL, {
+    headers,
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`OpenCode Go request failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function parseModels(payload: unknown): OpenCodeGoModelSummary[] {
+  const seen = new Set<string>();
+  const data = dataArray(payload);
+  return data.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const id = stringValue(item.id);
+    if (!id || !isOpenCodeGoModelSlug(id) || seen.has(id)) return [];
+    seen.add(id);
+    return [
+      {
+        id,
+        name: stringValue(item.name) ?? getOpenCodeGoModelLabel(id),
+      },
+    ];
+  });
+}
+
+function dataArray(payload: unknown): unknown[] {
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  return Array.isArray(payload) ? payload : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/src/lib/openrouter-catalog.ts
+++ b/src/lib/openrouter-catalog.ts
@@ -7,8 +7,9 @@ import type {
 } from "@/src/lib/api-types";
 import {
   FALLBACK_OPENROUTER_MODELS,
-  isStaticOpenCodeGoModelId,
+  getProviderId,
 } from "@/src/lib/models";
+import { isSupportedOpenCodeGoModelId } from "@/src/lib/opencode-go-catalog";
 
 const OPENROUTER_API_BASE = "https://openrouter.ai";
 const CATALOG_TTL_MS = 10 * 60 * 1000;
@@ -28,9 +29,13 @@ const endpointCache = new Map<
   }
 >();
 
-export async function getOpenRouterCatalog(): Promise<OpenRouterCatalogSummary> {
+export async function getOpenRouterCatalog(
+  { refresh = false }: { refresh?: boolean } = {},
+): Promise<OpenRouterCatalogSummary> {
   const now = Date.now();
-  if (catalogCache && catalogCache.expiresAt > now) return catalogCache.value;
+  if (!refresh && catalogCache && catalogCache.expiresAt > now) {
+    return catalogCache.value;
+  }
 
   try {
     const [providers, models] = await Promise.all([
@@ -98,7 +103,9 @@ export async function getOpenRouterModelEndpoints(
 }
 
 export async function isSupportedAgentModelId(modelId: string): Promise<boolean> {
-  if (isStaticOpenCodeGoModelId(modelId)) return true;
+  if (getProviderId(modelId) === "opencode-go") {
+    return isSupportedOpenCodeGoModelId(modelId);
+  }
   const providerModelId = modelId.startsWith("openrouter/")
     ? modelId.slice("openrouter/".length)
     : modelId.includes("/")

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -43,8 +43,11 @@ export const openrouter = createOpenRouter({
 });
 
 const ANTHROPIC_ENDPOINT_MODELS = new Set([
+  "minimax-m3",
   "minimax-m2.7",
   "minimax-m2.5",
+  "qwen3.7-max",
+  "qwen3.7-plus",
   "qwen3.6-plus",
   "qwen3.5-plus",
 ]);


### PR DESCRIPTION
## Summary
- add a live OpenCode Go model catalog route with static fallback models
- show the same refresh affordance for OpenCode Go models in the existing model picker
- preserve refreshed `opencode-go/<model-id>` validation through chat/settings server checks
- make model catalog refresh bypass cached server responses when explicitly requested
- align the Agent defaults approval strictness trigger content

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `git diff --cached --check`
- staged secret scan
- browser check: OpenCode Go refresh renders refreshed models without console errors
- browser check: Agent defaults approval strictness content is centered without console errors

Closes #188
