### PR TITLE
Fix text-only replay of image attachments

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -95,7 +95,10 @@ import {
 import { registerActiveChatStream } from "@/src/lib/chat-stream-registry";
 import { DEFAULT_MODEL } from "@/src/lib/providers";
 import { getProviderId, resolveModelId } from "@/src/lib/models";
-import { isSupportedAgentModelId } from "@/src/lib/openrouter-catalog";
+import {
+  isSupportedAgentModelId,
+  supportsAgentImageInputs,
+} from "@/src/lib/openrouter-catalog";
 import {
   resolveOpenRouterRouting,
   type OpenRouterRoutingResolution,
@@ -390,6 +393,7 @@ export async function POST(req: Request) {
       redactValue(incomingHistory) as AntonUIMessage[],
     );
   }
+  const imageInputsSupported = await supportsAgentImageInputs(model);
 
   const permissionMode =
     (isProfileHandoffContinuation && profileHandoffRun
@@ -509,6 +513,7 @@ export async function POST(req: Request) {
     uiMessages,
     profile,
     isSegmentContinuation,
+    { imageInputsSupported },
   );
   let contextBudget = budgetMessagesForModel({
     messages: preparedMessages,
@@ -786,6 +791,7 @@ function prepareMessagesForModel(
   messages: AntonUIMessage[],
   profile: AgentRunProfile,
   segmentContinuation: boolean,
+  capabilities: ModelInputCapabilities,
   preservation = modelContextPreservation(messages, profile, segmentContinuation),
 ): AntonUIMessage[] {
   return messages.flatMap((message) => {
@@ -798,11 +804,43 @@ function prepareMessagesForModel(
       source.id === preservation.approvalContinuationMessageId,
       source.id === preservation.segmentContinuationMessageId,
     )
+      .flatMap((part) => adaptPartForModelCapabilities(part, capabilities))
       .filter(isModelContextPart)
       .map(stripProviderReplayMetadata);
     if (!parts.some(isSubstantiveModelContextPart)) return [];
     return [{ ...source, parts }];
   });
+}
+
+type ModelInputCapabilities = {
+  imageInputsSupported: boolean;
+};
+
+function adaptPartForModelCapabilities(
+  part: AntonUIMessage["parts"][number],
+  capabilities: ModelInputCapabilities,
+): AntonUIMessage["parts"] {
+  if (
+    part.type === "file" &&
+    !capabilities.imageInputsSupported &&
+    isImageMediaType(part.mediaType)
+  ) {
+    return [{
+      type: "text",
+      text: imageOmittedText(part),
+    }];
+  }
+  return [part];
+}
+
+function imageOmittedText(
+  part: Extract<AntonUIMessage["parts"][number], { type: "file" }>,
+): string {
+  const filename = part.filename?.trim() || "attached image";
+  return [
+    `[Image attachment omitted: ${filename} (${part.mediaType}).`,
+    "The selected model does not support image inputs, so Anton did not send this image to the provider.]",
+  ].join(" ");
 }
 
 function modelContextPreservation(
@@ -1007,9 +1045,13 @@ function formatBytes(bytes: number): string {
 
 function isSupportedAttachmentMediaType(mediaType: string): boolean {
   return (
-    SUPPORTED_ATTACHMENT_IMAGE_TYPES.has(mediaType) ||
+    isImageMediaType(mediaType) ||
     SUPPORTED_ATTACHMENT_MEDIA_TYPES.has(mediaType)
   );
+}
+
+function isImageMediaType(mediaType: string): boolean {
+  return SUPPORTED_ATTACHMENT_IMAGE_TYPES.has(mediaType.toLowerCase());
 }
 
 function attachmentDataUrlBytes(url: string): number | undefined {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -31,6 +31,7 @@ export type OpenRouterProviderSummary = {
 export type OpenRouterModelSummary = {
   id: string;
   name: string;
+  inputModalities: string[];
   contextLength: number | null;
   promptPrice: string | null;
   completionPrice: string | null;

--- a/src/lib/openrouter-catalog.ts
+++ b/src/lib/openrouter-catalog.ts
@@ -106,14 +106,29 @@ export async function isSupportedAgentModelId(modelId: string): Promise<boolean>
   if (getProviderId(modelId) === "opencode-go") {
     return isSupportedOpenCodeGoModelId(modelId);
   }
-  const providerModelId = modelId.startsWith("openrouter/")
-    ? modelId.slice("openrouter/".length)
-    : modelId.includes("/")
-      ? modelId
-      : "";
+  const providerModelId = openRouterProviderModelId(modelId);
   if (!providerModelId) return false;
   const catalog = await getOpenRouterCatalog();
   return catalog.models.some((model) => model.id === providerModelId);
+}
+
+export async function supportsAgentImageInputs(modelId: string): Promise<boolean> {
+  if (getProviderId(modelId) !== "openrouter") return false;
+  const providerModelId = openRouterProviderModelId(modelId);
+  if (!providerModelId) return false;
+  const catalog = await getOpenRouterCatalog();
+  return catalog.models.some(
+    (model) =>
+      model.id === providerModelId &&
+      model.inputModalities.includes("image"),
+  );
+}
+
+function openRouterProviderModelId(modelId: string): string | undefined {
+  if (modelId.startsWith("openrouter/")) {
+    return modelId.slice("openrouter/".length);
+  }
+  return modelId.includes("/") ? modelId : undefined;
 }
 
 function fallbackCatalog(
@@ -125,6 +140,7 @@ function fallbackCatalog(
     models: FALLBACK_OPENROUTER_MODELS.map((model) => ({
       id: model.slug,
       name: model.label,
+      inputModalities: ["text"],
       contextLength: null,
       promptPrice: null,
       completionPrice: null,
@@ -183,6 +199,7 @@ function parseModels(payload: unknown): OpenRouterModelSummary[] {
     const name = stringValue(item.name);
     const supportedParameters = stringArray(item.supported_parameters);
     const architecture = isRecord(item.architecture) ? item.architecture : {};
+    const inputModalities = stringArray(architecture.input_modalities);
     const outputModalities = stringArray(architecture.output_modalities);
     if (
       !id ||
@@ -198,6 +215,7 @@ function parseModels(payload: unknown): OpenRouterModelSummary[] {
       {
         id,
         name,
+        inputModalities,
         contextLength: numberValue(item.context_length) ?? null,
         promptPrice: stringValue(pricing.prompt) ?? null,
         completionPrice: stringValue(pricing.completion) ?? null,


### PR DESCRIPTION
## Summary
- Parse OpenRouter input modalities and expose image-input support for agent models.
- Treat OpenCode Go and unknown/fallback catalog models as text-only for image replay safety.
- Replace unsupported image file parts with a compact model-only text placeholder before context budgeting and `convertToModelMessages`, while preserving the visible/stored transcript attachments.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (clean; only standard CRLF normalization warnings when showing unstaged diff)
- `git diff --cached --check`
- Staged secret scan
- `pnpm build` (passed; existing Turbopack NFT warning from `next.config.ts` import trace remains)
- Focused probe: `supportsAgentImageInputs("opencode-go/glm-5.2")` returns `false`

Closes #192
