### PR TITLE
Fix Agent mode fallback to Ask profile

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -18,6 +18,7 @@ import fs from "node:fs";
 import { z } from "zod";
 
 import {
+  normalizeProfileForMode,
   runAgent,
   type AgentRunMode,
   type AgentRunProfile,
@@ -226,6 +227,7 @@ export async function POST(req: Request) {
     approvalContinuation,
     profileHandoffRun,
   });
+  profile = normalizeProfileForMode(mode, profile);
   const needsProject = mode !== "chat";
   const requestBodyBytes = byteLength(JSON.stringify(json ?? {}));
   const workspaceSettings = getWorkspaceSettings();

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -315,10 +315,10 @@ function runProfilePromptLines(
   profile: AgentRunProfile,
 ): string[] {
   const header = [
-    "Current run profile:",
-    `- Profile: \`${profile}\`. Only the tool schemas supplied to this run are available.`,
+    "Current run context:",
+    `- Selected mode: \`${mode}\`. Run strategy: \`${profile}\`. Only the tool schemas supplied to this run are available.`,
   ];
-  if (profile === "ask") {
+  if (mode === "ask") {
     return [
       ...header,
       "- You are in Ask mode. Answer questions about the selected project using read-only tools and prior run context when useful.",
@@ -549,6 +549,7 @@ export async function runAgent({
     tokenAudit: TokenAudit;
   }) => void;
 }) {
+  profile = normalizeProfileForMode(mode, profile);
   const isFastEditStart = profile === "localized-edit";
   const budget = budgetForProfile(isFastEditStart ? "localized-edit" : profile);
   const effectiveProfile: AgentRunProfile = profile;
@@ -979,6 +980,19 @@ export function profileForMode(mode: AgentRunMode): AgentRunProfile {
   if (mode === "ask") return "ask";
   if (mode === "plan") return "plan";
   return "general-chat";
+}
+
+export function normalizeProfileForMode(
+  mode: AgentRunMode,
+  profile: AgentRunProfile,
+): AgentRunProfile {
+  if (mode === "chat") return "pure-chat";
+  if (mode === "ask") return "ask";
+  if (mode === "plan") return "plan";
+  if (profile === "pure-chat" || profile === "ask" || profile === "plan") {
+    return "general-chat";
+  }
+  return profile;
 }
 
 export function profileAllowsMcp(profile: AgentRunProfile): boolean {

--- a/src/agent/profile-classifier.ts
+++ b/src/agent/profile-classifier.ts
@@ -137,7 +137,7 @@ export function classifyAgentProfile(latestUserText: string): AgentRunProfile {
   if (isBroadScopeRequest(normalized)) return "general-chat";
   if (isLocalizedImplementationRequest(normalized)) return "localized-edit";
   if (isImplementationRequest(normalized)) return "general-chat";
-  return "ask";
+  return "general-chat";
 }
 
 export function classifyRunProfile(


### PR DESCRIPTION
## Summary
- Makes selected chat mode authoritative by normalizing incompatible profiles at both the API route and `runAgent` boundary.
- Prevents `mode=agent` runs from reaching the model, tools, run metadata, or trace display as `profile=ask`; ambiguous Agent turns now fall back to `general-chat`.
- Updates run prompt wording to describe selected mode plus internal run strategy, and gates the Ask-mode prompt on `mode === "ask"` only.
- Removes the earlier phrase-pattern workaround from the net PR diff.

## Session Evidence
From local session `b84042fb-ed46-49f0-b34f-4489c0fd7ae0`:
- Runs such as `1937918b-11da-4e2a-b1f0-77b14742ce4d` and `86b79d71-4fce-4f58-8db5-b89973e8e5cb` recorded `execution.mode = agent` with `execution.profile = ask`.
- Those runs used the Ask-mode prompt/tool surface and the assistant told the user it was in Ask mode despite the composer being in Agent mode.

## Verification
- Focused classifier probe: `Can you try again?` with prior PR context resolves to `general-chat` in Agent mode.
- Focused classifier probe: `Read the workflow requirements and do the required changes so that all the checks are in place` resolves to `general-chat` in Agent mode.
- Focused classifier probe: explicit Ask mode remains `ask`.
- Focused classifier probe: explicit Plan mode remains `plan`.
- Source invariant probe: Ask prompt is gated by `mode === "ask"`; route and loop both call `normalizeProfileForMode`; no `profile === "ask"` loop prompt branch remains.
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` (clean aside from standard CRLF normalization warnings)
- `git diff --cached --check`

Closes #194
