### PR TITLE
Add project environment settings and gh auth repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ A mini AI coding agent harness - built as a learning project to understand how p
 ```bash
 pnpm install
 cp .env.example .env.local          # then edit OPENROUTER_API_KEY
-pnpm db:migrate                     # apply Drizzle migrations
-pnpm dev                            # http://localhost:3000
+pnpm dev                            # applies migrations, then serves http://localhost:3000
 ```
 
 ## Scripts
 
 | Script | Purpose |
 |---|---|
-| `pnpm dev` | Start dev server (Turbopack) |
-| `pnpm build` / `pnpm start` | Production build + start |
+| `pnpm dev` | Apply pending migrations, then start dev server (Turbopack) |
+| `pnpm build` / `pnpm start` | Production build / apply pending migrations, then start |
 | `pnpm lint` | ESLint |
 | `pnpm typecheck` | `tsc --noEmit` |
 | `pnpm db:generate` | Generate Drizzle migration from schema |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,6 +150,7 @@ This roadmap is the working backlog for turning Anton from a learning harness in
 - [✔️] Add cancellable background command sessions for dev servers and watchers.
 - [] Add command history with rerun support.
 - [✔️] Add settings for default model, max steps, approval strictness, and workspace root.
+- [✔️] Add per-project Environment settings that write project `.env`, inject enabled variables into workspace processes, and repair stale Docker `gh` auth (#202).
 - [] Add mobile-friendly workspace and worklog controls.
 - [] Add accessible keyboard navigation for settings, sessions, worklog, approvals, and message actions.
 - [✔️] Split chat UI components into feature-oriented folders.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -148,6 +148,8 @@ const MAX_ATTACHMENT_COUNT = 10;
 const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 24 * 1024 * 1024;
 const MAX_WORKSPACE_REFERENCES = 50;
+const MAX_REASONING_SUMMARY_CHARS = 4_000;
+const REASONING_SUMMARY_TRUNCATED_SUFFIX = "\n...[reasoning summary truncated]";
 const SUPPORTED_ATTACHMENT_MEDIA_TYPES = new Set([
   "application/json",
   "application/pdf",
@@ -734,7 +736,7 @@ export async function POST(req: Request) {
 
         writer.merge(
           result.toUIMessageStream<AntonUIMessage>({
-            sendReasoning: true,
+            sendReasoning: false,
             sendStart: false,
             sendFinish: false,
           }),
@@ -1370,6 +1372,7 @@ function createTraceWriter({
   const effectiveProfile: AgentRunProfile = profile;
   const events = new Map<string, AntonActivityEvent>();
   const reasoningBuffers = new Map<string, string>();
+  const truncatedReasoningBuffers = new Set<string>();
   const activeReasoningEventIds = new Map<string, string>();
   const reasoningOccurrences = new Map<string, number>();
 
@@ -2079,10 +2082,10 @@ function createTraceWriter({
       if (part.type === "reasoning-delta") {
         const eventId = activeReasoningEventIds.get(part.id);
         const bufferId = eventId ?? `${runId}:reasoning:${part.id}`;
-        reasoningBuffers.set(
-          bufferId,
-          `${reasoningBuffers.get(bufferId) ?? ""}${part.text}`,
-        );
+        const current = reasoningBuffers.get(bufferId) ?? "";
+        const next = appendCappedReasoningBuffer(current, part.text);
+        reasoningBuffers.set(bufferId, next.text);
+        if (next.truncated) truncatedReasoningBuffers.add(bufferId);
       }
       if (part.type === "reasoning-start") {
         const occurrence = (reasoningOccurrences.get(part.id) ?? 0) + 1;
@@ -2103,8 +2106,12 @@ function createTraceWriter({
         const eventId =
           activeReasoningEventIds.get(part.id) ??
           `${runId}:reasoning:${part.id}`;
-        const summary = reasoningBuffers.get(eventId)?.trim();
+        const summary = reasoningSummaryFromBuffer(
+          reasoningBuffers.get(eventId),
+          truncatedReasoningBuffers.has(eventId),
+        );
         reasoningBuffers.delete(eventId);
+        truncatedReasoningBuffers.delete(eventId);
         activeReasoningEventIds.delete(part.id);
         finishEvent(eventId, {
           status: "completed",
@@ -2134,6 +2141,32 @@ function createTraceWriter({
     },
     finalize,
   };
+}
+
+function appendCappedReasoningBuffer(
+  current: string,
+  delta: string,
+): { text: string; truncated: boolean } {
+  if (current.length >= MAX_REASONING_SUMMARY_CHARS) {
+    return { text: current, truncated: delta.length > 0 };
+  }
+  const remaining = MAX_REASONING_SUMMARY_CHARS - current.length;
+  if (delta.length <= remaining) {
+    return { text: `${current}${delta}`, truncated: false };
+  }
+  return {
+    text: `${current}${delta.slice(0, remaining)}`,
+    truncated: true,
+  };
+}
+
+function reasoningSummaryFromBuffer(
+  value: string | undefined,
+  truncated: boolean,
+): string | undefined {
+  const summary = value?.trim();
+  if (!summary) return undefined;
+  return truncated ? `${summary}${REASONING_SUMMARY_TRUNCATED_SUFFIX}` : summary;
 }
 
 function todoItemsFromToolOutput(

--- a/app/api/projects/[id]/environment/route.ts
+++ b/app/api/projects/[id]/environment/route.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import {
+  getProject,
+  updateProjectEnvironmentEnabled,
+} from "@/src/db/queries";
+import {
+  patchProjectEnvironment,
+  ProjectEnvironmentError,
+  summarizeProjectEnvironment,
+} from "@/src/workspace/project-env";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+const keySchema = z.string().trim().regex(/^[A-Za-z_][A-Za-z0-9_]{0,127}$/);
+const patchSchema = z.object({
+  enabled: z.boolean().optional(),
+  upsert: z
+    .array(
+      z.object({
+        key: keySchema,
+        value: z.string().max(64 * 1024),
+      }),
+    )
+    .max(100)
+    .optional(),
+  delete: z.array(keySchema).max(100).optional(),
+});
+
+export async function GET(_req: Request, { params }: Ctx) {
+  const ready = await readyProject(params);
+  if ("error" in ready) return ready.error;
+
+  try {
+    return Response.json({
+      environment: await summarizeProjectEnvironment({
+        projectId: ready.project.id,
+        root: ready.root,
+        enabled: ready.project.environmentEnabled,
+      }),
+    });
+  } catch (err) {
+    return Response.json({ error: errorMessage(err) }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: Request, { params }: Ctx) {
+  const ready = await readyProject(params);
+  if ("error" in ready) return ready.error;
+
+  const body = await req.json().catch(() => null);
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return Response.json(
+      { error: "invalid body", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const upsertCount = parsed.data.upsert?.length ?? 0;
+    const deleteCount = parsed.data.delete?.length ?? 0;
+    if (upsertCount > 0 || deleteCount > 0) {
+      await patchProjectEnvironment(ready.root, parsed.data);
+    }
+
+    const enabled =
+      parsed.data.enabled ??
+      (upsertCount > 0 ? true : ready.project.environmentEnabled);
+    const project =
+      enabled === ready.project.environmentEnabled
+        ? ready.project
+        : updateProjectEnvironmentEnabled(ready.project.id, enabled) ?? ready.project;
+
+    return Response.json({
+      environment: await summarizeProjectEnvironment({
+        projectId: project.id,
+        root: ready.root,
+        enabled: project.environmentEnabled,
+      }),
+    });
+  } catch (err) {
+    const status = err instanceof ProjectEnvironmentError ? err.status : 500;
+    return Response.json({ error: errorMessage(err) }, { status });
+  }
+}
+
+async function readyProject(params: Promise<{ id: string }>): Promise<
+  | { project: NonNullable<ReturnType<typeof getProject>>; root: string }
+  | { error: Response }
+> {
+  const { id } = await params;
+  const project = getProject(id);
+  if (!project) {
+    return { error: Response.json({ error: "project not found" }, { status: 404 }) };
+  }
+  if (project.status !== "ready") {
+    return { error: Response.json({ error: "project is not ready" }, { status: 400 }) };
+  }
+  return { project, root: ensureWorkspaceRootAt(project.localPath) };
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/components/features/run-trace/trace-data.ts
+++ b/components/features/run-trace/trace-data.ts
@@ -25,6 +25,8 @@ import {
 
 import { isFailedToolOutput, previewToolInput } from "./tool-display";
 
+type ReasoningTextMap = ReadonlyMap<string, string> | null | undefined;
+
 export type StepGroup = {
   stepNumber: number;
   order: number;
@@ -325,8 +327,8 @@ function buildRunTimelineItems(
       event.status !== "running",
   );
   const reasoningByEventId = needsReasoningText
-    ? buildReasoningTextByEventId(message)
-    : undefined;
+    ? buildReasoningTextMapIfAvailable(message)
+    : null;
 
   for (const event of events) {
     const base = {
@@ -521,13 +523,22 @@ function compareTimelineItems(
 function reasoningTextForEvent(
   message: AntonUIMessage,
   event: AntonActivityEvent,
-  reasoningByEventId?: ReadonlyMap<string, string>,
+  reasoningByEventId?: ReasoningTextMap,
 ): string | undefined {
   const summary = event.summary?.trim();
   if (summary) return summary;
   if (event.status === "running") return undefined;
+  if (reasoningByEventId === null) return undefined;
   const map = reasoningByEventId ?? buildReasoningTextByEventId(message);
   return map.get(event.id);
+}
+
+function buildReasoningTextMapIfAvailable(
+  message: AntonUIMessage,
+): ReadonlyMap<string, string> | null {
+  return message.parts.some(isReasoningPart)
+    ? buildReasoningTextByEventId(message)
+    : null;
 }
 
 function todoSnapshotFromEventDetails(
@@ -832,7 +843,7 @@ export function getTraceRows(
   const reasoningActivities = activities.filter(
     (event) => event.kind === "reasoning",
   );
-  const reasoningByEventId = buildReasoningTextByEventId(message);
+  const reasoningByEventId = buildReasoningTextMapIfAvailable(message);
   const toolEntries = getToolTraceEntries([message]);
   const partSequenceMarkers = buildPartSequenceMarkers(
     message,

--- a/components/features/settings/environment-settings-panel.tsx
+++ b/components/features/settings/environment-settings-panel.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  FolderGit2,
+  KeyRound,
+  Loader2,
+  Pencil,
+  Plus,
+  Search,
+  Trash2,
+  Upload,
+} from "lucide-react";
+
+import { EmptyState, ErrorBanner } from "@/components/shared/feedback-states";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  ProjectEnvironmentSummary,
+  ProjectSummary,
+} from "@/src/lib/api-types";
+import {
+  errorMessage,
+  getJson,
+  jsonHeaders,
+  requestJson,
+} from "@/src/lib/client-fetch";
+
+import { SettingsPageShell } from "./settings-shell";
+
+type EnvironmentPatch = {
+  enabled?: boolean;
+  upsert?: { key: string; value: string }[];
+  delete?: string[];
+};
+
+type FormMode = "create" | "edit";
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+
+export function EnvironmentSettingsPanel() {
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [environment, setEnvironment] =
+    useState<ProjectEnvironmentSummary | null>(null);
+  const [loadingProjects, setLoadingProjects] = useState(false);
+  const [loadingEnvironment, setLoadingEnvironment] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [formMode, setFormMode] = useState<FormMode | null>(null);
+  const [draftKey, setDraftKey] = useState("");
+  const [draftValue, setDraftValue] = useState("");
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+
+  const readyProjects = useMemo(
+    () => projects.filter((project) => project.status === "ready"),
+    [projects],
+  );
+  const selectedProject = readyProjects.find(
+    (project) => project.id === selectedProjectId,
+  );
+  const filteredVariables = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const variables = environment?.variables ?? [];
+    if (!normalized) return variables;
+    return variables.filter((variable) =>
+      variable.key.toLowerCase().includes(normalized),
+    );
+  }, [environment?.variables, query]);
+
+  const loadProjects = useCallback(async () => {
+    setLoadingProjects(true);
+    try {
+      const data = await getJson<{ projects: ProjectSummary[] }>("/api/projects");
+      const ready = data.projects.filter((project) => project.status === "ready");
+      setProjects(data.projects);
+      setSelectedProjectId((current) =>
+        current && ready.some((project) => project.id === current)
+          ? current
+          : ready[0]?.id ?? "",
+      );
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to load projects"));
+    } finally {
+      setLoadingProjects(false);
+    }
+  }, []);
+
+  const loadEnvironment = useCallback(async (projectId: string) => {
+    if (!projectId) {
+      setEnvironment(null);
+      return;
+    }
+    setLoadingEnvironment(true);
+    try {
+      const data = await getJson<{ environment: ProjectEnvironmentSummary }>(
+        `/api/projects/${projectId}/environment`,
+      );
+      setEnvironment(data.environment);
+      setError(null);
+    } catch (err) {
+      setEnvironment(null);
+      setError(errorMessage(err, "Failed to load environment"));
+    } finally {
+      setLoadingEnvironment(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial settings hydration updates state after the project request settles.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
+    // Loading follows the selected project and writes the fetched summary into state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadEnvironment(selectedProjectId);
+  }, [loadEnvironment, selectedProjectId]);
+
+  const patchEnvironment = async (patch: EnvironmentPatch) => {
+    if (!selectedProjectId) return;
+    setSaving(true);
+    try {
+      const data = await requestJson<{ environment: ProjectEnvironmentSummary }>(
+        `/api/projects/${selectedProjectId}/environment`,
+        {
+          method: "PATCH",
+          headers: jsonHeaders(),
+          body: JSON.stringify(patch),
+        },
+      );
+      setEnvironment(data.environment);
+      setProjects((current) =>
+        current.map((project) =>
+          project.id === data.environment.projectId
+            ? { ...project, environmentEnabled: data.environment.enabled }
+            : project,
+        ),
+      );
+      setError(null);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to save environment"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const startCreate = () => {
+    setFormMode("create");
+    setDraftKey("");
+    setDraftValue("");
+  };
+
+  const startEdit = (key: string) => {
+    setFormMode("edit");
+    setDraftKey(key);
+    setDraftValue("");
+  };
+
+  const cancelForm = () => {
+    setFormMode(null);
+    setDraftKey("");
+    setDraftValue("");
+  };
+
+  const submitForm = async () => {
+    const key = draftKey.trim();
+    if (!ENV_KEY_PATTERN.test(key) || draftValue.length === 0) return;
+    await patchEnvironment({ upsert: [{ key, value: draftValue }] });
+    cancelForm();
+  };
+
+  const submitImport = async () => {
+    const parsed = parseImportText(importText);
+    if ("error" in parsed) {
+      setError(parsed.error);
+      return;
+    }
+    if (parsed.upsert.length === 0) return;
+    await patchEnvironment({ upsert: parsed.upsert });
+    setImportText("");
+    setImportOpen(false);
+  };
+
+  const disabled = saving || loadingEnvironment || !selectedProject;
+  const formKeyValid = ENV_KEY_PATTERN.test(draftKey.trim());
+  const formValueValid = draftValue.length > 0;
+  const canSubmitForm = formKeyValid && formValueValid && !disabled;
+
+  return (
+    <SettingsPageShell
+      title="Environment"
+      description="Store per-project environment variables in the selected repository .env file and inject them into Anton project commands."
+      contentClassName="max-w-[1040px] space-y-6"
+    >
+      {error && <ErrorBanner message={error} />}
+
+      <section className="rounded-[10px] border border-border bg-card">
+        <div className="flex flex-col gap-4 p-5">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-1">
+              <h3 className="flex items-center gap-2 text-sm font-semibold">
+                <KeyRound className="size-3.5 text-muted-foreground" />
+                Project environment
+              </h3>
+              <p className="text-[13px] leading-relaxed text-muted-foreground">
+                App runtime secrets stay in deployment settings. These variables
+                are only for commands run inside the selected project.
+              </p>
+            </div>
+            {selectedProject && environment && (
+              <label className="flex shrink-0 items-center gap-3 rounded-lg border border-border bg-input px-3 py-2">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Include in environment
+                </span>
+                <Switch
+                  checked={environment.enabled}
+                  onCheckedChange={(checked) =>
+                    void patchEnvironment({ enabled: checked })
+                  }
+                  disabled={saving || loadingEnvironment}
+                  aria-label="Include project environment"
+                />
+              </label>
+            )}
+          </div>
+
+          {readyProjects.length === 0 ? (
+            <EmptyState
+              message={
+                loadingProjects
+                  ? "Loading projects..."
+                  : "Import or clone a project before adding environment variables."
+              }
+            />
+          ) : (
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Project
+                </label>
+                <Select
+                  value={selectedProjectId}
+                  onValueChange={setSelectedProjectId}
+                  disabled={loadingProjects || saving}
+                >
+                  <SelectTrigger className="h-[34px] w-full rounded-lg border-border bg-input text-[13px]">
+                    <SelectValue placeholder="Select project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectViewport>
+                      {readyProjects.map((project) => (
+                        <SelectItem key={project.id} value={project.id}>
+                          {project.fullName}
+                        </SelectItem>
+                      ))}
+                    </SelectViewport>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  Env file
+                </span>
+                <div className="flex h-[34px] min-w-0 items-center gap-2 rounded-lg border border-border bg-input px-3">
+                  <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground/70" />
+                  <span className="truncate font-mono text-xs text-muted-foreground">
+                    {environment?.envFile ?? selectedProject?.localPath ?? "-"}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {selectedProject && (
+        <section className="overflow-hidden rounded-[10px] border border-border bg-card">
+          <div className="flex flex-col gap-3 border-b border-layout-border px-4 py-3 md:flex-row md:items-center md:justify-between">
+            <label className="flex h-[33px] min-w-0 flex-1 items-center gap-2 rounded-lg border border-border bg-input px-3 transition-colors focus-within:border-ring md:max-w-md">
+              <Search className="size-3.5 shrink-0 text-muted-foreground/70" />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search variables..."
+                aria-label="Search environment variables"
+                className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground/70"
+              />
+            </label>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                className="h-[33px] rounded-lg border-border px-3 text-[13px]"
+                onClick={() => setImportOpen((open) => !open)}
+                disabled={disabled}
+              >
+                <Upload className="size-3.5" />
+                Import
+              </Button>
+              <Button
+                type="button"
+                className="h-[33px] rounded-lg px-3 text-[13px]"
+                onClick={startCreate}
+                disabled={disabled}
+              >
+                <Plus className="size-3.5" />
+                Create
+              </Button>
+            </div>
+          </div>
+
+          {importOpen && (
+            <div className="space-y-3 border-b border-layout-border px-4 py-4">
+              <Textarea
+                value={importText}
+                onChange={(event) => setImportText(event.target.value)}
+                placeholder={"GITHUB_TOKEN=...\nGH_TOKEN=..."}
+                className="min-h-28 rounded-lg border-border bg-input font-mono text-xs"
+              />
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => {
+                    setImportOpen(false);
+                    setImportText("");
+                  }}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => void submitImport()}
+                  disabled={saving || importText.trim().length === 0}
+                >
+                  {saving && <Loader2 className="animate-spin" />}
+                  Import secrets
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {formMode && (
+            <div className="grid gap-3 border-b border-layout-border px-4 py-4 md:grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)_auto] md:items-end">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Name
+                </label>
+                <input
+                  value={draftKey}
+                  onChange={(event) => setDraftKey(event.target.value)}
+                  readOnly={formMode === "edit"}
+                  placeholder="GITHUB_TOKEN"
+                  className="h-[34px] w-full rounded-lg border border-border bg-input px-3 font-mono text-[13px] outline-none transition-colors placeholder:text-muted-foreground/70 focus:border-ring read-only:text-muted-foreground"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {formMode === "edit" ? "Replacement value" : "Value"}
+                </label>
+                <input
+                  value={draftValue}
+                  onChange={(event) => setDraftValue(event.target.value)}
+                  type="password"
+                  placeholder="Enter secret value"
+                  className="h-[34px] w-full rounded-lg border border-border bg-input px-3 font-mono text-[13px] outline-none transition-colors placeholder:text-muted-foreground/70 focus:border-ring"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={cancelForm}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => void submitForm()}
+                  disabled={!canSubmitForm}
+                >
+                  {saving && <Loader2 className="animate-spin" />}
+                  {formMode === "edit" ? "Update" : "Create"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {loadingEnvironment ? (
+            <div className="flex items-center justify-center gap-2 p-8 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading environment
+            </div>
+          ) : filteredVariables.length === 0 ? (
+            <div className="p-5">
+              <EmptyState
+                message={
+                  environment?.variables.length
+                    ? "No variables match."
+                    : "No environment variables yet."
+                }
+              />
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] text-left">
+                <thead className="bg-muted/45 text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">Type</th>
+                    <th className="px-4 py-3 font-medium">Value</th>
+                    <th className="px-4 py-3 text-right font-medium">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-layout-border">
+                  {filteredVariables.map((variable) => (
+                    <tr key={variable.key} className="hover:bg-muted/25">
+                      <td className="px-4 py-3 font-mono text-[13px] font-medium">
+                        {variable.key}
+                      </td>
+                      <td className="px-4 py-3 text-[13px] text-muted-foreground">
+                        Raw secret
+                      </td>
+                      <td className="px-4 py-3 text-[13px] text-muted-foreground">
+                        Hidden
+                      </td>
+                      <td className="px-4 py-2">
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => startEdit(variable.key)}
+                            disabled={disabled}
+                            aria-label={`Edit ${variable.key}`}
+                          >
+                            <Pencil className="size-3.5" />
+                          </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                disabled={disabled}
+                                aria-label={`Delete ${variable.key}`}
+                              >
+                                <Trash2 className="size-3.5" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>
+                                  Delete environment variable?
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  This removes {variable.key} from the project
+                                  .env file. Existing command output is not
+                                  changed.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel disabled={saving}>
+                                  Cancel
+                                </AlertDialogCancel>
+                                <AlertDialogAction
+                                  variant="destructive"
+                                  disabled={saving}
+                                  onClick={() =>
+                                    void patchEnvironment({
+                                      delete: [variable.key],
+                                    })
+                                  }
+                                >
+                                  Delete
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
+    </SettingsPageShell>
+  );
+}
+
+function parseImportText(
+  text: string,
+): { upsert: { key: string; value: string }[] } | { error: string } {
+  const upsert: { key: string; value: string }[] = [];
+  const seen = new Set<string>();
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match =
+      /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/.exec(line);
+    if (!match) {
+      return { error: `Line ${index + 1} is not a KEY=value assignment.` };
+    }
+    const key = match[1] ?? "";
+    if (!ENV_KEY_PATTERN.test(key)) {
+      return { error: `Line ${index + 1} has an invalid variable name.` };
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+    upsert.push({ key, value: parseImportedValue(match[2] ?? "") });
+  }
+  return { upsert };
+}
+
+function parseImportedValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\"/g, "\"")
+      .replace(/\\\\/g, "\\");
+  }
+  return raw.replace(/\s+#.*$/, "").trim();
+}

--- a/components/features/settings/settings-dialog.tsx
+++ b/components/features/settings/settings-dialog.tsx
@@ -11,6 +11,7 @@ import {
   type SettingsSection,
 } from "./settings-shell";
 import { AgentSettingsPanel } from "./agent-settings-panel";
+import { EnvironmentSettingsPanel } from "./environment-settings-panel";
 import { McpSettingsPanel } from "./mcp-settings-panel";
 import { WorkspaceSettingsPanel } from "./workspace-settings-panel";
 
@@ -52,6 +53,7 @@ export function SettingsDialog({
     >
       {section === "workspaces" && <WorkspaceSettingsPanel />}
       {section === "agent" && <AgentSettingsPanel />}
+      {section === "environment" && <EnvironmentSettingsPanel />}
       {section === "mcp" && <McpSettingsPanel />}
       {section === "memories" && (
         <SettingsPageShell

--- a/components/features/settings/settings-shell.tsx
+++ b/components/features/settings/settings-shell.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   Brain,
   FolderGit2,
+  KeyRound,
   Plug,
   SlidersHorizontal,
   Sparkles,
@@ -16,7 +17,13 @@ import { SearchField } from "@/components/shared/search-field";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
-export type SettingsSection = "workspaces" | "agent" | "mcp" | "memories" | "skills";
+export type SettingsSection =
+  | "workspaces"
+  | "agent"
+  | "environment"
+  | "mcp"
+  | "memories"
+  | "skills";
 
 export function SettingsShell({
   section,
@@ -68,6 +75,13 @@ export function SettingsShell({
                 icon={<SlidersHorizontal />}
               >
                 Agent defaults
+              </SettingsNavButton>
+              <SettingsNavButton
+                active={section === "environment"}
+                onClick={() => onSectionChange("environment")}
+                icon={<KeyRound />}
+              >
+                Environment
               </SettingsNavButton>
             </SettingsGroup>
             <SettingsGroup title="Project context">
@@ -128,6 +142,7 @@ export function SettingsShell({
             <TabsList size="sm">
               <TabsTrigger value="workspaces">Workspaces</TabsTrigger>
               <TabsTrigger value="agent">Agent</TabsTrigger>
+              <TabsTrigger value="environment">Environment</TabsTrigger>
               <TabsTrigger value="mcp">MCP</TabsTrigger>
               <TabsTrigger value="memories">Memories</TabsTrigger>
               <TabsTrigger value="skills">Skills</TabsTrigger>
@@ -248,6 +263,8 @@ function sectionTitle(section: SettingsSection): string {
       return "Workspaces";
     case "agent":
       return "Agent defaults";
+    case "environment":
+      return "Environment";
     case "mcp":
       return "MCP";
     case "memories":

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,11 @@ fi
 if command -v gh >/dev/null 2>&1; then
   GH_AUTH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${GITHUB_PAT:-}}}"
   if [ -n "$GH_AUTH_TOKEN" ]; then
-    if [ ! -s "$GH_CONFIG_DIR/hosts.yml" ]; then
+    if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+      if [ -s "$GH_CONFIG_DIR/hosts.yml" ]; then
+        echo "[entrypoint] repairing stale gh auth state"
+        rm -f "$GH_CONFIG_DIR/hosts.yml"
+      fi
       if ! printf '%s' "$GH_AUTH_TOKEN" | gh auth login --hostname github.com --with-token >/dev/null; then
         echo "[entrypoint] warning: gh auth login failed"
       fi

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "packageManager": "pnpm@10.13.1",
   "scripts": {
+    "predev": "tsx src/db/migrate.ts",
     "dev": "next dev",
     "build": "next build",
+    "prestart": "tsx src/db/migrate.ts",
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",

--- a/src/db/env.ts
+++ b/src/db/env.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function loadDatabaseEnvFiles(cwd = process.cwd()): void {
+  for (const file of envFilesForMode(process.env.NODE_ENV)) {
+    loadEnvFile(path.join(cwd, file));
+  }
+}
+
+function envFilesForMode(mode: string | undefined): string[] {
+  const normalized = mode?.trim();
+  const files: string[] = [];
+  if (normalized) files.push(`.env.${normalized}.local`);
+  if (normalized !== "test") files.push(".env.local");
+  if (normalized) files.push(`.env.${normalized}`);
+  files.push(".env");
+  return files;
+}
+
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+    const parsed = parseEnvLine(line);
+    if (!parsed) continue;
+    if (process.env[parsed.key] !== undefined) continue;
+    process.env[parsed.key] = parsed.value;
+  }
+}
+
+function parseEnvLine(line: string): { key: string; value: string } | undefined {
+  const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/.exec(line);
+  if (!match) return undefined;
+  const key = match[1] ?? "";
+  if (!ENV_KEY_PATTERN.test(key)) return undefined;
+  return { key, value: parseEnvValue(match[2] ?? "") };
+}
+
+function parseEnvValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\"/g, "\"")
+      .replace(/\\\\/g, "\\");
+  }
+  return raw.replace(/\s+#.*$/, "").trim();
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -2,6 +2,10 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 
+import { loadDatabaseEnvFiles } from "./env";
+
+loadDatabaseEnvFiles();
+
 const dbPath = process.env.DATABASE_URL ?? "./anton.db";
 const sqlite = new Database(dbPath);
 sqlite.pragma("journal_mode = WAL");

--- a/src/db/migrations/0014_superb_micromacro.sql
+++ b/src/db/migrations/0014_superb_micromacro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` ADD `environment_enabled` integer DEFAULT false NOT NULL;

--- a/src/db/migrations/meta/0014_snapshot.json
+++ b/src/db/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1496 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7b4a95e1-d3cc-46d6-bd48-ae5debb21c93",
+  "prevId": "96337ab2-021b-4a37-919b-193bfcfd4cd0",
+  "tables": {
+    "background_command_sessions": {
+      "name": "background_command_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command_kind": {
+          "name": "command_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stdout_tail": {
+          "name": "stdout_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "stderr_tail": {
+          "name": "stderr_tail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "detected_urls": {
+          "name": "detected_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "background_command_sessions_project_id_idx": {
+          "name": "background_command_sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_status_idx": {
+          "name": "background_command_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_command_sessions_project_started_idx": {
+          "name": "background_command_sessions_project_started_idx",
+          "columns": [
+            "project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "background_command_sessions_project_id_projects_id_fk": {
+          "name": "background_command_sessions_project_id_projects_id_fk",
+          "tableFrom": "background_command_sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_installations": {
+      "name": "github_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'untested'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_servers_namespace_unique": {
+          "name": "mcp_servers_namespace_unique",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_decisions": {
+      "name": "mcp_trust_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "mcp_trust_decisions_server_fingerprint_unique": {
+          "name": "mcp_trust_decisions_server_fingerprint_unique",
+          "columns": [
+            "mcp_server_id",
+            "fingerprint"
+          ],
+          "isUnique": true
+        },
+        "mcp_trust_decisions_server_idx": {
+          "name": "mcp_trust_decisions_server_idx",
+          "columns": [
+            "mcp_server_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_trust_decisions_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_trust_decisions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "memories_updated_at_idx": {
+          "name": "memories_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "messages_session_id_idx": {
+          "name": "messages_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo_id": {
+          "name": "github_repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clone_url": {
+          "name": "clone_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_enabled": {
+          "name": "environment_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_github_repo_id_unique": {
+          "name": "projects_github_repo_id_unique",
+          "columns": [
+            "github_repo_id"
+          ],
+          "isUnique": true
+        },
+        "projects_local_path_unique": {
+          "name": "projects_local_path_unique",
+          "columns": [
+            "local_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_context_summaries": {
+      "name": "run_context_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commands": {
+          "name": "commands",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "run_context_summaries_session_id_idx": {
+          "name": "run_context_summaries_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "run_context_summaries_created_at_idx": {
+          "name": "run_context_summaries_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_context_summaries_run_id_runs_id_fk": {
+          "name": "run_context_summaries_run_id_runs_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_context_summaries_session_id_sessions_id_fk": {
+          "name": "run_context_summaries_session_id_sessions_id_fk",
+          "tableFrom": "run_context_summaries",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_events": {
+      "name": "run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "run_events_run_id_sequence_idx": {
+          "name": "run_events_run_id_sequence_idx",
+          "columns": [
+            "run_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "run_events_tool_call_id_idx": {
+          "name": "run_events_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "run_events_run_id_runs_id_fk": {
+          "name": "run_events_run_id_runs_id_fk",
+          "tableFrom": "run_events",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "runs": {
+      "name": "runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_count": {
+          "name": "step_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "runs_session_id_idx": {
+          "name": "runs_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "runs_started_at_idx": {
+          "name": "runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "runs_session_id_sessions_id_fk": {
+          "name": "runs_session_id_sessions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_budget_multiplier": {
+          "name": "token_budget_multiplier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "tokens_total": {
+          "name": "tokens_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_updated_at_idx": {
+          "name": "sessions_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "sessions_project_id_idx": {
+          "name": "sessions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_approvals": {
+      "name": "tool_approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "risk_categories": {
+          "name": "risk_categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_approvals_tool_call_id_idx": {
+          "name": "tool_approvals_tool_call_id_idx",
+          "columns": [
+            "tool_call_id"
+          ],
+          "isUnique": false
+        },
+        "tool_approvals_approval_id_idx": {
+          "name": "tool_approvals_approval_id_idx",
+          "columns": [
+            "approval_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_approvals_tool_call_id_tool_calls_id_fk": {
+          "name": "tool_approvals_tool_call_id_tool_calls_id_fk",
+          "tableFrom": "tool_approvals",
+          "tableTo": "tool_calls",
+          "columnsFrom": [
+            "tool_call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_calls": {
+      "name": "tool_calls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approval_decision": {
+          "name": "approval_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_id_idx": {
+          "name": "tool_calls_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "tool_calls_run_tool_call_id_unique": {
+          "name": "tool_calls_run_tool_call_id_unique",
+          "columns": [
+            "run_id",
+            "tool_call_id"
+          ],
+          "isUnique": true
+        },
+        "tool_calls_started_at_idx": {
+          "name": "tool_calls_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_settings": {
+      "name": "workspace_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_workspaces_root": {
+          "name": "local_workspaces_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_max_steps": {
+          "name": "default_max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_permission_mode": {
+          "name": "default_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "openrouter_routing_preferences": {
+          "name": "openrouter_routing_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780393492675,
       "tag": "0013_pale_wong",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1782049899484,
+      "tag": "0014_superb_micromacro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -458,6 +458,7 @@ export function upsertProject(input: {
     localPath: input.localPath,
     status: input.status,
     lastError: input.lastError ?? null,
+    environmentEnabled: false,
     createdAt: now,
     updatedAt: now,
   };
@@ -490,6 +491,7 @@ export function createLocalProject(input: {
     localPath: input.localPath,
     status: "ready",
     lastError: null,
+    environmentEnabled: false,
     createdAt: now,
     updatedAt: now,
   };
@@ -505,6 +507,18 @@ export function updateProjectStatus(
   db
     .update(projects)
     .set({ status, lastError, updatedAt: new Date() })
+    .where(eq(projects.id, id))
+    .run();
+  return getProject(id);
+}
+
+export function updateProjectEnvironmentEnabled(
+  id: string,
+  enabled: boolean,
+): Project | undefined {
+  db
+    .update(projects)
+    .set({ environmentEnabled: enabled, updatedAt: new Date() })
     .where(eq(projects.id, id))
     .run();
   return getProject(id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -58,6 +58,9 @@ export const projects = sqliteTable(
       enum: ["cloning", "ready", "error"],
     }).notNull(),
     lastError: text("last_error"),
+    environmentEnabled: integer("environment_enabled", { mode: "boolean" })
+      .notNull()
+      .default(false),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .notNull()
       .default(sql`(unixepoch('now') * 1000)`),

--- a/src/lib/api-serializers.ts
+++ b/src/lib/api-serializers.ts
@@ -33,6 +33,7 @@ export function serializeProject(project: Project): ProjectSummary {
     localPath: project.localPath,
     status: project.status,
     lastError: project.lastError,
+    environmentEnabled: project.environmentEnabled,
     createdAt: project.createdAt.getTime(),
     updatedAt: project.updatedAt.getTime(),
   };

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -115,8 +115,21 @@ export type ProjectSummary = {
   localPath: string;
   status: "cloning" | "ready" | "error";
   lastError: string | null;
+  environmentEnabled: boolean;
   createdAt: number;
   updatedAt: number;
+};
+
+export type ProjectEnvironmentVariableSummary = {
+  key: string;
+  type: "raw_secret";
+};
+
+export type ProjectEnvironmentSummary = {
+  projectId: string;
+  enabled: boolean;
+  envFile: string;
+  variables: ProjectEnvironmentVariableSummary[];
 };
 
 export type ProjectGitStatusSummary = {

--- a/src/workspace/process-runner.ts
+++ b/src/workspace/process-runner.ts
@@ -2,6 +2,7 @@ import { execa, type ResultPromise } from "execa";
 
 import { buildBashEnvironment } from "@/src/agent/command-policy";
 import { redactText } from "@/src/lib/redaction";
+import { loadProjectEnvironmentForProcess } from "@/src/workspace/project-env";
 
 const DEFAULT_OUTPUT_CAP_BYTES = 64 * 1024;
 
@@ -76,9 +77,11 @@ export function startWorkspaceProcess(
   const outputCapBytes = options.outputCapBytes ?? DEFAULT_OUTPUT_CAP_BYTES;
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
+  const projectEnv = loadProjectEnvironmentForProcess(cwd);
+  const env = buildWorkspaceProcessEnvironment(cwd, projectEnv);
   const subprocess = execa(file, [...args], {
     cwd,
-    env: buildBashEnvironment(),
+    env,
     extendEnv: false,
     timeout: options.timeoutMs,
     reject: false,
@@ -93,13 +96,13 @@ export function startWorkspaceProcess(
   });
 
   subprocess.stdout?.on("data", (chunk: Buffer) => {
-    const text = redactText(chunk.toString("utf8"));
+    const text = redactProcessOutput(chunk.toString("utf8"), projectEnv);
     stdoutChunks.push(text);
     options.onStdout?.(text);
   });
 
   subprocess.stderr?.on("data", (chunk: Buffer) => {
-    const text = redactText(chunk.toString("utf8"));
+    const text = redactProcessOutput(chunk.toString("utf8"), projectEnv);
     stderrChunks.push(text);
     options.onStderr?.(text);
   });
@@ -128,6 +131,16 @@ export function startWorkspaceProcess(
     stderrChunks,
     result,
     boundary: getWorkspaceExecutionBoundary(),
+  };
+}
+
+export function buildWorkspaceProcessEnvironment(
+  cwd: string,
+  projectEnv: Record<string, string> = loadProjectEnvironmentForProcess(cwd),
+): Record<string, string> {
+  return {
+    ...buildBashEnvironment(),
+    ...projectEnv,
   };
 }
 
@@ -264,4 +277,16 @@ function asProcessRecord(value: unknown): {
   isMaxBuffer?: unknown;
 } {
   return typeof value === "object" && value !== null ? value : {};
+}
+
+function redactProcessOutput(
+  value: string,
+  env: Record<string, string>,
+): string {
+  let redacted = redactText(value);
+  for (const secret of Object.values(env)) {
+    if (secret.length < 4) continue;
+    redacted = redacted.split(secret).join("[redacted]");
+  }
+  return redacted;
 }

--- a/src/workspace/project-env.ts
+++ b/src/workspace/project-env.ts
@@ -1,0 +1,317 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { ensureWorkspaceRootAt } from "@/src/agent/sandbox";
+import { getProjectByLocalPath } from "@/src/db/queries";
+import type {
+  ProjectEnvironmentSummary,
+  ProjectEnvironmentVariableSummary,
+} from "@/src/lib/api-types";
+
+const execFileAsync = promisify(execFile);
+
+const ENV_FILE_NAME = ".env";
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+const MAX_ENV_VALUE_BYTES = 64 * 1024;
+const RESERVED_ENV_KEYS = new Set(
+  [
+    "ANTON_LOCAL_WORKSPACES_ROOT",
+    "CI",
+    "COLORTERM",
+    "COMSPEC",
+    "DATABASE_URL",
+    "FORCE_COLOR",
+    "GH_CONFIG_DIR",
+    "GH_HOST",
+    "GH_NO_EXTENSION_UPDATE_NOTIFIER",
+    "GH_NO_UPDATE_NOTIFIER",
+    "GH_PROMPT_DISABLED",
+    "GH_REPO",
+    "GH_SPINNER_DISABLED",
+    "HOME",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "HOSTNAME",
+    "LANG",
+    "LC_ALL",
+    "NO_COLOR",
+    "NODE_ENV",
+    "PATH",
+    "PATHEXT",
+    "PNPM_HOME",
+    "PORT",
+    "SHELL",
+    "SYSTEMROOT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USERPROFILE",
+    "WINDIR",
+    "WORKSPACE_ROOT",
+  ].map((key) => key.toUpperCase()),
+);
+
+export class ProjectEnvironmentError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "ProjectEnvironmentError";
+    this.status = status;
+  }
+}
+
+export type ProjectEnvPatch = {
+  upsert?: readonly { key: string; value: string }[];
+  delete?: readonly string[];
+};
+
+type ParsedEnvLine =
+  | { kind: "entry"; key: string; value: string; line: string }
+  | { kind: "other"; line: string };
+
+export function validateProjectEnvKey(key: string): string {
+  const trimmed = key.trim();
+  if (!ENV_KEY_PATTERN.test(trimmed)) {
+    throw new ProjectEnvironmentError(
+      "Environment variable names must start with a letter or underscore and contain only letters, numbers, and underscores.",
+    );
+  }
+  if (isReservedProjectEnvKey(trimmed)) {
+    throw new ProjectEnvironmentError(
+      `${trimmed} is reserved by Anton and cannot be managed as a project environment variable.`,
+    );
+  }
+  return trimmed;
+}
+
+export function validateProjectEnvValue(value: string): string {
+  const size = Buffer.byteLength(value, "utf8");
+  if (size > MAX_ENV_VALUE_BYTES) {
+    throw new ProjectEnvironmentError(
+      `Environment variable values must be ${MAX_ENV_VALUE_BYTES} bytes or smaller.`,
+    );
+  }
+  return value;
+}
+
+export async function summarizeProjectEnvironment(input: {
+  projectId: string;
+  root: string;
+  enabled: boolean;
+}): Promise<ProjectEnvironmentSummary> {
+  const root = ensureWorkspaceRootAt(input.root);
+  const entries = await readProjectEnvEntries(root);
+  return {
+    projectId: input.projectId,
+    enabled: input.enabled,
+    envFile: envFilePath(root),
+    variables: summarizeVariables(entries),
+  };
+}
+
+export async function patchProjectEnvironment(
+  rootInput: string,
+  patch: ProjectEnvPatch,
+): Promise<void> {
+  const root = ensureWorkspaceRootAt(rootInput);
+  await assertEnvFileIsUntracked(root);
+  await ensureEnvFileIgnored(root);
+
+  const entries = await readProjectEnvLines(root);
+  const upserts = new Map<string, string>();
+  for (const item of patch.upsert ?? []) {
+    upserts.set(
+      validateProjectEnvKey(item.key),
+      validateProjectEnvValue(item.value),
+    );
+  }
+  const deletes = new Set((patch.delete ?? []).map(validateProjectEnvKey));
+
+  const emitted = new Set<string>();
+  const nextLines: string[] = [];
+  for (const entry of entries) {
+    if (entry.kind !== "entry") {
+      nextLines.push(entry.line);
+      continue;
+    }
+    if (deletes.has(entry.key)) {
+      continue;
+    }
+    if (upserts.has(entry.key)) {
+      nextLines.push(formatEnvLine(entry.key, upserts.get(entry.key) ?? ""));
+      emitted.add(entry.key);
+      continue;
+    }
+    nextLines.push(entry.line);
+  }
+
+  for (const [key, value] of upserts) {
+    if (emitted.has(key) || deletes.has(key)) continue;
+    nextLines.push(formatEnvLine(key, value));
+  }
+
+  const content = nextLines.length === 0 ? "" : `${nextLines.join("\n")}\n`;
+  const file = envFilePath(root);
+  await fs.writeFile(file, content, { encoding: "utf8", mode: 0o600 });
+  await fs.chmod(file, 0o600).catch(() => null);
+}
+
+export function loadProjectEnvironmentForProcess(
+  cwdInput: string,
+): Record<string, string> {
+  let root: string;
+  try {
+    root = ensureWorkspaceRootAt(cwdInput);
+  } catch {
+    return {};
+  }
+  const project = getProjectByLocalPath(root);
+  if (!project?.environmentEnabled) return {};
+
+  const file = envFilePath(root);
+  if (!fsSync.existsSync(file)) return {};
+  const content = fsSync.readFileSync(file, "utf8");
+  return Object.fromEntries(
+    parseProjectEnvContent(content)
+      .filter((entry): entry is Extract<ParsedEnvLine, { kind: "entry" }> =>
+        entry.kind === "entry" &&
+        !isReservedProjectEnvKey(entry.key) &&
+        Buffer.byteLength(entry.value, "utf8") <= MAX_ENV_VALUE_BYTES
+      )
+      .map((entry) => [entry.key, entry.value]),
+  );
+}
+
+export function isReservedProjectEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return RESERVED_ENV_KEYS.has(normalized) || normalized.startsWith("LC_");
+}
+
+async function readProjectEnvEntries(
+  root: string,
+): Promise<Extract<ParsedEnvLine, { kind: "entry" }>[]> {
+  return (await readProjectEnvLines(root)).filter(
+    (entry): entry is Extract<ParsedEnvLine, { kind: "entry" }> =>
+      entry.kind === "entry",
+  );
+}
+
+async function readProjectEnvLines(root: string): Promise<ParsedEnvLine[]> {
+  const file = envFilePath(root);
+  const content = await fs.readFile(file, "utf8").catch((err: unknown) => {
+    if (isNodeError(err) && err.code === "ENOENT") return "";
+    throw err;
+  });
+  return parseProjectEnvContent(content);
+}
+
+function parseProjectEnvContent(content: string): ParsedEnvLine[] {
+  return content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .filter((line, index, lines) => index < lines.length - 1 || line.length > 0)
+    .map(parseEnvLine);
+}
+
+function parseEnvLine(line: string): ParsedEnvLine {
+  const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/.exec(line);
+  if (!match) return { kind: "other", line };
+  const key = match[1] ?? "";
+  if (isReservedProjectEnvKey(key)) return { kind: "entry", key, value: "", line };
+  return {
+    kind: "entry",
+    key,
+    value: parseEnvValue(match[2] ?? ""),
+    line,
+  };
+}
+
+function parseEnvValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+    return trimmed
+      .slice(1, -1)
+      .replace(/\\n/g, "\n")
+      .replace(/\\r/g, "\r")
+      .replace(/\\t/g, "\t")
+      .replace(/\\"/g, "\"")
+      .replace(/\\\\/g, "\\");
+  }
+  return raw.replace(/\s+#.*$/, "").trim();
+}
+
+function summarizeVariables(
+  entries: readonly Extract<ParsedEnvLine, { kind: "entry" }>[],
+): ProjectEnvironmentVariableSummary[] {
+  const keys = new Set<string>();
+  for (const entry of entries) {
+    if (isReservedProjectEnvKey(entry.key)) continue;
+    if (!ENV_KEY_PATTERN.test(entry.key)) continue;
+    keys.add(entry.key);
+  }
+  return [...keys].sort((left, right) => left.localeCompare(right)).map((key) => ({
+    key,
+    type: "raw_secret",
+  }));
+}
+
+async function assertEnvFileIsUntracked(root: string): Promise<void> {
+  const result = await execFileAsync("git", ["ls-files", "--error-unmatch", "--", ENV_FILE_NAME], {
+    cwd: root,
+  }).then(
+    () => true,
+    () => false,
+  );
+  if (result) {
+    throw new ProjectEnvironmentError(
+      "Refusing to manage .env because it is tracked by git in this project.",
+      409,
+    );
+  }
+}
+
+async function ensureEnvFileIgnored(root: string): Promise<void> {
+  const gitPath = await execFileAsync("git", ["rev-parse", "--git-path", "info/exclude"], {
+    cwd: root,
+  }).then((result) => result.stdout.trim());
+  const excludePath = path.isAbsolute(gitPath) ? gitPath : path.join(root, gitPath);
+  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+  const current = await fs.readFile(excludePath, "utf8").catch((err: unknown) => {
+    if (isNodeError(err) && err.code === "ENOENT") return "";
+    throw err;
+  });
+  const lines = current.replace(/\r\n/g, "\n").split("\n");
+  if (lines.some((line) => line.trim() === ENV_FILE_NAME)) return;
+  const prefix = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
+  await fs.appendFile(excludePath, `${prefix}${ENV_FILE_NAME}\n`, "utf8");
+}
+
+function formatEnvLine(key: string, value: string): string {
+  return `${key}=${formatEnvValue(value)}`;
+}
+
+function formatEnvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@+-]*$/.test(value)) return value;
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/"/g, "\\\"")}"`;
+}
+
+function envFilePath(root: string): string {
+  return path.join(root, ENV_FILE_NAME);
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}


### PR DESCRIPTION
## Summary
- Add per-project Environment settings that manage selected-project `.env` variables without returning raw values to the UI/API.
- Inject enabled project `.env` values into centralized workspace process launches while blocking reserved runtime keys.
- Repair stale Docker `gh` auth when a runtime GitHub token is present, and reduce reasoning stream memory growth by disabling reasoning UI parts and capping trace summaries.

Closes #202

## Verification
- [x] `pnpm db:generate`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build` (passes; existing Turbopack NFT warning remains for `next.config.ts -> src/workspace/project-inspect.ts`)
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] Focused temp-project env probe: `.env` created, `.git/info/exclude` updated, variable missing while disabled, present while enabled, missing again after disable.

## Manual notes
- Direct stdin `tsx` import of `src/workspace/process-runner.ts` hits the existing package export issue (`ERR_PACKAGE_PATH_NOT_EXPORTED` through `unicorn-magic`), so command injection is verified by the typed process-runner wiring plus typecheck/build and the lower-level env utility probe.
- Browser tooling was not available in this session and the repo has no local Playwright dependency, so the Settings UI was compile/build verified rather than screenshot verified.
