### PR TITLE
fix: honor agent mode for PR follow-ups

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -24,7 +24,7 @@ import {
   type TokenAudit,
 } from "@/src/agent/loop";
 import {
-  classifyRunProfile,
+  classifyRunProfileWithContext,
   isBroadScopeRequest,
   isImplementationRequest,
   executionModelFromCostMetadata,
@@ -2365,7 +2365,7 @@ function resolveRunProfile({
   if (profileHandoffRun) {
     return (
       profileHandoffFromCostMetadata(profileHandoffRun.costMetadata)
-        .handoffToProfile ?? classifyRunProfile(mode, latestUserText(messages))
+        .handoffToProfile ?? classifyRunProfileFromMessages(mode, messages)
     );
   }
   if (approvalContinuation) {
@@ -2373,10 +2373,21 @@ function resolveRunProfile({
     const originatingRun = runId ? getRunById(runId) : undefined;
     return (
       executionProfileFromCostMetadata(originatingRun?.costMetadata) ??
-      classifyRunProfile(mode, latestUserText(messages))
+      classifyRunProfileFromMessages(mode, messages)
     );
   }
-  return classifyRunProfile(mode, latestUserText(messages));
+  return classifyRunProfileFromMessages(mode, messages);
+}
+
+function classifyRunProfileFromMessages(
+  mode: ChatMode,
+  messages: AntonUIMessage[],
+): AgentRunProfile {
+  return classifyRunProfileWithContext(
+    mode,
+    latestUserText(messages),
+    previousUserText(messages),
+  );
 }
 
 function profileHandoffFromCostMetadata(costMetadata: unknown): {
@@ -2477,6 +2488,17 @@ function latestUserText(messages: AntonUIMessage[]): string {
     .filter((part) => part.type === "text")
     .map((part) => part.text)
     .join("\n");
+}
+
+function previousUserText(messages: AntonUIMessage[]): string | undefined {
+  const users = messages.filter((message) => message.role === "user");
+  const previous = users.at(-2);
+  if (!previous) return undefined;
+  const text = previous.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+  return text.trim() || undefined;
 }
 
 function byteLength(value: string): number {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2386,7 +2386,7 @@ function classifyRunProfileFromMessages(
   return classifyRunProfileWithContext(
     mode,
     latestUserText(messages),
-    previousUserText(messages),
+    recentUserIntentText(messages),
   );
 }
 
@@ -2490,15 +2490,33 @@ function latestUserText(messages: AntonUIMessage[]): string {
     .join("\n");
 }
 
-function previousUserText(messages: AntonUIMessage[]): string | undefined {
-  const users = messages.filter((message) => message.role === "user");
-  const previous = users.at(-2);
-  if (!previous) return undefined;
-  const text = previous.parts
-    .filter((part) => part.type === "text")
-    .map((part) => part.text)
+const RECENT_RETRY_CONTEXT_USER_MESSAGES = 4;
+const RECENT_RETRY_CONTEXT_MAX_CHARS = 2_000;
+
+function recentUserIntentText(messages: AntonUIMessage[]): string | undefined {
+  const latestUserIndex = messages.findLastIndex(
+    (message) => message.role === "user",
+  );
+  if (latestUserIndex <= 0) return undefined;
+
+  const text = messages
+    .slice(0, latestUserIndex)
+    .filter((message) => message.role === "user")
+    .slice(-RECENT_RETRY_CONTEXT_USER_MESSAGES)
+    .map((message) =>
+      message.parts
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n")
+        .trim(),
+    )
+    .filter(Boolean)
     .join("\n");
-  return text.trim() || undefined;
+
+  if (!text) return undefined;
+  return text.length > RECENT_RETRY_CONTEXT_MAX_CHARS
+    ? text.slice(-RECENT_RETRY_CONTEXT_MAX_CHARS)
+    : text;
 }
 
 function byteLength(value: string): number {

--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -419,26 +419,43 @@ function ChatSession({
     };
   }, [sessionId]);
 
-  useEffect(() => {
-    const controls: ComposerControlState = {
-      mode,
-      model,
-      permissionMode,
-      thinkingEnabled,
-      selectedMcpServerIds,
-    };
+  const persistComposerControls = useCallback((controls: ComposerControlState) => {
     composerControlStateBySession.set(sessionId, controls);
     if (!isDraftSession || persistedRef.current) {
       writeStoredComposerControlState(sessionId, controls);
     }
+  }, [isDraftSession, sessionId]);
+
+  const currentComposerControls = useCallback(
+    (nextMode: ChatMode = mode): ComposerControlState => ({
+      mode: nextMode,
+      model,
+      permissionMode,
+      thinkingEnabled,
+      selectedMcpServerIds,
+    }),
+    [
+      mode,
+      model,
+      permissionMode,
+      selectedMcpServerIds,
+      thinkingEnabled,
+    ],
+  );
+
+  const setModeAndPersist = useCallback(
+    (nextMode: ChatMode) => {
+      setMode(nextMode);
+      persistComposerControls(currentComposerControls(nextMode));
+    },
+    [currentComposerControls, persistComposerControls],
+  );
+
+  useEffect(() => {
+    persistComposerControls(currentComposerControls());
   }, [
-    isDraftSession,
-    mode,
-    model,
-    permissionMode,
-    selectedMcpServerIds,
-    sessionId,
-    thinkingEnabled,
+    currentComposerControls,
+    persistComposerControls,
   ]);
 
   const selectedEnabledMcpServerIds = useCallback(() => (
@@ -659,7 +676,7 @@ function ChatSession({
             streamingResponseMode={streaming ? streamingResponseMode : null}
             onApproval={approveTool}
             onAcceptPlan={() => {
-              setMode("agent");
+              setModeAndPersist("agent");
               void sendWithMcp(
                 { text: "Implement plan", references: [], files: [] },
                 "agent",
@@ -680,7 +697,7 @@ function ChatSession({
             disabled={streaming}
             streaming={streaming}
             mode={mode}
-            onModeChange={setMode}
+            onModeChange={setModeAndPersist}
             model={model}
             onModelChange={setModel}
             thinkingEnabled={thinkingEnabled}

--- a/src/agent/profile-classifier.ts
+++ b/src/agent/profile-classifier.ts
@@ -27,7 +27,7 @@ const IMPLEMENTATION_PATTERNS = [
   /\bhook up\b/,
   /\bintegrate\b/,
   /\bbuild\b/,
-  /\bcreate\b/,
+  /\bcreat(?:e|ing)\b/,
   /\benable\b/,
   /\bsupport\b/,
   /\bmake\b.+\bwork\b/,
@@ -91,7 +91,26 @@ export function isLocalizedImplementationRequest(text: string): boolean {
 export function isCommandRunRequest(latestText: string): boolean {
   return (
     /^(run|execute|rerun|use bash|use terminal)\b/.test(latestText) ||
-    /`(?:git|pnpm|npm|yarn|bun|cat|ls|rg|grep|find)\b[^`]*`/.test(latestText) ||
+    /`(?:git|gh|pnpm|npm|yarn|bun|cat|ls|rg|grep|find)\b[^`]*`/.test(latestText) ||
+    /\bgh\s+(?:pr|issue)\b/.test(latestText) ||
+    /^(?:commit|push|pull|fetch|checkout|switch|branch|merge|rebase)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:can you|please|retry|try|go ahead|now)\b.*\b(?:commit|committing|push|pushing|pull|fetch|checkout|switch|branch|merge|rebase)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:commit|committing)\b.*\b(?:push|pushing|pr|pull request)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:push|pushing)\b.*\b(?:pr|pull request)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:creat(?:e|ing)|open(?:ing)?|retry|rerun|try(?:ing)?)\b.*\b(?:pr|pull request|issue)\b/.test(
+      latestText,
+    ) ||
+    /\b(?:pr|pull request|issue)\b.*\b(?:creat(?:e|ing)|open(?:ing)?|retry|rerun|try(?:ing)?)\b/.test(
+      latestText,
+    ) ||
     /\b(?:discard|revert|restore)\b.*\b(?:changes|repo|repository|working tree|workspace)\b/.test(
       latestText,
     ) ||
@@ -129,6 +148,25 @@ export function classifyRunProfile(
   if (mode === "ask") return "ask";
   if (mode === "plan") return "plan";
   return classifyAgentProfile(latestUserText);
+}
+
+export function classifyRunProfileWithContext(
+  mode: AgentRunMode,
+  latestUserText: string,
+  previousUserText: string | undefined,
+): AgentRunProfile {
+  const profile = classifyRunProfile(mode, latestUserText);
+  if (
+    mode !== "agent" ||
+    profile !== "ask" ||
+    !previousUserText ||
+    !isRetryFollowUp(latestUserText)
+  ) {
+    return profile;
+  }
+
+  const retryProfile = classifyAgentProfile(`${previousUserText}\n${latestUserText}`);
+  return retryProfile === "ask" ? profile : retryProfile;
 }
 
 export function executionProfileFromCostMetadata(
@@ -188,6 +226,11 @@ function isAgentRunProfile(value: unknown): value is AgentRunProfile {
     value === "single-file-edit" ||
     value === "approval-continuation"
   );
+}
+
+function isRetryFollowUp(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  return /\b(?:again|now|retry|try|login|logged in|authenticated)\b/.test(normalized);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/agent/profile-classifier.ts
+++ b/src/agent/profile-classifier.ts
@@ -153,19 +153,19 @@ export function classifyRunProfile(
 export function classifyRunProfileWithContext(
   mode: AgentRunMode,
   latestUserText: string,
-  previousUserText: string | undefined,
+  recentContextText: string | undefined,
 ): AgentRunProfile {
   const profile = classifyRunProfile(mode, latestUserText);
   if (
     mode !== "agent" ||
     profile !== "ask" ||
-    !previousUserText ||
+    !recentContextText ||
     !isRetryFollowUp(latestUserText)
   ) {
     return profile;
   }
 
-  const retryProfile = classifyAgentProfile(`${previousUserText}\n${latestUserText}`);
+  const retryProfile = classifyAgentProfile(`${recentContextText}\n${latestUserText}`);
   return retryProfile === "ask" ? profile : retryProfile;
 }
 


### PR DESCRIPTION
## Summary
- Fix Agent-mode PR/git follow-up routing so requests like "creating PR" and retry-style follow-ups classify to an executable command-run profile instead of the read-only ask profile.
- Preserve Ask and Plan mode behavior by applying retry context only when the selected mode is Agent.
- Persist Agent mode synchronously when accepting a plan so the accepted-plan send path does not depend on a later React effect/localStorage write.

## Session evidence
In session `2ab5c395-60bd-452c-891d-e59882486a35`, the final turn was submitted with `mode: agent` and `permissionMode: full-access`, but the run metadata recorded `profile: ask`. That left only read-only tools active, so the assistant refused to run `gh pr create` despite Agent mode being selected.

## Verification
- Focused classifier probe: Agent + PR creation/retry => `command-run`; Ask and Plan remain unchanged.
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `git diff --cached --check`

## Visual verification
Not applicable; this is a harness routing/state fix with no layout or visual rendering changes.

Fixes #190.
