### PR TITLE
Fix chat streaming trace UI performance

### DIFF
--- a/components/features/chat/chat.tsx
+++ b/components/features/chat/chat.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCallback,
+  useDeferredValue,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -521,7 +522,7 @@ function ChatSession({
     });
   }, [messages, requestBodyForMode, sendMessage, sessionId, status]);
 
-  const sendWithMcp = async (
+  const sendWithMcp = useCallback(async (
     payload: ComposerSendPayload,
     requestedMode: ChatMode = mode,
   ): Promise<boolean> => {
@@ -564,7 +565,13 @@ function ChatSession({
       },
     );
     return true;
-  };
+  }, [
+    effectiveProjectId,
+    mode,
+    requestBodyForMode,
+    selectedEnabledMcpServerIds,
+    sendMessage,
+  ]);
 
   const trustAndSend = async () => {
     if (!pendingMcpSend) return;
@@ -590,6 +597,8 @@ function ChatSession({
     fallback: messageDisplayOverride,
     streaming,
   });
+  const deferredDisplayMessages = useDeferredValue(displayMessages);
+  const worklogMessages = streaming ? deferredDisplayMessages : displayMessages;
   const projectLocked =
     initialProjectId !== null || displayMessages.length > 0;
   const recoveringMessages =
@@ -599,7 +608,15 @@ function ChatSession({
     sessions.find((s) => s.id === sessionId)?.tokensTotal ?? initialTokensTotal;
   const tokenUsage = sessionTokenUsage(displayMessages, persistedTokensTotal);
 
-  const toggleWorklog = () => {
+  const handleAcceptPlan = useCallback(() => {
+    setModeAndPersist("agent");
+    void sendWithMcp(
+      { text: "Implement plan", references: [], files: [] },
+      "agent",
+    );
+  }, [sendWithMcp, setModeAndPersist]);
+
+  const toggleWorklog = useCallback(() => {
     if (
       typeof window !== "undefined" &&
       window.matchMedia("(min-width: 1280px)").matches
@@ -608,9 +625,9 @@ function ChatSession({
     } else {
       setMobileWorklogOpen((open) => !open);
     }
-  };
+  }, [setWorklogOpen]);
 
-  const openProjectStatus = () => {
+  const openProjectStatus = useCallback(() => {
     if (
       typeof window !== "undefined" &&
       window.matchMedia("(min-width: 1280px)").matches
@@ -620,7 +637,17 @@ function ChatSession({
       setMobileWorklogOpen(true);
     }
     notifyOpenWorklogStatus();
-  };
+  }, [setWorklogOpen]);
+
+  const openWorklogFile = useCallback(() => {
+    sidebar.setOpen(false);
+    expandWorklog();
+    setWorklogOpen(true);
+  }, [expandWorklog, setWorklogOpen, sidebar]);
+
+  const closeMobileWorklogFile = useCallback(() => {
+    setMobileWorklogOpen(false);
+  }, []);
 
   return (
     <div className="flex min-w-0 max-w-full flex-1 flex-col overflow-hidden bg-background">
@@ -675,13 +702,7 @@ function ChatSession({
             recovering={recoveringMessages}
             streamingResponseMode={streaming ? streamingResponseMode : null}
             onApproval={approveTool}
-            onAcceptPlan={() => {
-              setModeAndPersist("agent");
-              void sendWithMcp(
-                { text: "Implement plan", references: [], files: [] },
-                "agent",
-              );
-            }}
+            onAcceptPlan={handleAcceptPlan}
             acceptPlanDisabled={streaming || !effectiveProjectId}
           />
 
@@ -748,17 +769,13 @@ function ChatSession({
               />
             ) : null}
             <Worklog
-              messages={displayMessages}
+              messages={worklogMessages}
               streaming={streaming}
               onApproval={approveTool}
               project={project}
               visible={worklogOpen}
               expanded={worklogExpanded}
-              onFileOpen={() => {
-                sidebar.setOpen(false);
-                expandWorklog();
-                setWorklogOpen(true);
-              }}
+              onFileOpen={openWorklogFile}
               onExpandToggle={toggleWorklogExpanded}
               className="h-full w-full min-w-0"
             />
@@ -775,14 +792,14 @@ function ChatSession({
             }}
           >
             <Worklog
-              messages={displayMessages}
+              messages={worklogMessages}
               streaming={streaming}
               onApproval={approveTool}
               project={project}
               visible
               className="ml-auto h-full w-[min(420px,100%)] border-l"
-              onClose={() => setMobileWorklogOpen(false)}
-              onFileOpen={() => setMobileWorklogOpen(false)}
+              onClose={closeMobileWorklogFile}
+              onFileOpen={closeMobileWorklogFile}
             />
           </div>
         )}

--- a/components/features/chat/markdown.tsx
+++ b/components/features/chat/markdown.tsx
@@ -11,12 +11,14 @@ interface MarkdownProps {
   className?: string;
 }
 
+const REMARK_PLUGINS = [remarkGfm];
+
 function MarkdownImpl({ children, className }: MarkdownProps) {
   const normalized = normalizeGithubMarkdown(children);
 
   return (
     <div className={cn("anton-md space-y-1.5 leading-relaxed", className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={COMPONENTS}>
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={COMPONENTS}>
         {normalized}
       </ReactMarkdown>
     </div>

--- a/components/features/chat/message-list.tsx
+++ b/components/features/chat/message-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { ChatAddToolApproveResponseFunction, FileUIPart } from "ai";
 import {
   Check,
@@ -15,7 +15,6 @@ import {
   getAssistantTextDisplay,
   getRunData,
   getToolTraceEntries,
-  hasPendingToolApproval,
   messageHadSuccessfulStateChangingEdit,
   messageIsLoopGuardIncomplete,
   messageIsUnverifiedEdit,
@@ -128,6 +127,7 @@ export function MessageList({
           <MessageEvent
             key={message.id}
             message={message}
+            messageSignature={messageRenderSignature(message)}
             status={
               message.id === activeAssistantMessageId ? status : "ready"
             }
@@ -153,23 +153,45 @@ export function emptyMessageListText(recovering: boolean): string {
     : "Start a session by asking Anton to inspect or change the selected workspace.";
 }
 
-function MessageEvent({
-  message,
-  status,
-  streamingResponseMode,
-  todoDisplay,
-  onApproval,
-  onAcceptPlan,
-  acceptPlanDisabled,
-}: {
+const MessageEvent = memo(MessageEventImpl, (previous, next) => {
+  if (previous.message !== next.message) return false;
+  if (previous.messageSignature !== next.messageSignature) return false;
+  if (previous.status !== next.status) return false;
+  if (previous.streamingResponseMode !== next.streamingResponseMode) return false;
+  if (previous.onApproval !== next.onApproval) return false;
+  if (previous.onAcceptPlan !== next.onAcceptPlan) return false;
+  if (previous.acceptPlanDisabled !== next.acceptPlanDisabled) return false;
+  if (
+    messageHasTodoDataPart(previous.message) &&
+    previous.todoDisplay !== next.todoDisplay
+  ) {
+    return false;
+  }
+  return true;
+});
+MessageEvent.displayName = "MessageEvent";
+
+type MessageEventProps = {
   message: AntonUIMessage;
+  messageSignature: string;
   status: "submitted" | "streaming" | "ready" | "error";
   streamingResponseMode: ChatMode | null;
   todoDisplay: ReturnType<typeof getTodoTraceDisplay>;
   onApproval: ChatAddToolApproveResponseFunction;
   onAcceptPlan: (plan: string) => void;
   acceptPlanDisabled: boolean;
-}) {
+};
+
+function MessageEventImpl(props: MessageEventProps) {
+  const {
+    message,
+    status,
+    streamingResponseMode,
+    todoDisplay,
+    onApproval,
+    onAcceptPlan,
+    acceptPlanDisabled,
+  } = props;
   const isUser = message.role === "user";
   const streaming = status === "submitted" || status === "streaming";
   const responseKind =
@@ -186,9 +208,10 @@ function MessageEvent({
           responseKind !== "plan" && streaming,
       }).finalText
     : "";
-  const pendingApproval = !isUser && hasPendingToolApproval(message);
-  const failedToolText = !isUser ? toolFailureFallbackText(message) : "";
   const assistantFinal = !isUser && isAssistantMessageFinal(message);
+  const pendingApproval = !isUser && messageHasPendingApproval(message);
+  const failedToolText =
+    !isUser && assistantFinal ? toolFailureFallbackText(message) : "";
   const fallbackText = !isUser &&
     assistantText.length === 0 &&
     failedToolText.length === 0 &&
@@ -197,8 +220,9 @@ function MessageEvent({
     ? toolResultFallbackText(message)
     : "";
   const responseText = isUser ? userText : assistantText || fallbackText;
-  const responseTime = !isUser ? messageDisplayTime(message) : undefined;
-  const metrics = !isUser ? messageMetrics(message) : undefined;
+  const responseTime =
+    !isUser && assistantFinal ? messageDisplayTime(message) : undefined;
+  const metrics = !isUser && assistantFinal ? messageMetrics(message) : undefined;
   const showActions =
     !isUser &&
     responseText.length > 0 &&
@@ -211,12 +235,14 @@ function MessageEvent({
     responseText.length > 0 &&
     assistantFinal &&
     !streaming;
+  const hadSuccessfulEdit =
+    !isUser && assistantFinal ? messageHadSuccessfulStateChangingEdit(message) : false;
   const incompleteWithoutEdits =
-    !isUser && messageIsLoopGuardIncomplete(message) && !messageHadSuccessfulStateChangingEdit(message);
+    !isUser && assistantFinal && messageIsLoopGuardIncomplete(message) && !hadSuccessfulEdit;
   const unverifiedWithEdits =
-    !isUser && messageIsUnverifiedEdit(message) && messageHadSuccessfulStateChangingEdit(message);
+    !isUser && assistantFinal && messageIsUnverifiedEdit(message) && hadSuccessfulEdit;
   const verificationFailedWithEdits =
-    !isUser && messageIsVerificationFailed(message) && messageHadSuccessfulStateChangingEdit(message);
+    !isUser && assistantFinal && messageIsVerificationFailed(message) && hadSuccessfulEdit;
   const showToolFailure =
     !isUser &&
     failedToolText.length > 0 &&
@@ -284,9 +310,13 @@ function MessageEvent({
               </div>
             ) : responseKind === "plan" ? null
             : responseText.length > 0 ? (
-              <Markdown className="text-[13.5px] leading-[1.65]">
-                {responseText}
-              </Markdown>
+              streaming ? (
+                <StreamingText text={responseText} />
+              ) : (
+                <Markdown className="text-[13.5px] leading-[1.65]">
+                  {responseText}
+                </Markdown>
+              )
             ) : null}
           </div>
         )}
@@ -300,6 +330,57 @@ function MessageEvent({
       )}
     </div>
   );
+}
+
+function StreamingText({ text }: { text: string }) {
+  return (
+    <div className="whitespace-pre-wrap text-[13.5px] leading-[1.65] text-foreground">
+      {text}
+    </div>
+  );
+}
+
+function messageHasPendingApproval(message: AntonUIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      "state" in part &&
+      part.state === "approval-requested" &&
+      "toolCallId" in part &&
+      typeof part.toolCallId === "string",
+  );
+}
+
+function messageHasTodoDataPart(message: AntonUIMessage): boolean {
+  return message.parts.some((part) => part.type === "data-todos");
+}
+
+function messageRenderSignature(message: AntonUIMessage): string {
+  const part = message.parts.at(-1);
+  const metadataStatus = message.metadata?.status ?? "";
+  const responseKind = message.metadata?.responseKind ?? "";
+  if (!part) return `${message.parts.length}:${metadataStatus}:${responseKind}`;
+
+  const base = `${message.parts.length}:${metadataStatus}:${responseKind}:${part.type}`;
+  if (part.type === "text" || part.type === "reasoning") {
+    return `${base}:${part.text.length}`;
+  }
+  if ("state" in part && typeof part.state === "string") {
+    const toolCallId =
+      "toolCallId" in part && typeof part.toolCallId === "string"
+        ? part.toolCallId
+        : "";
+    return `${base}:${part.state}:${toolCallId}`;
+  }
+  if (part.type === "data-run") {
+    return `${base}:${part.data.status}:${part.data.finishedAt ?? ""}:${part.data.totalTokens ?? ""}`;
+  }
+  if (part.type === "data-activity") {
+    return `${base}:${part.data.id}:${part.data.status}:${part.data.finishedAt ?? ""}:${part.data.durationMs ?? ""}`;
+  }
+  if (part.type === "data-todos") {
+    return `${base}:${part.data.updatedAt}:${part.data.items.map((item) => item.status).join(",")}`;
+  }
+  return base;
 }
 
 function UserMessageContent({ message }: { message: AntonUIMessage }) {

--- a/components/features/run-trace/run-trace.tsx
+++ b/components/features/run-trace/run-trace.tsx
@@ -14,7 +14,6 @@ import {
   getAssistantTextDisplay,
   getMessageRunDurationMs,
   getRunData,
-  hasPendingToolApproval,
   type AntonUIMessage,
   type AntonRunStatus,
 } from "@/src/lib/trace";
@@ -67,13 +66,10 @@ export function RunTraceAccordion({
   );
   const isRunning = runStatus === "running";
 
-  const pendingApproval = useMemo(
-    () => hasPendingToolApproval(message),
-    [message],
-  );
+  const pendingApproval = useMemo(() => messageHasPendingApproval(message), [message]);
   const hasFinalResponseText = useMemo(
-    () => getAssistantTextDisplay(message).finalText.length > 0,
-    [message],
+    () => !isRunning && getAssistantTextDisplay(message).finalText.length > 0,
+    [isRunning, message],
   );
 
   const forceOpen = pendingApproval;
@@ -200,6 +196,16 @@ function messageHasTracePayload(message: AntonUIMessage): boolean {
     }
     return "toolCallId" in part && typeof part.toolCallId === "string";
   });
+}
+
+function messageHasPendingApproval(message: AntonUIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      "state" in part &&
+      part.state === "approval-requested" &&
+      "toolCallId" in part &&
+      typeof part.toolCallId === "string",
+  );
 }
 
 function effectiveRunStatus(

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -112,6 +112,11 @@ export type SessionTimelineRunGroup = {
   steps: SessionTimelineStepGroup[];
 };
 
+export type SessionTimelineOptions = {
+  runningStepLimit?: number;
+  runningItemLimit?: number;
+};
+
 export function groupTimelineItemsByStep<T extends TimelineStepBoundaryItem>(
   items: readonly T[],
   options?: { tailLabel?: string; activityLabel?: string },
@@ -224,6 +229,7 @@ function stepDisplayDurationMs(
 
 export function getSessionTimelineRunGroups(
   messages: AntonUIMessage[],
+  options: SessionTimelineOptions = {},
 ): SessionTimelineRunGroup[] {
   const groups: SessionTimelineRunGroup[] = [];
 
@@ -232,7 +238,7 @@ export function getSessionTimelineRunGroups(
 
     const runs = getRunsForTimelineMessage(message);
     runs.forEach((run, index) => {
-      const items = buildRunTimelineItems(message, run);
+      const items = buildRunTimelineItems(message, run, options);
       if (items.length === 0) return;
       groups.push({
         runId: run.runId,
@@ -282,18 +288,10 @@ function getRunsForTimelineMessage(message: AntonUIMessage): AntonRunData[] {
 function buildRunTimelineItems(
   message: AntonUIMessage,
   run: AntonRunData,
+  options: SessionTimelineOptions = {},
 ): SessionTimelineItem[] {
   const runStatus = run.status;
-  const toolByCallId = new Map(
-    getToolTraceEntries([message])
-      .filter((tool) => tool.activity?.runId === run.runId)
-      .map((tool) => [tool.id, tool]),
-  );
-  const seenToolIds = new Set<string>();
-  const items: SessionTimelineItem[] = [];
-  const reasoningByEventId = buildReasoningTextByEventId(message);
-
-  const events = getActivityEvents(message)
+  const allEvents = getActivityEvents(message)
     .filter(
       (event) =>
         event.runId === run.runId &&
@@ -301,6 +299,34 @@ function buildRunTimelineItems(
         !isTokenBudgetActivity(event),
     )
     .sort(compareTimelineEvents);
+  const events = limitRunningTimelineEvents(allEvents, runStatus, options);
+  const limitedToolCallIds =
+    events === allEvents
+      ? undefined
+      : new Set(
+          events.flatMap((event) =>
+            event.kind === "tool" && event.toolCallId ? [event.toolCallId] : [],
+          ),
+        );
+  const toolByCallId = new Map(
+    getToolTraceEntries(
+      [message],
+      limitedToolCallIds ? { toolCallIds: limitedToolCallIds } : {},
+    )
+      .filter((tool) => tool.activity?.runId === run.runId)
+      .map((tool) => [tool.id, tool]),
+  );
+  const seenToolIds = new Set<string>();
+  const items: SessionTimelineItem[] = [];
+  const needsReasoningText = events.some(
+    (event) =>
+      event.kind === "reasoning" &&
+      !event.summary?.trim() &&
+      event.status !== "running",
+  );
+  const reasoningByEventId = needsReasoningText
+    ? buildReasoningTextByEventId(message)
+    : undefined;
 
   for (const event of events) {
     const base = {
@@ -404,6 +430,55 @@ function buildRunTimelineItems(
   }
 
   return items.sort(compareTimelineItems);
+}
+
+function limitRunningTimelineEvents(
+  events: AntonActivityEvent[],
+  runStatus: AntonRunStatus,
+  options: SessionTimelineOptions,
+): AntonActivityEvent[] {
+  const stepLimit = options.runningStepLimit;
+  const itemLimit = options.runningItemLimit;
+  if (
+    runStatus !== "running" ||
+    (stepLimit === undefined && itemLimit === undefined)
+  ) {
+    return events;
+  }
+
+  const stepEvents = events.filter((event) => event.kind === "step");
+  const nonStepEvents = events.filter((event) => event.kind !== "step");
+
+  if (stepEvents.length === 0) {
+    return (
+      itemLimit === undefined
+        ? events
+        : nonStepEvents.slice(-itemLimit)
+    ).sort(compareTimelineEvents);
+  }
+
+  const visibleSteps =
+    stepLimit === undefined ? stepEvents : stepEvents.slice(-stepLimit);
+  const visibleStepIds = new Set(visibleSteps.map((event) => event.id));
+  const visibleEvents: AntonActivityEvent[] = [];
+
+  for (const [index, step] of visibleSteps.entries()) {
+    visibleEvents.push(step);
+    const nextStepStart =
+      visibleSteps[index + 1]?.startedAt ?? Number.POSITIVE_INFINITY;
+    const stepItems = nonStepEvents.filter(
+      (event) =>
+        event.startedAt >= step.startedAt &&
+        event.startedAt < nextStepStart,
+    );
+    visibleEvents.push(
+      ...(itemLimit === undefined ? stepItems : stepItems.slice(-itemLimit)),
+    );
+  }
+
+  return visibleEvents
+    .filter((event) => event.kind !== "step" || visibleStepIds.has(event.id))
+    .sort(compareTimelineEvents);
 }
 
 export function activityDisplayDurationMs(

--- a/components/features/run-trace/worklog-timeline.tsx
+++ b/components/features/run-trace/worklog-timeline.tsx
@@ -92,7 +92,13 @@ export function WorklogTimeline({
     [stableTimelineKey],
   );
   const liveGroups = useMemo(
-    () => (liveMessage ? getSessionTimelineRunGroups([liveMessage]) : []),
+    () =>
+      liveMessage
+        ? getSessionTimelineRunGroups([liveMessage], {
+            runningStepLimit: LIVE_WORKLOG_STEP_LIMIT,
+            runningItemLimit: LIVE_WORKLOG_ITEM_LIMIT,
+          })
+        : [],
     [liveMessage],
   );
   const groups = useMemo(

--- a/components/shared/disclosure.tsx
+++ b/components/shared/disclosure.tsx
@@ -5,7 +5,7 @@ import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 const DISCLOSURE_ANIMATION =
-  "overflow-hidden transition-[max-height,opacity] ease-in-out will-change-[max-height,opacity] motion-reduce:transition-none";
+  "overflow-hidden transition-[max-height,opacity] ease-in-out motion-reduce:transition-none";
 
 type DisclosureChildren = ReactNode | ((state: { open: boolean }) => ReactNode);
 
@@ -59,7 +59,7 @@ export function Disclosure({
       observer.disconnect();
       window.removeEventListener("resize", updateHeight);
     };
-  }, [children, renderContent]);
+  }, [renderContent]);
 
   if (disabled) {
     return <div className={className}>{trigger({ open: false })}</div>;

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -1177,12 +1177,19 @@ export function getActivityEvents(
 
 export function getToolTraceEntries(
   messages: AntonUIMessage[],
+  options: { toolCallIds?: ReadonlySet<string> } = {},
 ): ToolTraceEntry[] {
   const entriesById = new Map<string, ToolTraceEntry>();
   for (const message of messages) {
     const activityByToolCallId = new Map<string, AntonActivityEvent>();
     for (const activity of getActivityEvents(message)) {
       if (activity.kind === "tool" && activity.toolCallId) {
+        if (
+          options.toolCallIds &&
+          !options.toolCallIds.has(activity.toolCallId)
+        ) {
+          continue;
+        }
         activityByToolCallId.set(activity.toolCallId, activity);
       }
     }
@@ -1194,6 +1201,12 @@ export function getToolTraceEntries(
         "toolCallId" in part && typeof part.toolCallId === "string"
           ? part.toolCallId
           : undefined;
+      if (
+        options.toolCallIds &&
+        (!toolCallId || !options.toolCallIds.has(toolCallId))
+      ) {
+        return;
+      }
       const id = toolCallId ?? `${message.id}:${index}`;
       const entry = {
         id,


### PR DESCRIPTION
## Summary
- Render active streaming assistant text as cheap plain text until the response is final, avoiding repeated React Markdown parsing on every token delta.
- Defer live Worklog message updates so urgent UI controls can respond while trace rendering catches up in the background.
- Bound running Worklog trace derivation to the visible recent steps/items before building timeline groups, and allow tool trace extraction by target tool IDs.
- Avoid full trace/text scans for pending approval/final-text checks during active runs and remove persistent disclosure `will-change` usage that can inflate browser memory with many trace rows.

## Root Cause Notes
- Synthetic render probe showed the current Markdown renderer costs about 159 ms for 10 KiB and 753 ms for 50 KiB of markdown on this machine. The old live path reparsed growing streaming text repeatedly.
- The Worklog already limited visible running rows, but the derivation still built the full running timeline first. The new live-limited path avoids allocating full historical item arrays for every live tick.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check` and `git diff --cached --check` (only normal CRLF checkout warnings before staging; cached check clean)
- `pnpm build` passed. Build still reports the existing Turbopack NFT warning through `app/api/projects/[id]/status/route.ts`.
- Synthetic trace probe at 720 tool events: full timeline p95 3.23 ms / ~1256 KiB avg heap delta; live-limited p95 0.78 ms / ~292 KiB avg heap delta.
- Production browser smoke on `http://127.0.0.1:3001`: status 200, title `Anton`, Worklog toggle found/responded, no console errors, no page errors.

Fixes #196
